### PR TITLE
fix: use released pipeline pointer

### DIFF
--- a/core/runner/ProcessorRunner.cpp
+++ b/core/runner/ProcessorRunner.cpp
@@ -124,7 +124,8 @@ void ProcessorRunner::Run(uint32_t threadNo) {
         sInGroupDataSizeBytes->Add(item->mEventGroup.DataSize());
 
         shared_ptr<Pipeline>& pipeline = item->mPipeline;
-        if (!pipeline) {
+        bool hasOldPipeline = pipeline != nullptr;
+        if (!hasOldPipeline) {
             pipeline = PipelineManager::GetInstance()->FindConfigByName(configName);
         }
         if (!pipeline) {
@@ -139,6 +140,10 @@ void ProcessorRunner::Run(uint32_t threadNo) {
         vector<PipelineEventGroup> eventGroupList;
         eventGroupList.emplace_back(std::move(item->mEventGroup));
         pipeline->Process(eventGroupList, item->mInputIndex);
+        // if the pipeline is updated, the pointer will be released, so we need to update it to the new pipeline
+        if (hasOldPipeline) {
+            pipeline = PipelineManager::GetInstance()->FindConfigByName(configName);
+        }
 
         if (pipeline->IsFlushingThroughGoPipeline()) {
             // TODO:

--- a/core/runner/ProcessorRunner.cpp
+++ b/core/runner/ProcessorRunner.cpp
@@ -143,6 +143,12 @@ void ProcessorRunner::Run(uint32_t threadNo) {
         // if the pipeline is updated, the pointer will be released, so we need to update it to the new pipeline
         if (hasOldPipeline) {
             pipeline = PipelineManager::GetInstance()->FindConfigByName(configName);
+            if (!pipeline) {
+                LOG_INFO(sLogger,
+                         ("pipeline not found during processing, perhaps due to config deletion",
+                          "discard data")("config", configName));
+                continue;
+            }
         }
 
         if (pipeline->IsFlushingThroughGoPipeline()) {

--- a/core/runner/sink/http/HttpSink.cpp
+++ b/core/runner/sink/http/HttpSink.cpp
@@ -238,6 +238,7 @@ void HttpSink::HandleCompletedRequests(int& runningHandlers) {
             CURL* handler = msg->easy_handle;
             HttpSinkRequest* request = nullptr;
             curl_easy_getinfo(handler, CURLINFO_PRIVATE, &request);
+            auto pipelinePlaceHolder = request->mItem->mPipeline; // keep pipeline alive
             auto responseTime = chrono::system_clock::now() - request->mLastSendTime;
             auto responseTimeMs = chrono::duration_cast<chrono::milliseconds>(responseTime).count();
             switch (msg->data.result) {


### PR DESCRIPTION
## 问题
### 问题一
Flusher在OnSendDone中会将item从队列中移出，后续由于Pipeline被释放，所以导致访问空指针。
修复：在处理之前，先持有Pipeline对象，避免其被释放。

### 问题二
配置变更时，ProcessRunner在处理完旧Pipeline残留在处理队列的数据时，再将其塞入到发送队列或者Go流水线。
1. 发送队列：由于发送队列复用，数据会走新流水线。
2. Go流水线：Go流水线可能已被停止。数据会发送失败。

修复：在处理完之后，统一走新流水线发送数据。

## 测试
后续在配置变更测试中，统一补充测试用例。