### PR TITLE
[WIP] update export file

### DIFF
--- a/core/ebpf/SelfMonitor.cpp
+++ b/core/ebpf/SelfMonitor.cpp
@@ -232,7 +232,7 @@ void eBPFSelfMonitorMgr::Suspend(const nami::PluginType type) {
     mInited[int(type)] = false;
 }
 
-void eBPFSelfMonitorMgr::HandleStatistic(std::vector<nami::eBPFStatistics>&& stats) {
+void eBPFSelfMonitorMgr::HandleStatistic(std::vector<nami::eBPFStatistics>& stats) {
     for (auto& stat : stats) {
         if (!stat.updated_) {
             continue;

--- a/core/ebpf/SelfMonitor.h
+++ b/core/ebpf/SelfMonitor.h
@@ -125,7 +125,7 @@ public:
     void Init(const nami::PluginType type, PluginMetricManagerPtr mgr, const std::string& name, const std::string& project);
     void Release(const nami::PluginType type);
     void Suspend(const nami::PluginType type);
-    void HandleStatistic(std::vector<nami::eBPFStatistics>&& stats);
+    void HandleStatistic(std::vector<nami::eBPFStatistics>& stats);
 private:
     // `mLock` is used to protect mSelfMonitors
     ReadWriteLock mLock;

--- a/core/ebpf/handler/ObserveHandler.h
+++ b/core/ebpf/handler/ObserveHandler.h
@@ -26,31 +26,31 @@ class MeterHandler : public AbstractHandler {
 public:
     MeterHandler(const logtail::PipelineContext* ctx, QueueKey key, uint32_t idx) : AbstractHandler(ctx, key, idx) {}
 
-    virtual void handle(std::vector<std::unique_ptr<ApplicationBatchMeasure>>&&, uint64_t) = 0;
+    virtual void handle(std::vector<std::unique_ptr<ApplicationBatchMeasure>>&, uint64_t) = 0;
 };
 
 class OtelMeterHandler : public MeterHandler {
 public:
     OtelMeterHandler(const logtail::PipelineContext* ctx, QueueKey key, uint32_t idx) : MeterHandler(ctx, key, idx) {}
-    void handle(std::vector<std::unique_ptr<ApplicationBatchMeasure>>&& measures, uint64_t timestamp) override;
+    void handle(std::vector<std::unique_ptr<ApplicationBatchMeasure>>& measures, uint64_t timestamp) override;
 };
 
 class SpanHandler : public AbstractHandler {
 public:
     SpanHandler(const logtail::PipelineContext* ctx, QueueKey key, uint32_t idx) : AbstractHandler(ctx, key, idx) {}
-    virtual void handle(std::vector<std::unique_ptr<ApplicationBatchSpan>>&&) = 0;
+    virtual void handle(std::vector<std::unique_ptr<ApplicationBatchSpan>>&) = 0;
 };
 
 class OtelSpanHandler : public SpanHandler {
 public:
     OtelSpanHandler(const logtail::PipelineContext* ctx, QueueKey key, uint32_t idx) : SpanHandler(ctx, key, idx) {}
-    void handle(std::vector<std::unique_ptr<ApplicationBatchSpan>>&&) override;
+    void handle(std::vector<std::unique_ptr<ApplicationBatchSpan>>&) override;
 };
 
 class EventHandler : public AbstractHandler {
 public:
     EventHandler(const logtail::PipelineContext* ctx, QueueKey key, uint32_t idx) : AbstractHandler(ctx, key, idx) {}
-    void handle(std::vector<std::unique_ptr<ApplicationBatchEvent>>&&);
+    void handle(std::vector<std::unique_ptr<ApplicationBatchEvent>>&);
 };
 
 #ifdef __ENTERPRISE__
@@ -58,13 +58,13 @@ public:
 class ArmsMeterHandler : public MeterHandler {
 public:
     ArmsMeterHandler(const logtail::PipelineContext* ctx, QueueKey key, uint32_t idx) : MeterHandler(ctx, key, idx) {}
-    void handle(std::vector<std::unique_ptr<ApplicationBatchMeasure>>&& measures, uint64_t timestamp) override;
+    void handle(std::vector<std::unique_ptr<ApplicationBatchMeasure>>& measures, uint64_t timestamp) override;
 };
 
 class ArmsSpanHandler : public SpanHandler {
 public:
     ArmsSpanHandler(const logtail::PipelineContext* ctx, QueueKey key, uint32_t idx) : SpanHandler(ctx, key, idx) {}
-    void handle(std::vector<std::unique_ptr<ApplicationBatchSpan>>&&) override;
+    void handle(std::vector<std::unique_ptr<ApplicationBatchSpan>>&) override;
 };
 
 #endif

--- a/core/ebpf/handler/SecurityHandler.cpp
+++ b/core/ebpf/handler/SecurityHandler.cpp
@@ -34,7 +34,7 @@ SecurityHandler::SecurityHandler(const logtail::PipelineContext* ctx, logtail::Q
     mHostIp = GetHostIp();
 }
 
-void SecurityHandler::handle(std::vector<std::unique_ptr<AbstractSecurityEvent>>&& events) {
+void SecurityHandler::handle(std::vector<std::unique_ptr<AbstractSecurityEvent>>& events) {
     if (events.empty()) {
         return ;
     }
@@ -48,9 +48,9 @@ void SecurityHandler::handle(std::vector<std::unique_ptr<AbstractSecurityEvent>>
     const static std::string host_name_key = "host.name";
     event_group.SetTag(host_ip_key, mHostIp);
     event_group.SetTag(host_name_key, mHostName);
-    for (auto& x : events) {
+    for (const auto& x : events) {
         auto event = event_group.AddLogEvent();
-        for (auto& tag : x->GetAllTags()) {
+        for (const auto& tag : x->GetAllTags()) {
             event->SetContent(tag.first, tag.second);
         }
         auto seconds = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::nanoseconds(x->GetTimestamp()));

--- a/core/ebpf/handler/SecurityHandler.h
+++ b/core/ebpf/handler/SecurityHandler.h
@@ -26,7 +26,7 @@ namespace ebpf {
 class SecurityHandler : public AbstractHandler {
 public:
     SecurityHandler(const logtail::PipelineContext* ctx, logtail::QueueKey key, uint32_t idx);
-    void handle(std::vector<std::unique_ptr<AbstractSecurityEvent>>&& events);
+    void handle(std::vector<std::unique_ptr<AbstractSecurityEvent>>& events);
 private:
     // TODO 后续这两个 key 需要移到 group 的 metadata 里，在 processortagnative 中转成tag
     std::string mHostIp;

--- a/core/ebpf/include/export.h
+++ b/core/ebpf/include/export.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <map>
 #include <variant>
+#include <future>
 
 enum class SecureEventType {
   SECURE_EVENT_TYPE_SOCKET_SECURE,
@@ -48,14 +49,16 @@ private:
   std::vector<std::unique_ptr<AbstractSecurityEvent>> events;
 };
 
-using HandleSingleDataEventFn = std::function<void(std::unique_ptr<AbstractSecurityEvent>&& event)>;
-using HandleBatchDataEventFn = std::function<void(std::vector<std::unique_ptr<AbstractSecurityEvent>>&& events)>;
+using HandleSingleDataEventFn = std::function<void(std::unique_ptr<AbstractSecurityEvent>& event)>;
+using HandleBatchDataEventFn = std::function<void(std::vector<std::unique_ptr<AbstractSecurityEvent>>& events)>;
 
 enum class UpdataType {
   SECURE_UPDATE_TYPE_ENABLE_PROBE,
   SECURE_UPDATE_TYPE_CONFIG_CHAGE,
   SECURE_UPDATE_TYPE_SUSPEND_PROBE,
   SECURE_UPDATE_TYPE_DISABLE_PROBE,
+  OBSERVER_UPDATE_TYPE_CHANGE_WHITELIST,
+  OBSERVER_UPDATE_TYPE_UPDATE_PROBE,
   SECURE_UPDATE_TYPE_MAX,
 };
 
@@ -104,8 +107,9 @@ struct Measure {
 // process
 struct ApplicationBatchMeasure {
   std::string app_id_;
-  std::string region_id_;
+  std::string app_name_;
   std::string ip_;
+  std::string host_;
   std::vector<std::unique_ptr<Measure>> measures_;
 };
 
@@ -123,6 +127,9 @@ struct SingleSpan {
 
 struct ApplicationBatchSpan {
   std::string app_id_;
+  std::string app_name_;
+  std::string host_ip_;
+  std::string host_name_;
   std::vector<std::unique_ptr<SingleSpan>> single_spans_;
 };
 
@@ -176,13 +183,13 @@ enum class PluginType {
 };
 
 // observe metrics
-using NamiHandleBatchMeasureFunc = std::function<void(std::vector<std::unique_ptr<ApplicationBatchMeasure>>&& measures, uint64_t timestamp)>;
+using NamiHandleBatchMeasureFunc = std::function<void(std::vector<std::unique_ptr<ApplicationBatchMeasure>>& measures, uint64_t timestamp)>;
 // observe spans
-using NamiHandleBatchSpanFunc = std::function<void(std::vector<std::unique_ptr<ApplicationBatchSpan>>&&)>;
+using NamiHandleBatchSpanFunc = std::function<void(std::vector<std::unique_ptr<ApplicationBatchSpan>>&)>;
 // observe events
-using NamiHandleBatchEventFunc = std::function<void(std::vector<std::unique_ptr<ApplicationBatchEvent>>&&)>;
+using NamiHandleBatchEventFunc = std::function<void(std::vector<std::unique_ptr<ApplicationBatchEvent>>&)>;
 // observe security
-using NamiHandleBatchDataEventFn = std::function<void(std::vector<std::unique_ptr<AbstractSecurityEvent>>&& events)>;
+using NamiHandleBatchDataEventFn = std::function<void(std::vector<std::unique_ptr<AbstractSecurityEvent>>& events)>;
 
 struct ObserverNetworkOption {
     std::vector<std::string> mEnableProtocols;
@@ -192,6 +199,9 @@ struct ObserverNetworkOption {
     bool mEnableSpan = false;
     bool mEnableMetric = false;
     bool mEnableLog = true;
+    bool mEnableCidFilter = true;
+    std::vector<std::string> mEnableCids;
+    std::vector<std::string> mDisableCids;
     std::string mMeterHandlerType;
     std::string mSpanHandlerType;
 };
@@ -233,6 +243,28 @@ struct SecurityOption {
   }
 };
 
+class PodMeta {
+public:
+  PodMeta(const std::string& app_id, const std::string& app_name, 
+    const std::string& ns, 
+    const std::string& workload_name, 
+    const std::string& workload_kind, 
+    const std::string& pod_name, const std::string& pod_ip, const std::string& service_name) 
+    : app_id_(app_id), app_name_(app_name), namespace_(ns), workload_name_(workload_name), workload_kind_(workload_kind), pod_name_(pod_name), pod_ip_(pod_ip), service_name_(service_name){}
+  std::string app_id_;
+  std::string app_name_;
+  std::string namespace_;
+  std::string workload_name_;
+  std::string workload_kind_;
+  std::string pod_name_;
+  std::string pod_ip_;
+  std::string service_name_;
+};
+
+using K8sMetadataCacheCallback = std::function<std::unique_ptr<PodMeta>(const std::string&)>;
+using K8sMetadataCallback = std::function<bool(std::vector<std::string>&, std::vector<std::unique_ptr<PodMeta>>&)>;
+using AsyncK8sMetadataCallback = std::function<std::future<bool>(std::vector<std::string>&, std::vector<std::unique_ptr<PodMeta>>&)>;
+
 struct NetworkObserveConfig {
   bool enable_libbpf_debug_ = false;
   bool enable_so_ = false;
@@ -247,9 +279,19 @@ struct NetworkObserveConfig {
   bool enable_span_ = false;
   bool enable_metric_ = false;
   bool enable_event_ = false;
+  bool enable_cid_filter = false;
   NamiHandleBatchMeasureFunc measure_cb_ = nullptr;
   NamiHandleBatchSpanFunc span_cb_ = nullptr;
   NamiHandleBatchEventFunc event_cb_ = nullptr;
+  K8sMetadataCallback metadata_by_cid_cb_ = nullptr;
+  K8sMetadataCallback metadata_by_ip_cb_ = nullptr;
+  AsyncK8sMetadataCallback async_metadata_by_cid_cb_ = nullptr;
+  AsyncK8sMetadataCallback async_metadata_by_ip_cb_ = nullptr;
+  K8sMetadataCacheCallback metadata_by_cid_cache_ = nullptr;
+  K8sMetadataCacheCallback metadata_by_ip_cache_ = nullptr;
+  std::vector<std::string> enable_container_ids_;
+  std::vector<std::string> disable_container_ids_;
+
   bool operator==(const NetworkObserveConfig& other) const {
     return enable_libbpf_debug_ == other.enable_libbpf_debug_ &&
            enable_so_ == other.enable_so_ &&

--- a/core/unittest/ebpf/eBPFServerUnittest.cpp
+++ b/core/unittest/ebpf/eBPFServerUnittest.cpp
@@ -434,7 +434,7 @@ void eBPFServerUnittest::GenerateBatchMeasure(nami::NamiHandleBatchMeasureFunc c
             batch_app_measures.emplace_back(std::move(app_measure_ptr));
         }
     }
-    cb(std::move(batch_app_measures), 100000);
+    cb(batch_app_measures, 100000);
 }
 
 void eBPFServerUnittest::GenerateBatchAppEvent(nami::NamiHandleBatchEventFunc cb) {
@@ -452,7 +452,7 @@ void eBPFServerUnittest::GenerateBatchAppEvent(nami::NamiHandleBatchEventFunc cb
         batch_app_events.emplace_back(std::move(appEvent));
     }
 
-    if (cb) cb(std::move(batch_app_events));
+    if (cb) cb(batch_app_events);
 
     return;
 }
@@ -539,7 +539,7 @@ void eBPFServerUnittest::GenerateBatchSpan(nami::NamiHandleBatchSpanFunc cb) {
         batch_spans->single_spans_.emplace_back(std::move(single_span));
     }
     batch_app_spans.emplace_back(std::move(batch_spans));
-    cb(std::move(batch_app_spans));
+    cb(batch_app_spans);
 }
 
 void eBPFServerUnittest::GenerateBatchEvent(nami::NamiHandleBatchDataEventFn cb, SecureEventType type) {
@@ -555,7 +555,7 @@ void eBPFServerUnittest::GenerateBatchEvent(nami::NamiHandleBatchDataEventFn cb,
         auto event = std::make_unique<AbstractSecurityEvent> (std::move(tags), type, 1000);
         events.emplace_back(std::move(event));
     }
-    cb(std::move(events));
+    cb(events);
 }
 
 void eBPFServerUnittest::InitSecurityOpts() {


### PR DESCRIPTION
更新 export 文件，将 callback 方法入参的右值替换成引用，避免动态库中分配的内存在主进程中回收。

WIP 的原因是目前 oss 的 so 包尚未更新，整体流程验证完成并替换后，合并代码并升级 so 包。