### PR TITLE
[backport 2.0] fix go pipeline stop hang caused by improper component stop order

### DIFF
--- a/pluginmanager/config_update_test.go
+++ b/pluginmanager/config_update_test.go
@@ -76,8 +76,7 @@ func (s *configUpdateTestSuite) TestConfigUpdate() {
 	// unblock old config
 	checkFlusher.Block = false
 	time.Sleep(time.Second * time.Duration(5))
-	s.Equal(10000, checkFlusher.GetLogCount())
-	// this magic number(10000) must exceed number of logs can be hold in processor channel(LogsChan) + aggregator buffer(defaultLogGroup) + flusher channel(LogGroupsChan)
+	s.Equal(0, checkFlusher.GetLogCount())
 	s.Equal(20000, GetConfigFlushers(LogtailConfig[noblockUpdateConfigName].PluginRunner)[0].(*checker.FlusherChecker).GetLogCount())
 }
 
@@ -99,7 +98,7 @@ func (s *configUpdateTestSuite) TestConfigUpdateMany() {
 	s.Equal(0, checkFlusher.GetLogCount(), "the hold on block flusher checker doesn't have any logs")
 	checkFlusher.Block = false
 	time.Sleep(time.Second * time.Duration(5))
-	s.Equal(checkFlusher.GetLogCount(), 10000)
+	s.Equal(checkFlusher.GetLogCount(), 0)
 
 	// load normal config
 	for i := 0; i < 5; i++ {
@@ -168,7 +167,11 @@ func (s *configUpdateTestSuite) TestHoldOnExitTimeout() {
 	s.Equal(0, checkFlusher.GetLogCount())
 	checkFlusher.Block = false
 	time.Sleep(time.Second * time.Duration(5))
+<<<<<<< HEAD
 	s.Equal(10000, checkFlusher.GetLogCount())
 	time.Sleep(time.Second * 10)
 	s.NoError(Resume())
+=======
+	s.Equal(0, checkFlusher.GetLogCount())
+>>>>>>> aab30589 (fix: fix go pipeline stop hang caused by improper component stop order (#1914))
 }

--- a/pluginmanager/config_update_test.go
+++ b/pluginmanager/config_update_test.go
@@ -167,11 +167,5 @@ func (s *configUpdateTestSuite) TestHoldOnExitTimeout() {
 	s.Equal(0, checkFlusher.GetLogCount())
 	checkFlusher.Block = false
 	time.Sleep(time.Second * time.Duration(5))
-<<<<<<< HEAD
-	s.Equal(10000, checkFlusher.GetLogCount())
-	time.Sleep(time.Second * 10)
-	s.NoError(Resume())
-=======
 	s.Equal(0, checkFlusher.GetLogCount())
->>>>>>> aab30589 (fix: fix go pipeline stop hang caused by improper component stop order (#1914))
 }

--- a/pluginmanager/plugin_runner_v1.go
+++ b/pluginmanager/plugin_runner_v1.go
@@ -380,6 +380,8 @@ func (p *pluginv1Runner) Stop(exit bool) error {
 	for _, flusher := range p.FlusherPlugins {
 		flusher.Flusher.SetUrgent(exit)
 	}
+	p.LogstoreConfig.FlushOutFlag.Store(true)
+
 	for _, service := range p.ServicePlugins {
 		_ = service.Stop()
 	}
@@ -392,7 +394,6 @@ func (p *pluginv1Runner) Stop(exit bool) error {
 	p.AggregateControl.WaitCancel()
 	logger.Info(p.LogstoreConfig.Context.GetRuntimeContext(), "aggregator plugins stop", "done")
 
-	p.LogstoreConfig.FlushOutFlag = true
 	p.FlushControl.WaitCancel()
 
 	if exit && p.FlushOutStore.Len() > 0 {

--- a/pluginmanager/plugin_runner_v2.go
+++ b/pluginmanager/plugin_runner_v2.go
@@ -375,6 +375,8 @@ func (p *pluginv2Runner) Stop(exit bool) error {
 	for _, flusher := range p.FlusherPlugins {
 		flusher.SetUrgent(exit)
 	}
+	p.LogstoreConfig.FlushOutFlag.Store(true)
+
 	for _, serviceInput := range p.ServicePlugins {
 		_ = serviceInput.Stop()
 	}
@@ -387,7 +389,6 @@ func (p *pluginv2Runner) Stop(exit bool) error {
 	p.AggregateControl.WaitCancel()
 	logger.Info(p.LogstoreConfig.Context.GetRuntimeContext(), "aggregator plugins stop", "done")
 
-	p.LogstoreConfig.FlushOutFlag = true
 	p.FlushControl.WaitCancel()
 
 	if exit && p.FlushOutStore.Len() > 0 {


### PR DESCRIPTION
* fix go pipeline stop hang caused by improper component stop order