### PR TITLE
Multi-line parsing supports SIMD optimization

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -33,6 +33,7 @@ cmake_dependent_option(ENABLE_STATIC_LINK_CRT "Build Logtail by linking CRT stat
 option(WITHOUTGDB "Build Logtail without gdb")
 option(WITHSPL "Build Logtail and UT with SPL" ON)
 option(BUILD_LOGTAIL_UT "Build unit test for Logtail")
+option(ENABLE_SIMD "Enable vectorization support" ON)
 set(PROVIDER_PATH "provider" CACHE PATH "Path to the provider module") # external provider path can be set with -DPROVIDER_PATH
 set(UNITTEST_PATH "unittest" CACHE PATH "Path to the unittest module") # external unittest path can be set with -DUNITTEST_PATH
 
@@ -52,6 +53,16 @@ endif ()
 if (NOT WITHSPL)
     add_definitions(-D__EXCLUDE_SPL__)
 endif()
+
+if (ENABLE_SIMD)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("-mavx2" COMPILER_SUPPORTS_AVX2)
+
+    if (COMPILER_SUPPORTS_AVX2)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=haswell")
+        add_definitions(-DUSE_SIMD_AVX2)
+    endif ()
+endif ()
 
 # Default C/CXX flags.
 if (UNIX)

--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -27,6 +27,9 @@
 #include <limits>
 #include <numeric>
 #include <random>
+#ifdef USE_SIMD_AVX2
+#include <immintrin.h>
+#endif
 
 #include "app_config/AppConfig.h"
 #include "checkpoint/CheckPointManager.h"
@@ -2197,7 +2200,27 @@ LineInfo RawTextParser::GetLastLine(StringView buffer,
     if (protocolFunctionIndex != 0) {
         return {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
     }
+#ifdef USE_SIMD_AVX2
+    const char * data = buffer.data();
+    const int vecSize = 32;
+    __m256i newlineVec = _mm256_set1_epi8('\n');
 
+    for (int32_t pos = end - vecSize; pos >= 0; pos -= vecSize) {
+        __m256i chunk = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(data + pos));
+        __m256i cmp = _mm256_cmpeq_epi8(chunk, newlineVec);
+        int mask = _mm256_movemask_epi8(cmp);
+
+        if (mask != 0) {
+            int offset = __builtin_ctz(mask);
+            int32_t begin = pos + offset + 1;
+            return {.data = StringView(data + begin, end - begin),
+                    .lineBegin = begin,
+                    .lineEnd = end,
+                    .rollbackLineFeedCount = 1,
+                    .fullLine = true};
+        }
+    }
+#else
     for (int32_t begin = end; begin > 0; --begin) {
         if (begin == 0 || buffer[begin - 1] == '\n') {
             return {.data = StringView(buffer.data() + begin, end - begin),
@@ -2207,6 +2230,7 @@ LineInfo RawTextParser::GetLastLine(StringView buffer,
                     .fullLine = true};
         }
     }
+#endif
     return {.data = StringView(buffer.data(), end),
             .lineBegin = 0,
             .lineEnd = end,


### PR DESCRIPTION
Improve the performance of parsing newlines through SIMD.
The following are the performance comparison test results under 150 tasks and 180MB/s traffic:
Before optimization:
![image](https://github.com/user-attachments/assets/db425e25-6af9-467d-b276-be7f20c852ab)
![image](https://github.com/user-attachments/assets/a2fc7a28-7ac9-4fec-9071-e658cb34be52)

After optimization:
![image](https://github.com/user-attachments/assets/19f6989b-8bbc-4a6b-ac52-a13c781be920)
![image](https://github.com/user-attachments/assets/0c9e47f8-8121-4e1f-ab65-315428a94c9d)

After optimization, the performance is improved by about 8%. If the `GetNextLine` method is tested separately, the performance is improved by 1 times.
