### PR TITLE
synchronize eBPF lib header

### DIFF
--- a/core/ebpf/SourceManager.cpp
+++ b/core/ebpf/SourceManager.cpp
@@ -57,10 +57,9 @@ namespace ebpf {
 SourceManager::SourceManager() = default;
 
 SourceManager::~SourceManager() {
-  if (!DynamicLibSuccess()) {
-    LOG_WARNING(sLogger, ("dynamic lib not load, just exit", "need check"));
-    return;
-  }
+    if (!DynamicLibSuccess()) {
+        return;
+    }
 
   for (size_t i = 0; i < mRunning.size(); i++) {
     auto& x = mRunning[i];
@@ -76,7 +75,12 @@ SourceManager::~SourceManager() {
 #endif
 
   // call deinit
-  auto deinit_f = (deinit_func)mFuncs[(int)ebpf_func::EBPF_DEINIT];
+  void* f = mFuncs[(int)ebpf_func::EBPF_DEINIT];
+  if (!f) {
+      return;
+  }
+
+  auto deinit_f = (deinit_func)f;
   deinit_f();
 }
 

--- a/core/ebpf/SourceManager.cpp
+++ b/core/ebpf/SourceManager.cpp
@@ -53,11 +53,31 @@ namespace ebpf {
         } \
         res; \
     })
-    
-SourceManager::SourceManager() {
-}
+
+SourceManager::SourceManager() = default;
 
 SourceManager::~SourceManager() {
+  if (!DynamicLibSuccess()) {
+    LOG_WARNING(sLogger, ("dynamic lib not load, just exit", "need check"));
+    return;
+  }
+
+  for (size_t i = 0; i < mRunning.size(); i++) {
+    auto& x = mRunning[i];
+    if (!x) {
+        continue;
+    }
+    // stop plugin
+    StopPlugin(static_cast<nami::PluginType>(i));
+  }
+
+#ifdef APSARA_UNIT_TEST_MAIN
+  return;
+#endif
+
+  // call deinit
+  auto deinit_f = (deinit_func)mFuncs[(int)ebpf_func::EBPF_DEINIT];
+  deinit_f();
 }
 
 void SourceManager::Init() {
@@ -71,7 +91,7 @@ void SourceManager::Init() {
   } else {
     LOG_DEBUG(sLogger, ("running in host mode", "would not set host path prefix ..."));
   }
-  
+
   mBinaryPath = GetProcessExecutionDir();
   mFullLibName = "lib" + m_lib_name_ + ".so";
   for (auto& x : mRunning) {
@@ -81,8 +101,8 @@ void SourceManager::Init() {
 
 bool SourceManager::LoadDynamicLib(const std::string& lib_name) {
   if (DynamicLibSuccess()) {
-    // already load
-    return true;
+      // already load
+      return true;
   }
 #ifdef APSARA_UNIT_TEST_MAIN
     return true;
@@ -120,8 +140,8 @@ bool SourceManager::LoadDynamicLib(const std::string& lib_name) {
   mOffsets[(int)ebpf_func::EBPF_SOCKET_TRACE_UPDATE_CONN_ADDR] = LOAD_UPROBE_OFFSET(mFuncs[(int)ebpf_func::EBPF_SOCKET_TRACE_UPDATE_CONN_ADDR]);
 
   // check function load success
-  for (auto& x : mFuncs) {
-    if (x == nullptr) return false;
+  if (std::any_of(mFuncs.begin(), mFuncs.end(), [](auto* x) { return x == nullptr; })) {
+      return false;
   }
 
   // update meta
@@ -135,8 +155,8 @@ bool SourceManager::DynamicLibSuccess() {
     return true;
 #endif
   if (!mLib) return false;
-  for (auto x : mFuncs) {
-    if (x == nullptr) return false;
+  if (!std::all_of(mFuncs.begin(), mFuncs.end(), [](auto* x) { return x != nullptr; })) {
+      return false;
   }
   return true;
 }
@@ -215,31 +235,6 @@ bool SourceManager::UpdatePlugin(nami::PluginType plugin_type, std::unique_ptr<n
   auto update_f = (update_func)f;
   int res = update_f(conf.get());
   return !res;
-}
-
-bool SourceManager::StopAll() {
-  if (!DynamicLibSuccess()) {
-      LOG_WARNING(sLogger, ("dynamic lib not load, just exit", "need check"));
-      return true;
-  }
-
-  for (size_t i = 0; i < mRunning.size(); i ++) {
-    auto& x = mRunning[i];
-    if (!x) {
-        continue;
-    }
-    // stop plugin
-    StopPlugin(static_cast<nami::PluginType>(i));
-  }
-
-#ifdef APSARA_UNIT_TEST_MAIN
-  return true;
-#endif
-
-  // call deinit
-  auto deinit_f = (deinit_func)mFuncs[(int)ebpf_func::EBPF_DEINIT];
-  deinit_f();
-  return true;
 }
 
 bool SourceManager::SuspendPlugin(nami::PluginType plugin_type) {

--- a/core/ebpf/SourceManager.h
+++ b/core/ebpf/SourceManager.h
@@ -53,8 +53,6 @@ public:
 
     bool SuspendPlugin(nami::PluginType plugin_type);
 
-    bool StopAll();
-
     bool CheckPluginRunning(nami::PluginType plugin_type);
         
     SourceManager();

--- a/core/ebpf/config.cpp
+++ b/core/ebpf/config.cpp
@@ -379,13 +379,13 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
         case SecurityProbeType::FILE: {
             nami::SecurityFileFilter thisFileFilter;
             InitSecurityFileFilter(innerConfig, thisFileFilter, mContext, sName);
-            thisFilter.emplace<nami::SecurityFileFilter>(thisFileFilter);
+            thisFilter.emplace<nami::SecurityFileFilter>(std::move(thisFileFilter));
             break;
         }
         case SecurityProbeType::NETWORK: {
             nami::SecurityNetworkFilter thisNetworkFilter;
             InitSecurityNetworkFilter(innerConfig, thisNetworkFilter, mContext, sName);
-            thisFilter.emplace<nami::SecurityNetworkFilter>(thisNetworkFilter);
+            thisFilter.emplace<nami::SecurityNetworkFilter>(std::move(thisNetworkFilter));
             break;
         }
         case SecurityProbeType::PROCESS: {

--- a/core/ebpf/eBPFServer.cpp
+++ b/core/ebpf/eBPFServer.cpp
@@ -183,7 +183,6 @@ void eBPFServer::Stop() {
     if (!mInited) return;
     mInited = false;
     LOG_INFO(sLogger, ("begin to stop all plugins", ""));
-    mSourceManager->StopAll();
     // destroy source manager 
     mSourceManager.reset();
     for (int i = 0; i < int(nami::PluginType::MAX); i ++) {

--- a/core/ebpf/eBPFServer.cpp
+++ b/core/ebpf/eBPFServer.cpp
@@ -130,7 +130,6 @@ void EnvManager::InitEnvInfo() {
     LOG_WARNING(sLogger, 
         ("not redhat release, will not start eBPF plugin ...", ""));
     m310Support = false;
-    return;
 }
 
 bool eBPFServer::IsSupportedEnv(nami::PluginType type) {

--- a/core/ebpf/include/export.h
+++ b/core/ebpf/include/export.h
@@ -10,8 +10,8 @@
 #include <memory>
 #include <string>
 #include <variant>
-#include <future>
 #include <vector>
+#include <future>
 
 enum class SecureEventType {
   SECURE_EVENT_TYPE_SOCKET_SECURE,
@@ -238,24 +238,6 @@ struct SecurityNetworkFilter {
 struct SecurityOption {
   std::vector<std::string> call_names_;
   std::variant<std::monostate, SecurityFileFilter, SecurityNetworkFilter> filter_;
-
-  SecurityOption() = default;
-
-  SecurityOption(const SecurityOption& other) = default;
-
-  SecurityOption(SecurityOption&& other) noexcept
-      : call_names_(std::move(other.call_names_)), filter_(std::move(other.filter_)) {}
-
-  SecurityOption& operator=(const SecurityOption& other) = default;
-
-  SecurityOption& operator=(SecurityOption&& other) noexcept {
-      call_names_ = other.call_names_;
-      filter_ = other.filter_;
-      return *this;
-  }
-
-  ~SecurityOption() {}
-
   bool operator==(const SecurityOption& other) const {
     return call_names_ == other.call_names_ &&
             filter_ == other.filter_;

--- a/core/plugin/flusher/sls/FlusherSLS.cpp
+++ b/core/plugin/flusher/sls/FlusherSLS.cpp
@@ -671,10 +671,6 @@ void FlusherSLS::OnSendDone(const HttpResponse& response, SenderQueueItem* item)
     }
 
     auto data = static_cast<SLSSenderQueueItem*>(item);
-    std::shared_ptr<Pipeline> pipeline; // preserve self pipeline while this method is executing
-    if (data->mPipeline) {
-        pipeline = data->mPipeline;
-    }
     string configName = HasContext() ? GetContext().GetConfigName() : "";
     bool isProfileData = GetProfileSender()->IsProfileData(mRegion, mProject, data->mLogstore);
     int32_t curTime = time(NULL);


### PR DESCRIPTION
1. Synchronize export.h:
  Updated export.h to ensure consistency across the codebase. All necessary declarations and definitions are now properly synchronized.
2. Leverage destructor for stop functionality:
  Implemented the stopAll functionality within the destructor to ensure a clean and automatic resource cleanup when objects go out of scope, enhancing robustness and reducing the likelihood of resource leaks.
3. Fix memory violation in FlusherSLS:
  In FlusherSLS, the DealSenderQueueItemAfterSend function was releasing the pipeline object prematurely, which could lead to memory violations if the pipeline member was accessed afterward.