### PR TITLE
fix: fix memory management issues when passing config to observer library

### DIFF
--- a/core/ebpf/config.cpp
+++ b/core/ebpf/config.cpp
@@ -368,10 +368,10 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
         }
         nami::SecurityOption thisSecurityOption;
         GetSecurityProbeDefaultCallName(probeType, thisSecurityOption.call_names_);
-        mOptionList.emplace_back(thisSecurityOption);
+        mOptionList.emplace_back(std::move(thisSecurityOption));
         return true;
     }
-    auto innerConfig = config["ProbeConfig"];
+    const auto& innerConfig = config["ProbeConfig"];
     nami::SecurityOption thisSecurityOption;
     // Genral Filter (Optional)
     std::variant<std::monostate, nami::SecurityFileFilter, nami::SecurityNetworkFilter> thisFilter;
@@ -402,8 +402,8 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
                                     mContext->GetRegion());
     }
     thisSecurityOption.filter_ = thisFilter;
-    GetSecurityProbeDefaultCallName(probeType, thisSecurityOption.call_names_);    
-    mOptionList.emplace_back(thisSecurityOption);
+    GetSecurityProbeDefaultCallName(probeType, thisSecurityOption.call_names_);
+    mOptionList.emplace_back(std::move(thisSecurityOption));
     mProbeType = probeType;
     return true;
 }

--- a/core/ebpf/handler/SecurityHandler.cpp
+++ b/core/ebpf/handler/SecurityHandler.cpp
@@ -49,7 +49,7 @@ void SecurityHandler::handle(std::vector<std::unique_ptr<AbstractSecurityEvent>>
     event_group.SetTag(host_ip_key, mHostIp);
     event_group.SetTag(host_name_key, mHostName);
     for (auto& x : events) {
-        auto event = event_group.AddLogEvent();
+        auto* event = event_group.AddLogEvent();
         for (auto& tag : x->GetAllTags()) {
             event->SetContent(tag.first, tag.second);
         }

--- a/core/ebpf/include/SysAkApi.h
+++ b/core/ebpf/include/SysAkApi.h
@@ -4,8 +4,10 @@
 
 #pragma once
 
-using init_func = int (*)(void *);
-using remove_func = int (*)(void *);
-using suspend_func = int(*)(void *);
+#include "ebpf/include/export.h"
+
+using init_func = int (*)(nami::eBPFConfig*);
+using remove_func = int (*)(nami::eBPFConfig*);
 using deinit_func = void (*)(void);
-using update_func = int(*)(void*);
+using suspend_func = int (*)(nami::eBPFConfig*);
+using update_func = int (*)(nami::eBPFConfig*);

--- a/core/ebpf/include/export.h
+++ b/core/ebpf/include/export.h
@@ -4,12 +4,13 @@
 
 #pragma once
 
-#include <vector>
-#include <string>
-#include <memory>
 #include <functional>
+#include <iostream>
 #include <map>
+#include <memory>
+#include <string>
 #include <variant>
+#include <vector>
 
 enum class SecureEventType {
   SECURE_EVENT_TYPE_SOCKET_SECURE,
@@ -227,6 +228,24 @@ struct SecurityNetworkFilter {
 struct SecurityOption {
   std::vector<std::string> call_names_;
   std::variant<std::monostate, SecurityFileFilter, SecurityNetworkFilter> filter_;
+
+  SecurityOption() = default;
+
+  SecurityOption(const SecurityOption& other) = default;
+
+  SecurityOption(SecurityOption&& other) noexcept
+      : call_names_(std::move(other.call_names_)), filter_(std::move(other.filter_)) {}
+
+  SecurityOption& operator=(const SecurityOption& other) = default;
+
+  SecurityOption& operator=(SecurityOption&& other) noexcept {
+      call_names_ = other.call_names_;
+      filter_ = other.filter_;
+      return *this;
+  }
+
+  ~SecurityOption() {}
+
   bool operator==(const SecurityOption& other) const {
     return call_names_ == other.call_names_ &&
             filter_ == other.filter_;
@@ -342,4 +361,4 @@ struct eBPFConfig {
   }
 };
 
-};
+}; // namespace nami


### PR DESCRIPTION
Refactor configuration management to ensure memory consistency:

Move both construction and destruction of config to the application side to avoid new/free mismatch errors.
Use pointers instead of static objects to prevent premature destruction after library unloading.