### PR TITLE
fix: docker file Root role, sudoer.d/ file name can not .

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,8 +40,10 @@ RUN source /tmp/.env && rm /tmp/.env; \
     fi; \
     useradd --uid $USER_UID --gid $GROUP_GID -m $USERNAME; \
     if [ -n "$USER_PASSWORD" ]; then echo "$USERNAME:$USER_PASSWORD" | chpasswd; fi; \
-    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME; \
-    chmod 0440 /etc/sudoers.d/$USERNAME; \
+    # the filename should not have the . or ~ symbol.
+    USER_SUDOER_FILE=$(echo $USERNAME | sed 's/\./-/g'); \
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USER_SUDOER_FILE; \
+    chmod 0440 /etc/sudoers.d/$USER_SUDOER_FILE; \
     chown -R $USERNAME:$GROUPNAME /opt $(eval echo ~$USERNAME); \
     chmod -R 755 $(eval echo ~$USERNAME);
 


### PR DESCRIPTION
https://superuser.com/questions/869144/why-does-the-system-have-etc-sudoers-d-how-should-i-edit-it
sudoer.d 目前下的文件名不能包含 ~和.
如果 username name 有 `.`, 则无法被授予 root 权限。