### PR TITLE
feat: provider add GetReadMetrics API

### DIFF
--- a/core/monitor/MetricExportor.cpp
+++ b/core/monitor/MetricExportor.cpp
@@ -25,6 +25,7 @@
 #include "common/TimeUtil.h"
 #include "go_pipeline/LogtailPlugin.h"
 #include "pipeline/PipelineManager.h"
+#include "provider/Provider.h"
 #include "protobuf/sls/sls_logs.pb.h"
 
 using namespace sls_logs;
@@ -51,7 +52,7 @@ void MetricExportor::PushMetrics(bool forceSend) {
     }
 
     // go指标在Cpp指标前获取，是为了在 Cpp 部分指标做 SnapShot
-    // 前（即调用 ReadMetrics::GetInstance()->UpdateMetrics() 函数），把go部分的进程级指标填写到 Cpp
+    // 前（即调用 GetReadMetrics()->UpdateMetrics() 函数），把go部分的进程级指标填写到 Cpp
     // 的进程级指标中去，随Cpp的进程级指标一起输出
     if (LogtailPlugin::GetInstance()->IsPluginOpened()) {
         PushGoMetrics();
@@ -60,17 +61,21 @@ void MetricExportor::PushMetrics(bool forceSend) {
 }
 
 void MetricExportor::PushCppMetrics() {
-    ReadMetrics::GetInstance()->UpdateMetrics();
+    GetReadMetrics()->UpdateMetrics();
 
     if ("sls" == STRING_FLAG(metrics_report_method)) {
         std::map<std::string, sls_logs::LogGroup*> logGroupMap;
-        ReadMetrics::GetInstance()->ReadAsLogGroup(METRIC_LABEL_KEY_REGION, METRIC_REGION_DEFAULT, logGroupMap);
+        GetReadMetrics()->ReadAsLogGroup(METRIC_LABEL_KEY_REGION, METRIC_REGION_DEFAULT, logGroupMap);
         SendToSLS(logGroupMap);
     } else if ("file" == STRING_FLAG(metrics_report_method)) {
         std::string metricsContent;
-        ReadMetrics::GetInstance()->ReadAsFileBuffer(metricsContent);
+        GetReadMetrics()->ReadAsFileBuffer(metricsContent);
         SendToLocalFile(metricsContent, "self-metrics-cpp");
-    }
+    } else if ("custom" == STRING_FLAG(metrics_report_method)) {
+        std::string metricsContent;
+        GetReadMetrics()->ReadAsCustomizedProtocol(metricsContent);
+        GetProfileSender()->SendMetricContent(metricsContent);
+    }       
 }
 
 void MetricExportor::PushGoMetrics() {
@@ -162,7 +167,11 @@ void MetricExportor::PushGoDirectMetrics(std::vector<std::map<std::string, std::
         std::string metricsContent;
         SerializeGoDirectMetricsListToString(metricsList, metricsContent);
         SendToLocalFile(metricsContent, "self-metrics-go");
-    }
+    }  else if ("custom" == STRING_FLAG(metrics_report_method)) {
+        std::string metricsContent;
+        GetReadMetrics()->ReadAsCustomizedProtocol(metricsContent);
+        GetProfileSender()->SendMetricContent(metricsContent);
+    }          
 }
 
 // metrics from Go that are provided by cpp

--- a/core/monitor/MetricExportor.cpp
+++ b/core/monitor/MetricExportor.cpp
@@ -169,7 +169,7 @@ void MetricExportor::PushGoDirectMetrics(std::vector<std::map<std::string, std::
         SendToLocalFile(metricsContent, "self-metrics-go");
     }  else if ("custom" == STRING_FLAG(metrics_report_method)) {
         std::string metricsContent;
-        GetReadMetrics()->ReadAsCustomizedProtocol(metricsContent);
+        GetReadMetrics()->SerializeMetricsToString(metricsList, metricsContent);
         GetProfileSender()->SendMetricContent(metricsContent);
     }          
 }

--- a/core/monitor/MetricManager.cpp
+++ b/core/monitor/MetricManager.cpp
@@ -309,6 +309,7 @@ void ReadMetrics::UpdateMetrics() {
     }
 }
 
+
 MetricsRecord* ReadMetrics::GetHead() {
     WriteLock lock(mReadWriteLock);
     return mHead;

--- a/core/monitor/MetricManager.h
+++ b/core/monitor/MetricManager.h
@@ -62,15 +62,15 @@ public:
 };
 
 class ReadMetrics {
-private:
-    ReadMetrics() = default;
+protected:
+    ReadMetrics() = default;    
     mutable ReadWriteLock mReadWriteLock;
     MetricsRecord* mHead = nullptr;
     void Clear();
     MetricsRecord* GetHead();
 
 public:
-    ~ReadMetrics();
+    virtual ~ReadMetrics();        
     static ReadMetrics* GetInstance() {
         static ReadMetrics* ptr = new ReadMetrics();
         return ptr;
@@ -78,9 +78,23 @@ public:
     void ReadAsLogGroup(const std::string& regionFieldName,
                         const std::string& defaultRegion,
                         std::map<std::string, sls_logs::LogGroup*>& logGroupMap) const;
+    
     void ReadAsFileBuffer(std::string& metricsContent) const;
-    void UpdateMetrics();
+    
+    
+    virtual void ReadAsLogGroup(const std::string& regionFieldName,
+                                const std::string& defaultRegion,
+                                std::unordered_map<std::string, sls_logs::LogGroup>& logGroupMap) const;
 
+
+    // serlesialize metrics to other format
+    virtual void SerializeMetricsToString(std::vector<std::map<std::string, std::string>>& metricsList,
+                                          std::string& metricsContent) const {}
+
+    // read metrics to other format    
+    virtual void ReadAsCustomizedProtocol(std::string& metricsContent) const {}
+    
+    void UpdateMetrics();
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class MetricManagerUnittest;
 #endif

--- a/core/monitor/MetricManager.h
+++ b/core/monitor/MetricManager.h
@@ -63,14 +63,14 @@ public:
 
 class ReadMetrics {
 protected:
-    ReadMetrics() = default;    
+    ReadMetrics() = default;
     mutable ReadWriteLock mReadWriteLock;
     MetricsRecord* mHead = nullptr;
     void Clear();
     MetricsRecord* GetHead();
 
 public:
-    virtual ~ReadMetrics();        
+    virtual ~ReadMetrics();
     static ReadMetrics* GetInstance() {
         static ReadMetrics* ptr = new ReadMetrics();
         return ptr;
@@ -81,17 +81,12 @@ public:
     
     void ReadAsFileBuffer(std::string& metricsContent) const;
     
-    
-    virtual void ReadAsLogGroup(const std::string& regionFieldName,
-                                const std::string& defaultRegion,
-                                std::unordered_map<std::string, sls_logs::LogGroup>& logGroupMap) const;
 
-
-    // serlesialize metrics to other format
+    // serialize input metrics to metricsContent
     virtual void SerializeMetricsToString(std::vector<std::map<std::string, std::string>>& metricsList,
                                           std::string& metricsContent) const {}
 
-    // read metrics to other format    
+    // iterate through the metrics list to serialize into metricsContent
     virtual void ReadAsCustomizedProtocol(std::string& metricsContent) const {}
     
     void UpdateMetrics();

--- a/core/monitor/profile_sender/ProfileSender.h
+++ b/core/monitor/profile_sender/ProfileSender.h
@@ -31,6 +31,8 @@ public:
     ProfileSender(const ProfileSender&) = delete;
     ProfileSender& operator=(const ProfileSender&) = delete;
 
+    virtual ~ProfileSender() = default;
+
     static ProfileSender* GetInstance();
 
     void SetDefaultProfileRegion(const std::string& profileRegion);
@@ -46,10 +48,10 @@ public:
     bool IsProfileData(const std::string& region, const std::string& project, const std::string& logstore);
 
     virtual void SendToProfileProject(const std::string& region, sls_logs::LogGroup& logGroup);
-
+    
+    virtual void SendMetricContent(const std::string& content) {}
 protected:
-    ProfileSender();
-    ~ProfileSender() = default;
+    ProfileSender();   
 
     FlusherSLS* GetFlusher(const std::string& region);
 

--- a/core/provider/CMakeLists.txt
+++ b/core/provider/CMakeLists.txt
@@ -17,8 +17,8 @@ project(provider)
 
 file(GLOB LIB_SOURCE_FILES *.cpp *.h)
 
-set(PROVIDER_SUB_DIRECTORIES_LIST    
-    monitor/profile_sender config/feedbacker config/provider config/common_provider protobuf/config_server/v1 protobuf/config_server/v2
+set(PROVIDER_SUB_DIRECTORIES_LIST
+    monitor monitor/profile_sender config/feedbacker config/provider config/common_provider protobuf/config_server/v1 protobuf/config_server/v2
 )
 
 foreach(DIR_NAME IN LISTS PROVIDER_SUB_DIRECTORIES_LIST)

--- a/core/provider/CMakeLists.txt
+++ b/core/provider/CMakeLists.txt
@@ -18,7 +18,8 @@ project(provider)
 file(GLOB LIB_SOURCE_FILES *.cpp *.h)
 
 set(PROVIDER_SUB_DIRECTORIES_LIST
-    monitor monitor/profile_sender config/feedbacker config/provider config/common_provider protobuf/config_server/v1 protobuf/config_server/v2
+    monitor monitor/profile_sender 
+    config/feedbacker config/provider config/common_provider protobuf/config_server/v1 protobuf/config_server/v2
 )
 
 foreach(DIR_NAME IN LISTS PROVIDER_SUB_DIRECTORIES_LIST)

--- a/core/provider/Provider.cpp
+++ b/core/provider/Provider.cpp
@@ -34,6 +34,10 @@ void InitRemoteConfigProviders() {
     LegacyCommonConfigProvider::GetInstance()->Init("common");
 }
 
+ReadMetrics* GetReadMetrics() {
+    return ReadMetrics::GetInstance();
+}
+
 ProfileSender* GetProfileSender() {
     return ProfileSender::GetInstance();
 }

--- a/core/provider/Provider.h
+++ b/core/provider/Provider.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "monitor/MetricManager.h"
 #include "config/provider/ConfigProvider.h"
 #include "monitor/profile_sender/ProfileSender.h"
 
@@ -31,6 +32,9 @@ std::vector<ConfigProvider*> GetRemoteConfigProviders();
 // InitRemoteConfigProviders initializes the remote config providers.
 // It currently initializes the LegacyCommonConfigProvider and CommonConfigProvider.
 void InitRemoteConfigProviders();
+
+// GetReadMetrics returns the ReadMetrics instance.
+ReadMetrics* GetReadMetrics();
 
 // GetProfileSender returns the ProfileSender instance.
 ProfileSender* GetProfileSender();

--- a/core/provider/Provider.h
+++ b/core/provider/Provider.h
@@ -34,6 +34,7 @@ std::vector<ConfigProvider*> GetRemoteConfigProviders();
 void InitRemoteConfigProviders();
 
 // GetReadMetrics returns the ReadMetrics instance.
+// It currently can marshal metrics to sls and file format.
 ReadMetrics* GetReadMetrics();
 
 // GetProfileSender returns the ProfileSender instance.

--- a/core/unittest/monitor/MetricManagerUnittest.cpp
+++ b/core/unittest/monitor/MetricManagerUnittest.cpp
@@ -21,6 +21,7 @@
 #include "MetricManager.h"
 #include "MetricExportor.h"
 #include "MetricConstants.h"
+#include "provider/Provider.h"
 
 namespace logtail {
 
@@ -33,7 +34,7 @@ public:
     void SetUp() {}
 
     void TearDown() {
-        ReadMetrics::GetInstance()->Clear();
+        GetReadMetrics()->Clear();
         WriteMetrics::GetInstance()->Clear();
     }
 
@@ -76,7 +77,7 @@ void MetricManagerUnittest::TestCreateMetricAutoDelete() {
 
 
     // assert ReadMetrics count
-    tmp = ReadMetrics::GetInstance()->GetHead();
+    tmp = GetReadMetrics()->GetHead();
     count = 0;
     while (tmp) {
         tmp = tmp->GetNext();
@@ -121,7 +122,7 @@ void MetricManagerUnittest::TestCreateMetricAutoDelete() {
 
 
     // assert ReadMetrics count
-    tmp = ReadMetrics::GetInstance()->GetHead();
+    tmp = GetReadMetrics()->GetHead();
     count = 0;
     while (tmp) {
         tmp = tmp->GetNext();
@@ -189,7 +190,7 @@ void MetricManagerUnittest::TestCreateMetricAutoDeleteMultiThread() {
     APSARA_TEST_EQUAL(count, 0);
 
     // assert ReadMetrics count
-    tmp = ReadMetrics::GetInstance()->GetHead();
+    tmp = GetReadMetrics()->GetHead();
     count = 0;
     while (tmp) {
         tmp = tmp->GetNext();
@@ -281,7 +282,7 @@ void MetricManagerUnittest::TestCreateAndDeleteMetric() {
     }
 
     // assert ReadMetrics count
-    tmp = ReadMetrics::GetInstance()->GetHead();
+    tmp = GetReadMetrics()->GetHead();
     count = 0;
     while (tmp) {
         tmp = tmp->GetNext();
@@ -291,7 +292,7 @@ void MetricManagerUnittest::TestCreateAndDeleteMetric() {
 
     // assert readMetric value
     if (count == 1) {
-        tmp = ReadMetrics::GetInstance()->GetHead();
+        tmp = GetReadMetrics()->GetHead();
         std::vector<CounterPtr> values = tmp->GetCounters();
         APSARA_TEST_EQUAL(values.size(), 1);
         if (values.size() == 1) {
@@ -308,7 +309,7 @@ void MetricManagerUnittest::TestCreateAndDeleteMetric() {
 
     MetricExportor::GetInstance()->PushMetrics(true);
     // assert ReadMetrics count
-    tmp = ReadMetrics::GetInstance()->GetHead();
+    tmp = GetReadMetrics()->GetHead();
     count = 0;
     while (tmp) {
         tmp = tmp->GetNext();
@@ -318,7 +319,7 @@ void MetricManagerUnittest::TestCreateAndDeleteMetric() {
 
     // assert readMetric value
     if (count == 1) {
-        tmp = ReadMetrics::GetInstance()->GetHead();
+        tmp = GetReadMetrics()->GetHead();
         std::vector<CounterPtr> values = tmp->GetCounters();
         APSARA_TEST_EQUAL(values.size(), 1);
         if (values.size() == 1) {

--- a/core/unittest/provider/ProviderUnittest.cpp
+++ b/core/unittest/provider/ProviderUnittest.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "monitor/MetricManager.h"
 #include "unittest/Unittest.h"
 #include "provider/Provider.h"
 
@@ -22,11 +23,19 @@ class ProviderUnittest : public testing::Test {
 public:
     void TestGetRemoteConfigProvider();
     void TestGetProfileSender();
+    void TestGetReadMetrics();
 
 };
 void ProviderUnittest::TestGetRemoteConfigProvider() {
     auto remoteConfigProviders = GetRemoteConfigProviders();
     APSARA_TEST_GT(remoteConfigProviders.size(), 0U);
+}
+
+void ProviderUnittest::TestGetReadMetrics() {
+    auto readMetrics = GetReadMetrics();
+    auto expected = ReadMetrics::GetInstance();
+    APSARA_TEST_NOT_EQUAL(nullptr, readMetrics);
+    APSARA_TEST_EQUAL(expected, readMetrics);
 }
 
 void ProviderUnittest::TestGetProfileSender() {
@@ -37,6 +46,7 @@ void ProviderUnittest::TestGetProfileSender() {
 
 UNIT_TEST_CASE(ProviderUnittest, TestGetRemoteConfigProvider)
 UNIT_TEST_CASE(ProviderUnittest, TestGetProfileSender)
+UNIT_TEST_CASE(ProviderUnittest, TestGetReadMetrics)
 } // namespace logtail
 
 UNIT_TEST_MAIN


### PR DESCRIPTION
当前Agent自监控只支持序列化成sls或者json格式，写到远端或者本地文件。

希望拓展这部分能力，
1. 暴露出ReadMetric相关的接口。
2. 拓展ProfileSender发送逻辑。