### PR TITLE
fix: add mLatestScrapeTime for scrapeTimestamp

### DIFF
--- a/core/prometheus/PrometheusInputRunner.cpp
+++ b/core/prometheus/PrometheusInputRunner.cpp
@@ -85,10 +85,13 @@ void PrometheusInputRunner::UpdateScrapeInput(std::shared_ptr<TargetSubscriberSc
 
     targetSubscriber->mUnRegisterMs = mUnRegisterMs.load();
     targetSubscriber->SetComponent(mTimer, &mEventPool);
-    auto randSleepMilliSec = GetRandSleepMilliSec(
-        targetSubscriber->GetId(), prometheus::RefeshIntervalSeconds, GetCurrentTimeInMilliSeconds());
+    auto currSystemTime = chrono::system_clock::now();
+    auto randSleepMilliSec
+        = GetRandSleepMilliSec(targetSubscriber->GetId(),
+                               prometheus::RefeshIntervalSeconds,
+                               chrono::duration_cast<chrono::milliseconds>(currSystemTime.time_since_epoch()).count());
     auto firstExecTime = chrono::steady_clock::now() + chrono::milliseconds(randSleepMilliSec);
-    auto firstSubscribeTime = chrono::system_clock::now() + chrono::milliseconds(randSleepMilliSec);
+    auto firstSubscribeTime = currSystemTime + chrono::milliseconds(randSleepMilliSec);
     targetSubscriber->SetFirstExecTime(firstExecTime, firstSubscribeTime);
     // 1. add subscriber to mTargetSubscriberSchedulerMap
     {

--- a/core/prometheus/PrometheusInputRunner.cpp
+++ b/core/prometheus/PrometheusInputRunner.cpp
@@ -87,8 +87,9 @@ void PrometheusInputRunner::UpdateScrapeInput(std::shared_ptr<TargetSubscriberSc
     targetSubscriber->SetComponent(mTimer, &mEventPool);
     auto randSleepMilliSec = GetRandSleepMilliSec(
         targetSubscriber->GetId(), prometheus::RefeshIntervalSeconds, GetCurrentTimeInMilliSeconds());
-    auto firstExecTime = std::chrono::steady_clock::now() + std::chrono::milliseconds(randSleepMilliSec);
-    targetSubscriber->SetFirstExecTime(firstExecTime);
+    auto firstExecTime = chrono::steady_clock::now() + chrono::milliseconds(randSleepMilliSec);
+    auto firstSubscribeTime = chrono::system_clock::now() + chrono::milliseconds(randSleepMilliSec);
+    targetSubscriber->SetFirstExecTime(firstExecTime, firstSubscribeTime);
     // 1. add subscriber to mTargetSubscriberSchedulerMap
     {
         WriteLock lock(mSubscriberMapRWLock);

--- a/core/prometheus/schedulers/BaseScheduler.cpp
+++ b/core/prometheus/schedulers/BaseScheduler.cpp
@@ -8,20 +8,25 @@ using namespace std;
 namespace logtail {
 void BaseScheduler::ExecDone() {
     mExecCount++;
-    mLatestExecTime = mFirstExecTime + std::chrono::seconds(mExecCount * mInterval);
+    mLatestExecTime = mFirstExecTime + chrono::seconds(mExecCount * mInterval);
+    mLatestScrapeTime = mFirstScrapeTime + chrono::seconds(mExecCount * mInterval);
 }
 
-std::chrono::steady_clock::time_point BaseScheduler::GetNextExecTime() {
+chrono::steady_clock::time_point BaseScheduler::GetNextExecTime() {
     return mLatestExecTime;
 }
 
-void BaseScheduler::SetFirstExecTime(std::chrono::steady_clock::time_point firstExecTime) {
+void BaseScheduler::SetFirstExecTime(chrono::steady_clock::time_point firstExecTime,
+                                     chrono::system_clock::time_point firstScrapeTime) {
     mFirstExecTime = firstExecTime;
     mLatestExecTime = mFirstExecTime;
+    mFirstScrapeTime = firstScrapeTime;
+    mLatestScrapeTime = mFirstScrapeTime;
 }
 
 void BaseScheduler::DelayExecTime(uint64_t delaySeconds) {
-    mLatestExecTime = mLatestExecTime + std::chrono::seconds(delaySeconds);
+    mLatestExecTime = mLatestExecTime + chrono::seconds(delaySeconds);
+    mLatestScrapeTime = mLatestScrapeTime + chrono::seconds(delaySeconds);
 }
 
 void BaseScheduler::Cancel() {

--- a/core/prometheus/schedulers/BaseScheduler.h
+++ b/core/prometheus/schedulers/BaseScheduler.h
@@ -20,7 +20,7 @@ public:
 
     std::chrono::steady_clock::time_point GetNextExecTime();
 
-    void SetFirstExecTime(std::chrono::steady_clock::time_point firstExecTime);
+    void SetFirstExecTime(std::chrono::steady_clock::time_point firstExecTime,std::chrono::system_clock::time_point firstScrapeTime);
     void DelayExecTime(uint64_t delaySeconds);
     virtual void Cancel();
 
@@ -29,6 +29,11 @@ public:
 protected:
     bool IsCancelled();
 
+    // for scrape monitor
+    std::chrono::system_clock::time_point mFirstScrapeTime;
+    std::chrono::system_clock::time_point mLatestScrapeTime;
+
+    // for scheduler
     std::chrono::steady_clock::time_point mFirstExecTime;
     std::chrono::steady_clock::time_point mLatestExecTime;
     int64_t mExecCount = 0;

--- a/core/prometheus/schedulers/ScrapeScheduler.cpp
+++ b/core/prometheus/schedulers/ScrapeScheduler.cpp
@@ -87,7 +87,7 @@ ScrapeScheduler::ScrapeScheduler(std::shared_ptr<ScrapeConfig> scrapeConfigPtr,
 }
 
 void ScrapeScheduler::OnMetricResult(HttpResponse& response, uint64_t) {
-    static double sRate = 1.0 / 1000;
+    static double sRate = 0.001;
     auto now = GetCurrentTimeInMilliSeconds();
     mScrapeTimestampMilliSec
         = chrono::duration_cast<chrono::milliseconds>(mLatestScrapeTime.time_since_epoch()).count();

--- a/core/prometheus/schedulers/ScrapeScheduler.cpp
+++ b/core/prometheus/schedulers/ScrapeScheduler.cpp
@@ -86,17 +86,20 @@ ScrapeScheduler::ScrapeScheduler(std::shared_ptr<ScrapeConfig> scrapeConfigPtr,
     mInterval = mScrapeConfigPtr->mScrapeIntervalSeconds;
 }
 
-void ScrapeScheduler::OnMetricResult(HttpResponse& response, uint64_t timestampMilliSec) {
+void ScrapeScheduler::OnMetricResult(HttpResponse& response, uint64_t) {
+    static double sRate = 1.0 / 1000;
+    auto now = GetCurrentTimeInMilliSeconds();
+    mScrapeTimestampMilliSec
+        = chrono::duration_cast<chrono::milliseconds>(mLatestScrapeTime.time_since_epoch()).count();
+    auto scrapeDurationMilliSeconds = now - mScrapeTimestampMilliSec;
+
     auto& responseBody = *response.GetBody<PromMetricResponseBody>();
     responseBody.FlushCache();
     mSelfMonitor->AddCounter(METRIC_PLUGIN_OUT_EVENTS_TOTAL, response.GetStatusCode());
     mSelfMonitor->AddCounter(METRIC_PLUGIN_OUT_SIZE_BYTES, response.GetStatusCode(), responseBody.mRawSize);
-    mSelfMonitor->AddCounter(METRIC_PLUGIN_PROM_SCRAPE_TIME_MS,
-                             response.GetStatusCode(),
-                             GetCurrentTimeInMilliSeconds() - timestampMilliSec);
+    mSelfMonitor->AddCounter(METRIC_PLUGIN_PROM_SCRAPE_TIME_MS, response.GetStatusCode(), scrapeDurationMilliSeconds);
 
-    mScrapeTimestampMilliSec = timestampMilliSec;
-    mScrapeDurationSeconds = 1.0 * (GetCurrentTimeInMilliSeconds() - timestampMilliSec) / 1000;
+    mScrapeDurationSeconds = scrapeDurationMilliSeconds * sRate;
     mScrapeResponseSizeBytes = responseBody.mRawSize;
     mUpState = response.GetStatusCode() == 200;
     if (response.GetStatusCode() != 200) {
@@ -114,7 +117,7 @@ void ScrapeScheduler::OnMetricResult(HttpResponse& response, uint64_t timestampM
     SetAutoMetricMeta(eventGroup);
     SetTargetLabels(eventGroup);
     PushEventGroup(std::move(eventGroup));
-    mPluginTotalDelayMs->Add(GetCurrentTimeInMilliSeconds() - timestampMilliSec);
+    mPluginTotalDelayMs->Add(scrapeDurationMilliSeconds);
 }
 
 void ScrapeScheduler::SetAutoMetricMeta(PipelineEventGroup& eGroup) {

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
@@ -228,7 +228,8 @@ TargetSubscriberScheduler::BuildScrapeSchedulerSet(std::vector<Labels>& targetGr
         auto randSleepMilliSec = GetRandSleepMilliSec(
             scrapeScheduler->GetId(), mScrapeConfigPtr->mScrapeIntervalSeconds, GetCurrentTimeInMilliSeconds());
         auto firstExecTime = std::chrono::steady_clock::now() + std::chrono::milliseconds(randSleepMilliSec);
-        scrapeScheduler->SetFirstExecTime(firstExecTime);
+        auto firstScrapeTIme = std::chrono::system_clock::now() + std::chrono::milliseconds(randSleepMilliSec);
+        scrapeScheduler->SetFirstExecTime(firstExecTime, firstScrapeTIme);
         scrapeScheduler->InitSelfMonitor(mDefaultLabels);
 
         scrapeSchedulerMap[scrapeScheduler->GetId()] = scrapeScheduler;
@@ -333,7 +334,8 @@ void TargetSubscriberScheduler::InitSelfMonitor(const MetricLabels& defaultLabel
     mSelfMonitor = std::make_shared<PromSelfMonitorUnsafe>();
     mSelfMonitor->InitMetricManager(sSubscriberMetricKeys, mDefaultLabels);
 
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_PLUGIN_SOURCE, std::move(mDefaultLabels));
+    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_PLUGIN_SOURCE, std::move(mDefaultLabels));
     mPromSubscriberTargets = mMetricsRecordRef.CreateIntGauge(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS);
     mTotalDelayMs = mMetricsRecordRef.CreateCounter(METRIC_PLUGIN_TOTAL_DELAY_MS);
 }

--- a/core/unittest/prometheus/ScrapeSchedulerUnittest.cpp
+++ b/core/unittest/prometheus/ScrapeSchedulerUnittest.cpp
@@ -220,7 +220,8 @@ void ScrapeSchedulerUnittest::TestQueueIsFull() {
     EventPool eventPool{true};
     event.SetComponent(timer, &eventPool);
     auto now = std::chrono::steady_clock::now();
-    event.SetFirstExecTime(now);
+    auto nowScrape = std::chrono::system_clock::now();
+    event.SetFirstExecTime(now, nowScrape);
     event.ScheduleNext();
 
     APSARA_TEST_TRUE(timer->mQueue.size() == 1);


### PR DESCRIPTION
将原来的 Curl 执行时间作为采集时间戳不准确，因为：从指定的调度执行时间到 Curl 执行时间的间隔不可控，会出现某个 Targets 的实际采集间隔小于指定间隔如（14.932s < 15s）