### PR TITLE
add cmake log pb generate custom command

### DIFF
--- a/core/dependencies.cmake
+++ b/core/dependencies.cmake
@@ -130,7 +130,17 @@ endmacro()
 logtail_define(protobuf_BIN "Absolute path to protoc" "${DEPS_BINARY_ROOT}/protoc")
 set(PROTO_FILE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/log_pb")
 set(PROTO_FILES ${PROTO_FILE_PATH}/sls_logs.proto ${PROTO_FILE_PATH}/logtail_buffer_meta.proto ${PROTO_FILE_PATH}/metric.proto ${PROTO_FILE_PATH}/checkpoint.proto)
-execute_process(COMMAND ${protobuf_BIN} --proto_path=${PROTO_FILE_PATH} --cpp_out=${PROTO_FILE_PATH} ${PROTO_FILES})
+foreach(PROTO_FILE ${PROTO_FILES})
+    string(REGEX REPLACE "[.]proto$" ".pb.cc" PB_OUTPUT_SOURCE ${PROTO_FILE})
+    list(APPEND PB_OUTPUT_SOURCES ${PB_OUTPUT_SOURCE})
+endforeach()
+message("pb output: ${PB_OUTPUT_SOURCES}")
+add_custom_command(
+    OUTPUT ${PB_OUTPUT_SOURCES}
+    COMMAND ${protobuf_BIN} --proto_path=${PROTO_FILE_PATH} --cpp_out=${PROTO_FILE_PATH} ${PROTO_FILES}
+    DEPENDS ${PROTO_FILES}
+    COMMENT "generate log protobuf files"
+)
 
 # re2
 macro(link_re2 target_name)


### PR DESCRIPTION
目前，每次编译 ilogtail 时，都会在 dependencies.cmake 中重新生成 log pb 文件，导致依赖于这些文件的 target 都需要重新编译。
通过 add_custom_command 命令，只有在依赖的 .proto 文件变化时，才触发重新生成 pb 文件。