### PR TITLE
fix: Handle timeout for exited containers in docker discover process

### DIFF
--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -1072,7 +1072,7 @@ func (dc *DockerCenter) fetchAll() error {
 	}
 	dc.updateContainers(containerMap)
 
-	return err
+	return nil
 }
 
 func (dc *DockerCenter) fetchOne(containerID string, tryFindSandbox bool) error {


### PR DESCRIPTION
fix #1934