### PR TITLE
[backport]: fix GetLastLine core

### DIFF
--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -2405,12 +2405,8 @@ LineInfo ContainerdTextParser::NewGetLastLine(StringView buffer,
 
         LineInfo line;
         parseLine(rawLine, line);
-        // containerd 不需要外层协议的 dataRaw
-        finalLine.data = line.data;
-        finalLine.fullLine = line.fullLine;
-        finalLine.lineBegin = line.lineBegin;
-        finalLine.rollbackLineFeedCount += line.rollbackLineFeedCount;
-        finalLine.lineEnd = line.lineEnd;
+        line.rollbackLineFeedCount += finalLine.rollbackLineFeedCount;
+        finalLine = std::move(line);
         mergeLines(finalLine, finalLine, true);
         if (!finalLine.fullLine) {
             if (finalLine.lineBegin == 0) {

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -2362,11 +2362,12 @@ LineInfo DockerJsonFileParser::NewGetLastLine(StringView buffer,
 
         LineInfo line;
         parseLine(rawLine, line);
-        line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
         if (line.fullLine) {
-            line.rollbackLineFeedCount += finalLine.rollbackLineFeedCount;
+            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
+            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount + line.rollbackLineFeedCount;
         } else {
-            line.forceRollbackLineFeedCount += line.rollbackLineFeedCount;
+            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
+            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount;
         }
         finalLine = std::move(line);
         if (!finalLine.fullLine) {
@@ -2457,11 +2458,12 @@ LineInfo ContainerdTextParser::NewGetLastLine(StringView buffer,
 
         LineInfo line;
         parseLine(rawLine, line);
-        line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
         if (line.fullLine) {
-            line.rollbackLineFeedCount += finalLine.rollbackLineFeedCount;
+            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
+            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount + line.rollbackLineFeedCount;
         } else {
-            line.forceRollbackLineFeedCount += line.rollbackLineFeedCount;
+            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
+            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount;
         }
         finalLine = std::move(line);
         mergeLines(finalLine, finalLine, true);

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -2087,11 +2087,13 @@ LogFileReader::RemoveLastIncompleteLog(char* buffer, int32_t size, int32_t& roll
         }
         LineInfo content = NewGetLastLine(StringView(buffer, size), endPs, true);
         // 最后一行是完整行,且以 \n 结尾
-        if (content.fullLine && buffer[size - 1] == '\n' && content.lineEnd == endPs) {
-            return size;
+        if (content.fullLine && buffer[content.lineEnd] == '\n') {
+            rollbackLineFeedCount += content.forceRollbackLineFeedCount;
+            return content.lineEnd + 1;
         }
         content = NewGetLastLine(StringView(buffer, size), endPs, false);
-        rollbackLineFeedCount = content.rollbackLineFeedCount;
+        rollbackLineFeedCount += content.forceRollbackLineFeedCount;
+        rollbackLineFeedCount += content.rollbackLineFeedCount;
         return content.lineBegin;
     } else {
         bool foundEnd = false;

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -2072,10 +2072,6 @@ LogFileReader::RemoveLastIncompleteLog(char* buffer, int32_t size, int32_t& roll
         // Single line rollback or all unmatch rollback
         rollbackLineFeedCount = 0;
         if (buffer[size - 1] == '\n') {
-            if (mReaderConfig.first->mInputType == FileReaderOptions::InputType::InputFile) {
-                // 如果是文件采集，直接返回，节约性能
-                return size;
-            }
             endPs = size - 1;
         } else {
             endPs = size;

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -2364,14 +2364,19 @@ LineInfo DockerJsonFileParser::NewGetLastLine(StringView buffer,
 
         LineInfo line;
         parseLine(rawLine, line);
+        int32_t rollbackLineFeedCount = 0;
+        int32_t forceRollbackLineFeedCount = 0;
         if (line.fullLine) {
-            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
-            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount + line.rollbackLineFeedCount;
+            rollbackLineFeedCount = line.rollbackLineFeedCount;
+            forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
         } else {
-            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
-            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount;
+            forceRollbackLineFeedCount
+                = finalLine.forceRollbackLineFeedCount + line.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
+            rollbackLineFeedCount = 0;
         }
         finalLine = std::move(line);
+        finalLine.rollbackLineFeedCount = rollbackLineFeedCount;
+        finalLine.forceRollbackLineFeedCount = forceRollbackLineFeedCount;
         if (!finalLine.fullLine) {
             if (finalLine.lineBegin == 0) {
                 return {.data = StringView(),
@@ -2460,14 +2465,19 @@ LineInfo ContainerdTextParser::NewGetLastLine(StringView buffer,
 
         LineInfo line;
         parseLine(rawLine, line);
+        int32_t rollbackLineFeedCount = 0;
+        int32_t forceRollbackLineFeedCount = 0;
         if (line.fullLine) {
-            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
-            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount + line.rollbackLineFeedCount;
+            rollbackLineFeedCount = line.rollbackLineFeedCount;
+            forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
         } else {
-            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
-            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount;
+            forceRollbackLineFeedCount
+                = finalLine.forceRollbackLineFeedCount + line.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
+            rollbackLineFeedCount = 0;
         }
         finalLine = std::move(line);
+        finalLine.rollbackLineFeedCount = rollbackLineFeedCount;
+        finalLine.forceRollbackLineFeedCount = forceRollbackLineFeedCount;
         mergeLines(finalLine, finalLine, true);
         if (!finalLine.fullLine) {
             if (finalLine.lineBegin == 0) {

--- a/core/reader/LogFileReader.cpp
+++ b/core/reader/LogFileReader.cpp
@@ -2377,7 +2377,7 @@ LineInfo DockerJsonFileParser::NewGetLastLine(StringView buffer,
                         .lineEnd = 0,
                         .rollbackLineFeedCount = finalLine.rollbackLineFeedCount,
                         .fullLine = false,
-                        .forceRollbackLineFeedCount = 0};
+                        .forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount};
             }
             end = finalLine.lineBegin - 1;
         }

--- a/core/reader/LogFileReader.h
+++ b/core/reader/LogFileReader.h
@@ -34,7 +34,6 @@
 #include "event/Event.h"
 #include "file_server/FileDiscoveryOptions.h"
 #include "file_server/FileServer.h"
-#include "file_server/FileServer.h"
 #include "file_server/MultilineOptions.h"
 #include "log_pb/sls_logs.pb.h"
 #include "logger/Logger.h"
@@ -57,16 +56,19 @@ struct LineInfo {
     int32_t lineEnd;
     int32_t rollbackLineFeedCount;
     bool fullLine;
+    int32_t forceRollbackLineFeedCount;
     LineInfo(StringView data = StringView(),
              int32_t lineBegin = 0,
              int32_t lineEnd = 0,
              int32_t rollbackLineFeedCount = 0,
-             bool fullLine = false)
+             bool fullLine = false,
+             int32_t forceRollbackLineFeedCount = 0)
         : data(data),
           lineBegin(lineBegin),
           lineEnd(lineEnd),
           rollbackLineFeedCount(rollbackLineFeedCount),
-          fullLine(fullLine) {}
+          fullLine(fullLine),
+          forceRollbackLineFeedCount(forceRollbackLineFeedCount) {}
 };
 
 class BaseLineParse {

--- a/core/unittest/reader/GetLastLineDataUnittest.cpp
+++ b/core/unittest/reader/GetLastLineDataUnittest.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "common/FileSystemUtil.h"
-#include "reader/LogFileReader.h"
 #include "common/memory/SourceBuffer.h"
+#include "reader/LogFileReader.h"
 #include "unittest/Unittest.h"
 
 namespace logtail {
@@ -516,6 +516,44 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
         BaseLineParse* baseLineParsePtr = nullptr;
         baseLineParsePtr = logFileReader.GetParser<ContainerdTextParser>(LogFileReader::BUFFER_SIZE);
         logFileReader.mLineParsers.emplace_back(baseLineParsePtr);
+        {
+            {
+                std::string testLog = "\n2024-01-05T23:28:06.818486411+08:00 stdout P 123123\n";
+
+                int32_t size = testLog.size();
+                int32_t endPs; // the position of \n or \0
+                if (testLog[size - 1] == '\n') {
+                    endPs = size - 1;
+                } else {
+                    endPs = size;
+                }
+                LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
+
+                APSARA_TEST_EQUAL("", line.data.to_string());
+                APSARA_TEST_EQUAL(0, line.lineBegin);
+                APSARA_TEST_EQUAL(0, line.lineEnd);
+                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(true, line.fullLine);
+            }
+            {
+                std::string testLog = "\n2024-01-05T23:28:06.818486411+08:00 stdout F 123123\n";
+
+                int32_t size = testLog.size();
+                int32_t endPs; // the position of \n or \0
+                if (testLog[size - 1] == '\n') {
+                    endPs = size - 1;
+                } else {
+                    endPs = size;
+                }
+                LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
+
+                APSARA_TEST_EQUAL("123123", line.data.to_string());
+                APSARA_TEST_EQUAL(1, line.lineBegin);
+                APSARA_TEST_EQUAL(endPs, line.lineEnd);
+                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(true, line.fullLine);
+            }
+        }
         // 异常情况+有回车
         {
             // case: PartLogFlag存在，第三个空格存在但空格后无内容

--- a/core/unittest/reader/GetLastLineDataUnittest.cpp
+++ b/core/unittest/reader/GetLastLineDataUnittest.cpp
@@ -104,7 +104,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineSingleLine
 
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL(false, line.fullLine);
             }
             // case: PartLogFlag存在，第三个空格不存在
@@ -122,7 +123,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineSingleLine
 
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL(false, line.fullLine);
             }
             // case: PartLogFlag不存在，第二个空格存在
@@ -197,7 +199,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineSingleLine
 
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL(false, line.fullLine);
             }
             // case: PartLogFlag存在，第三个空格不存在
@@ -215,7 +218,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineSingleLine
 
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL(false, line.fullLine);
             }
             // case: PartLogFlag不存在，第二个空格存在
@@ -289,7 +293,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineSingleLine
 
             APSARA_TEST_EQUAL("789", line.data.to_string());
             APSARA_TEST_EQUAL(0, line.lineBegin);
-            APSARA_TEST_EQUAL(3, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(2, line.forceRollbackLineFeedCount);
             APSARA_TEST_EQUAL(true, line.fullLine);
         }
         // case: F + P + P + '\n'
@@ -308,7 +313,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineSingleLine
 
             APSARA_TEST_EQUAL("789", line.data.to_string());
             APSARA_TEST_EQUAL(0, line.lineBegin);
-            APSARA_TEST_EQUAL(3, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(2, line.forceRollbackLineFeedCount);
             APSARA_TEST_EQUAL(true, line.fullLine);
         }
 
@@ -483,7 +489,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineSingleLine
 
             APSARA_TEST_EQUAL("", line.data.to_string());
             APSARA_TEST_EQUAL(0, line.lineBegin);
-            APSARA_TEST_EQUAL(2, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(2, line.forceRollbackLineFeedCount);
             APSARA_TEST_EQUAL(false, line.fullLine);
         }
         // case: P + P + '\n'
@@ -502,7 +509,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineSingleLine
 
             APSARA_TEST_EQUAL("", line.data.to_string());
             APSARA_TEST_EQUAL(0, line.lineBegin);
-            APSARA_TEST_EQUAL(2, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(2, line.forceRollbackLineFeedCount);
             APSARA_TEST_EQUAL(false, line.fullLine);
         }
     }
@@ -532,7 +540,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
                 APSARA_TEST_EQUAL(0, line.lineEnd);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL(true, line.fullLine);
             }
             {
@@ -571,7 +580,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
 
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL(false, line.fullLine);
             }
             // case: PartLogFlag存在，第三个空格不存在
@@ -589,7 +599,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
 
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL(false, line.fullLine);
             }
             // case: PartLogFlag不存在，第二个空格存在
@@ -664,7 +675,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
 
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL(false, line.fullLine);
             }
             // case: PartLogFlag存在，第三个空格不存在
@@ -682,7 +694,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
 
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL(false, line.fullLine);
             }
             // case: PartLogFlag不存在，第二个空格存在
@@ -756,7 +769,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
 
             APSARA_TEST_EQUAL("789", line.data.to_string());
             APSARA_TEST_EQUAL(0, line.lineBegin);
-            APSARA_TEST_EQUAL(3, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(2, line.forceRollbackLineFeedCount);
             APSARA_TEST_EQUAL(true, line.fullLine);
         }
         // case: F + P + P + '\n'
@@ -775,7 +789,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
 
             APSARA_TEST_EQUAL("789", line.data.to_string());
             APSARA_TEST_EQUAL(0, line.lineBegin);
-            APSARA_TEST_EQUAL(3, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(2, line.forceRollbackLineFeedCount);
             APSARA_TEST_EQUAL(true, line.fullLine);
         }
 
@@ -950,7 +965,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
 
             APSARA_TEST_EQUAL("", line.data.to_string());
             APSARA_TEST_EQUAL(0, line.lineBegin);
-            APSARA_TEST_EQUAL(2, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(2, line.forceRollbackLineFeedCount);
             APSARA_TEST_EQUAL(false, line.fullLine);
         }
         // case: P + P + '\n'
@@ -969,7 +985,8 @@ void LastMatchedContainerdTextLineUnittest::TestLastContainerdTextLineMerge() {
 
             APSARA_TEST_EQUAL("", line.data.to_string());
             APSARA_TEST_EQUAL(0, line.lineBegin);
-            APSARA_TEST_EQUAL(2, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(2, line.forceRollbackLineFeedCount);
             APSARA_TEST_EQUAL(false, line.fullLine);
         }
     }
@@ -1069,7 +1086,8 @@ void LastMatchedDockerJsonFileUnittest::TestLastDockerJsonFile() {
                     endPs = size;
                 }
                 LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
                 APSARA_TEST_EQUAL(false, line.fullLine);
@@ -1086,7 +1104,8 @@ void LastMatchedDockerJsonFileUnittest::TestLastDockerJsonFile() {
                     endPs = size;
                 }
                 LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
                 APSARA_TEST_EQUAL(false, line.fullLine);
@@ -1103,7 +1122,8 @@ void LastMatchedDockerJsonFileUnittest::TestLastDockerJsonFile() {
                     endPs = size;
                 }
                 LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
                 APSARA_TEST_EQUAL(false, line.fullLine);
@@ -1120,7 +1140,8 @@ void LastMatchedDockerJsonFileUnittest::TestLastDockerJsonFile() {
                     endPs = size;
                 }
                 LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
                 APSARA_TEST_EQUAL(false, line.fullLine);
@@ -1162,7 +1183,8 @@ void LastMatchedDockerJsonFileUnittest::TestLastDockerJsonFile() {
                     endPs = size;
                 }
                 LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
                 APSARA_TEST_EQUAL(false, line.fullLine);
@@ -1181,7 +1203,8 @@ void LastMatchedDockerJsonFileUnittest::TestLastDockerJsonFile() {
                     endPs = size;
                 }
                 LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
                 APSARA_TEST_EQUAL(false, line.fullLine);
@@ -1200,7 +1223,8 @@ void LastMatchedDockerJsonFileUnittest::TestLastDockerJsonFile() {
                     endPs = size;
                 }
                 LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
                 APSARA_TEST_EQUAL(false, line.fullLine);
@@ -1219,7 +1243,8 @@ void LastMatchedDockerJsonFileUnittest::TestLastDockerJsonFile() {
                     endPs = size;
                 }
                 LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-                APSARA_TEST_EQUAL(1, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(0, line.rollbackLineFeedCount);
+                APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
                 APSARA_TEST_EQUAL("", line.data.to_string());
                 APSARA_TEST_EQUAL(0, line.lineBegin);
                 APSARA_TEST_EQUAL(false, line.fullLine);
@@ -1332,7 +1357,8 @@ void LastMatchedContainerdTextWithDockerJsonUnittest::TestContainerdTextWithDock
             endPs = size;
         }
         LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-        APSARA_TEST_EQUAL(4, line.rollbackLineFeedCount);
+        APSARA_TEST_EQUAL(2, line.rollbackLineFeedCount);
+        APSARA_TEST_EQUAL(0, line.forceRollbackLineFeedCount);
         APSARA_TEST_EQUAL(R"(Exception in thread  "main" java.lang.NullPoinntterException)", line.data.to_string());
         APSARA_TEST_EQUAL(0, line.lineBegin);
         APSARA_TEST_EQUAL(true, line.fullLine);
@@ -1382,7 +1408,8 @@ void LastMatchedContainerdTextWithDockerJsonUnittest::TestDockerJsonWithContaine
             endPs = size;
         }
         LineInfo line = logFileReader.NewGetLastLine(testLog, endPs);
-        APSARA_TEST_EQUAL(3, line.rollbackLineFeedCount);
+        APSARA_TEST_EQUAL(2, line.rollbackLineFeedCount);
+        APSARA_TEST_EQUAL(1, line.forceRollbackLineFeedCount);
         APSARA_TEST_EQUAL(R"(Exception in thread  "main" java.lang.NullPoinntterException)", line.data.to_string());
         APSARA_TEST_EQUAL(0, line.lineBegin);
         APSARA_TEST_EQUAL(true, line.fullLine);

--- a/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
+++ b/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
@@ -448,14 +448,14 @@ void RemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncompleteLogWithEn
             APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
         }
         {
-            std::string expectMatch = "\n\n";
-            std::string testLog = expectMatch + LOG_UNMATCH + "\n";
+            std::string expectMatch = "\n\n" + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch;
             int32_t rollbackLineFeedCount = 0;
             int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
                 const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
-            APSARA_TEST_EQUAL_FATAL(static_cast<int32_t>(expectMatch.size()), matchSize);
-            APSARA_TEST_EQUAL_FATAL(std::string(testLog.data(), matchSize), expectMatch);
-            APSARA_TEST_EQUAL_FATAL(0, rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(static_cast<int32_t>(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(std::string(testLog.data(), matchSize), expectMatch);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
         }
     }
 }
@@ -487,7 +487,7 @@ void GetLastLineUnittest::TestGetLastLineEmpty() {
     LogFileReader logFileReader(
         "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(nullptr, &ctx));
     auto lastLine = logFileReader.GetLastLine(const_cast<char*>(testLog.data()), testLog.size());
-    APSARA_TEST_EQUAL_FATAL(0, lastLine.size());
+    APSARA_TEST_EQUAL_FATAL(0, int(lastLine.size()));
     APSARA_TEST_EQUAL_FATAL("", std::string(lastLine.data(), lastLine.size()));
     APSARA_TEST_EQUAL_FATAL(testLog.data(), lastLine.data());
 }
@@ -547,7 +547,6 @@ void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncom
     BaseLineParse* baseLineParsePtr = nullptr;
     baseLineParsePtr = logFileReader.GetParser<ContainerdTextParser>(LogFileReader::BUFFER_SIZE);
     logFileReader.mLineParsers.emplace_back(baseLineParsePtr);
-    // logFileReader.mDiscardUnmatch = true;
     { // case: end with end
         std::string expectMatch
             = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + '\n';
@@ -558,9 +557,9 @@ void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncom
             const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
         const auto& matchLog = std::string(testLog.data(), matchSize);
 
-        APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
-        APSARA_TEST_EQUAL_FATAL(expectMatch, matchLog);
-        APSARA_TEST_EQUAL_FATAL(0, rollbackLineFeedCount);
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
     }
     { // case: end with unmatch
         std::string expectMatch
@@ -572,9 +571,9 @@ void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncom
             const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
         const auto& matchLog = std::string(testLog.data(), matchSize);
 
-        APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
-        APSARA_TEST_EQUAL_FATAL(expectMatch, matchLog);
-        APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
     }
     { // case: all unmatch
         {
@@ -586,38 +585,38 @@ void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncom
                 const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
             const auto& matchLog = std::string(testLog.data(), matchSize);
 
-            APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
-            APSARA_TEST_EQUAL_FATAL(expectMatch, matchLog);
-            APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
         }
         {
-            std::string expectMatch = "\n\n";
-            std::string testLog = expectMatch + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string expectMatch = "\n\n" + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch;
 
             int32_t rollbackLineFeedCount = 0;
             int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
                 const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
             const auto& matchLog = std::string(testLog.data(), matchSize);
 
-            APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
-            APSARA_TEST_EQUAL_FATAL(expectMatch, matchLog);
-            APSARA_TEST_EQUAL_FATAL(0, rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
         }
     }
     {
         std::string expectMatch
             = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + '\n';
-        std::string testLog = expectMatch + LOG_PART + LOG_UNMATCH + "\n" + LOG_PART + LOG_UNMATCH + "\n" + LOG_PART
-            + LOG_UNMATCH + "\n";
+        std::string testLog
+            = expectMatch + LOG_PART + LOG_UNMATCH + "\n" + LOG_PART + LOG_UNMATCH + "\n" + LOG_PART + LOG_UNMATCH;
 
         int32_t rollbackLineFeedCount = 0;
         int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
             const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
         const auto& matchLog = std::string(testLog.data(), matchSize);
 
-        APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
-        APSARA_TEST_EQUAL_FATAL(expectMatch, matchLog);
-        APSARA_TEST_EQUAL_FATAL(3, rollbackLineFeedCount);
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
     }
     {
         std::string expectMatch
@@ -630,9 +629,9 @@ void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncom
             const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
         const auto& matchLog = std::string(testLog.data(), matchSize);
 
-        APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
-        APSARA_TEST_EQUAL_FATAL(expectMatch, matchLog);
-        APSARA_TEST_EQUAL_FATAL(3, rollbackLineFeedCount);
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
     }
 }
 

--- a/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
+++ b/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
@@ -437,24 +437,26 @@ void RemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncompleteLogWithEn
         APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
     }
     { // case: all unmatch
-        std::string expectMatch = "\n\n";
-        std::string testLog = expectMatch + LOG_UNMATCH;
-        int32_t rollbackLineFeedCount = 0;
-        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
-            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
-        APSARA_TEST_EQUAL_FATAL(static_cast<int32_t>(expectMatch.size()), matchSize);
-        APSARA_TEST_EQUAL_FATAL(std::string(testLog.data(), matchSize), expectMatch);
-        APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
-    }
-    { // case: all unmatch
-        std::string expectMatch = "\n\n";
-        std::string testLog = expectMatch + LOG_UNMATCH + "\n";
-        int32_t rollbackLineFeedCount = 0;
-        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
-            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
-        APSARA_TEST_EQUAL_FATAL(static_cast<int32_t>(expectMatch.size()), matchSize);
-        APSARA_TEST_EQUAL_FATAL(std::string(testLog.data(), matchSize), expectMatch);
-        APSARA_TEST_EQUAL_FATAL(0, rollbackLineFeedCount);
+        {
+            std::string expectMatch = "\n\n";
+            std::string testLog = expectMatch + LOG_UNMATCH;
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            APSARA_TEST_EQUAL_FATAL(static_cast<int32_t>(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL_FATAL(std::string(testLog.data(), matchSize), expectMatch);
+            APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n";
+            std::string testLog = expectMatch + LOG_UNMATCH + "\n";
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            APSARA_TEST_EQUAL_FATAL(static_cast<int32_t>(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL_FATAL(std::string(testLog.data(), matchSize), expectMatch);
+            APSARA_TEST_EQUAL_FATAL(0, rollbackLineFeedCount);
+        }
     }
 }
 
@@ -575,17 +577,32 @@ void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncom
         APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
     }
     { // case: all unmatch
-        std::string expectMatch = "\n\n";
-        std::string testLog = expectMatch + LOG_FULL + LOG_UNMATCH;
+        {
+            std::string expectMatch = "\n\n";
+            std::string testLog = expectMatch + LOG_FULL + LOG_UNMATCH;
 
-        int32_t rollbackLineFeedCount = 0;
-        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
-            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
-        const auto& matchLog = std::string(testLog.data(), matchSize);
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
 
-        APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
-        APSARA_TEST_EQUAL_FATAL(expectMatch, matchLog);
-        APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
+            APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL_FATAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n";
+            std::string testLog = expectMatch + LOG_FULL + LOG_UNMATCH + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL_FATAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL_FATAL(0, rollbackLineFeedCount);
+        }
     }
     {
         std::string expectMatch

--- a/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
+++ b/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
@@ -727,6 +727,32 @@ void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncom
             APSARA_TEST_EQUAL(expectMatch, matchLog);
             APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
         }
+        {
+            std::string expectMatch = "\n\n" + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch + LOG_PART + LOG_BEGIN_STRING + "\n" + LOG_PART + LOG_BEGIN_STRING + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n" + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch + LOG_PART + LOG_BEGIN_STRING + "\n" + LOG_PART + LOG_BEGIN_STRING;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
     }
     { // case: end with part log
         {

--- a/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
+++ b/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
@@ -737,6 +737,36 @@ void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncom
         }
     }
     { // case: end with part log
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + '\n';
+            std::string testLog = expectMatch + LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_PART + LOG_BEGIN_STRING + "\n"
+                + LOG_PART + LOG_BEGIN_STRING + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + '\n';
+            std::string testLog = expectMatch + LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_PART + LOG_BEGIN_STRING + "\n"
+                + LOG_PART + LOG_BEGIN_STRING;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
     }
 }
 


### PR DESCRIPTION
- **修复了因特定日志条目导致的崩溃问题**  
  例如：\n2021-08-25T07:00:00.000000000Z stdout F xxx 导致的日志崩溃。

- **优化了在行尾多行模式匹配到 "xxx\nend" 时的日志回退逻辑**  
  这种情况下应该因为end没有换行符，应该回退所有日志

- **解决了行尾多行模式下当 containerd 日志以 "xxx\nend\npart log" 格式出现时的日志回退问题**  
  例如，在遇到以下日志序列时，如果 "end log" 匹配成功，则应将日志回退至 "2021-08-25T07:00:00.000000000Z stdout F end log" 的位置，回退行数为3行：
  ```
  2021-08-25T07:00:00.000000000Z stdout F unmatch log
  2021-08-25T07:00:00.000000000Z stdout F unmatch log
  2021-08-25T07:00:00.000000000Z stdout F unmatch log
  2021-08-25T07:00:00.000000000Z stdout F end log
  2021-08-25T07:00:00.000000000Z stdout P unmatch log
  2021-08-25T07:00:00.000000000Z stdout P unmatch log
  2021-08-25T07:00:00.000000000Z stdout P unmatch log
  ```