### PR TITLE
fix GetLastLine core

### DIFF
--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -2201,38 +2201,18 @@ LineInfo RawTextParser::GetLastLine(StringView buffer,
                                     bool needSingleLine,
                                     std::vector<BaseLineParse*>* lineParsers) {
     if (end == 0) {
-        return {.data = StringView(),
-                .lineBegin = 0,
-                .lineEnd = 0,
-                .rollbackLineFeedCount = 0,
-                .fullLine = false,
-                .forceRollbackLineFeedCount = 0};
+        return LineInfo(StringView(), 0, 0, 0, false, 0);
     }
     if (protocolFunctionIndex != 0) {
-        return {.data = StringView(),
-                .lineBegin = 0,
-                .lineEnd = 0,
-                .rollbackLineFeedCount = 0,
-                .fullLine = false,
-                .forceRollbackLineFeedCount = 0};
+        return LineInfo(StringView(), 0, 0, 0, false, 0);
     }
 
     for (int32_t begin = end; begin > 0; --begin) {
         if (buffer[begin - 1] == '\n') {
-            return {.data = StringView(buffer.data() + begin, end - begin),
-                    .lineBegin = begin,
-                    .lineEnd = end,
-                    .rollbackLineFeedCount = 1,
-                    .fullLine = true,
-                    .forceRollbackLineFeedCount = 0};
+            return LineInfo(StringView(buffer.data() + begin, end - begin), begin, end, 1, true, 0);
         }
     }
-    return {.data = StringView(buffer.data(), end),
-            .lineBegin = 0,
-            .lineEnd = end,
-            .rollbackLineFeedCount = 1,
-            .fullLine = true,
-            .forceRollbackLineFeedCount = 0};
+    return LineInfo(StringView(buffer.data(), end), 0, end, 1, true, 0);
 }
 
 LineInfo DockerJsonFileParser::GetLastLine(StringView buffer,
@@ -2241,21 +2221,11 @@ LineInfo DockerJsonFileParser::GetLastLine(StringView buffer,
                                            bool needSingleLine,
                                            std::vector<BaseLineParse*>* lineParsers) {
     if (end == 0) {
-        return {.data = StringView(),
-                .lineBegin = 0,
-                .lineEnd = 0,
-                .rollbackLineFeedCount = 0,
-                .fullLine = false,
-                .forceRollbackLineFeedCount = 0};
+        return LineInfo(StringView(), 0, 0, 0, false, 0);
     }
     if (protocolFunctionIndex == 0) {
         // 异常情况, DockerJsonFileParse不允许在最后一个解析器
-        return {.data = StringView(),
-                .lineBegin = 0,
-                .lineEnd = 0,
-                .rollbackLineFeedCount = 0,
-                .fullLine = false,
-                .forceRollbackLineFeedCount = 0};
+        return LineInfo(StringView(), 0, 0, 0, false, 0);
     }
 
     size_t nextProtocolFunctionIndex = protocolFunctionIndex - 1;
@@ -2279,12 +2249,8 @@ LineInfo DockerJsonFileParser::GetLastLine(StringView buffer,
         finalLine = std::move(line);
         if (!finalLine.fullLine) {
             if (finalLine.lineBegin == 0) {
-                return {.data = StringView(),
-                        .lineBegin = 0,
-                        .lineEnd = 0,
-                        .rollbackLineFeedCount = finalLine.rollbackLineFeedCount,
-                        .fullLine = false,
-                        .forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount};
+                return LineInfo(
+                    StringView(), 0, 0, finalLine.rollbackLineFeedCount, false, finalLine.forceRollbackLineFeedCount);
             }
             end = finalLine.lineBegin - 1;
         }
@@ -2335,21 +2301,11 @@ LineInfo ContainerdTextParser::GetLastLine(StringView buffer,
                                            bool needSingleLine,
                                            std::vector<BaseLineParse*>* lineParsers) {
     if (end == 0) {
-        return {.data = StringView(),
-                .lineBegin = 0,
-                .lineEnd = 0,
-                .rollbackLineFeedCount = 0,
-                .fullLine = false,
-                .forceRollbackLineFeedCount = 0};
+        return LineInfo(StringView(), 0, 0, 0, false, 0);
     }
     if (protocolFunctionIndex == 0) {
         // 异常情况, ContainerdTextParser不允许在最后一个解析器
-        return {.data = StringView(),
-                .lineBegin = 0,
-                .lineEnd = 0,
-                .rollbackLineFeedCount = 0,
-                .fullLine = false,
-                .forceRollbackLineFeedCount = 0};
+        return LineInfo(StringView(), 0, 0, 0, false, 0);
     }
     LineInfo finalLine;
     finalLine.fullLine = false;
@@ -2376,12 +2332,8 @@ LineInfo ContainerdTextParser::GetLastLine(StringView buffer,
         mergeLines(finalLine, finalLine, true);
         if (!finalLine.fullLine) {
             if (finalLine.lineBegin == 0) {
-                return {.data = StringView(),
-                        .lineBegin = 0,
-                        .lineEnd = 0,
-                        .rollbackLineFeedCount = finalLine.rollbackLineFeedCount,
-                        .fullLine = false,
-                        .forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount};
+                return LineInfo(
+                    StringView(), 0, 0, finalLine.rollbackLineFeedCount, false, finalLine.forceRollbackLineFeedCount);
             }
             end = finalLine.lineBegin - 1;
         }

--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -2195,6 +2195,13 @@ StringBuffer* BaseLineParse::GetStringBuffer() {
     return &mStringBuffer;
 }
 
+/*
+    params:
+        buffer: all read logs
+        end: the end position of current line, \n or \0
+    return:
+        last line (backward), without \n or \0
+*/
 LineInfo RawTextParser::GetLastLine(StringView buffer,
                                     int32_t end,
                                     size_t protocolFunctionIndex,

--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -349,26 +349,25 @@ void LogFileReader::InitReader(bool tailExisted, FileReadPolicy policy, uint32_t
 
 namespace detail {
 
-    void updatePrimaryCheckpoint(const std::string& key, PrimaryCheckpointPB& cpt, const std::string& field) {
-        cpt.set_update_time(time(NULL));
-        if (CheckpointManagerV2::GetInstance()->SetPB(key, cpt)) {
-            LOG_INFO(sLogger, ("update primary checkpoint", key)("field", field)("checkpoint", cpt.DebugString()));
-        } else {
-            LOG_WARNING(sLogger,
-                        ("update primary checkpoint error", key)("field", field)("checkpoint", cpt.DebugString()));
-        }
+void updatePrimaryCheckpoint(const std::string& key, PrimaryCheckpointPB& cpt, const std::string& field) {
+    cpt.set_update_time(time(NULL));
+    if (CheckpointManagerV2::GetInstance()->SetPB(key, cpt)) {
+        LOG_INFO(sLogger, ("update primary checkpoint", key)("field", field)("checkpoint", cpt.DebugString()));
+    } else {
+        LOG_WARNING(sLogger, ("update primary checkpoint error", key)("field", field)("checkpoint", cpt.DebugString()));
     }
+}
 
-    std::pair<size_t, size_t> getPartitionRange(size_t idx, size_t concurrency, size_t totalPartitionCount) {
-        auto base = totalPartitionCount / concurrency;
-        auto extra = totalPartitionCount % concurrency;
-        if (extra == 0) {
-            return std::make_pair(idx * base, (idx + 1) * base - 1);
-        }
-        size_t min = idx <= extra ? idx * (base + 1) : extra * (base + 1) + (idx - extra) * base;
-        size_t max = idx < extra ? min + base : min + base - 1;
-        return std::make_pair(min, max);
+std::pair<size_t, size_t> getPartitionRange(size_t idx, size_t concurrency, size_t totalPartitionCount) {
+    auto base = totalPartitionCount / concurrency;
+    auto extra = totalPartitionCount % concurrency;
+    if (extra == 0) {
+        return std::make_pair(idx * base, (idx + 1) * base - 1);
     }
+    size_t min = idx <= extra ? idx * (base + 1) : extra * (base + 1) + (idx - extra) * base;
+    size_t max = idx < extra ? min + base : min + base - 1;
+    return std::make_pair(min, max);
+}
 
 } // namespace detail
 
@@ -687,7 +686,7 @@ void LogFileReader::SetFilePosBackwardToFixedPos(LogFileOperator& op) {
 
 void LogFileReader::checkContainerType(LogFileOperator& op) {
     // 判断container类型
-    char containerBOMBuffer[1] = {0};
+    char containerBOMBuffer[2] = {0};
     size_t readBOMByte = 1;
     int64_t filePos = 0;
     TruncateInfo* truncateInfo = NULL;
@@ -1991,7 +1990,8 @@ LogFileReader::FileCompareResult LogFileReader::CompareToFile(const string& file
         3. continue\nend\ncontinue\nend\n -> continue\nxxx\nend
     5. mLogEndRegPtr != NULL
         1. xxx\nend\n -> xxx\nend
-        1. xxx\nend\nxxx\n -> xxx\nend
+        2. xxx\nend\nxxx\n -> xxx\nend
+        3. xxx\nend -> ""
 */
 /*
     return: the number of bytes left, including \n
@@ -2009,6 +2009,7 @@ LogFileReader::RemoveLastIncompleteLog(char* buffer, int32_t size, int32_t& roll
     }
     rollbackLineFeedCount = 0;
     // Multiline rollback
+    bool foundEnd = false;
     if (mMultilineConfig.first->IsMultiline()) {
         std::string exception;
         while (endPs >= 0) {
@@ -2019,6 +2020,8 @@ LogFileReader::RemoveLastIncompleteLog(char* buffer, int32_t size, int32_t& roll
                                      content.data.size(),
                                      *mMultilineConfig.first->GetEndPatternReg(),
                                      exception)) {
+                    rollbackLineFeedCount += content.forceRollbackLineFeedCount;
+                    foundEnd = true;
                     // Ensure the end line is complete
                     if (buffer[content.lineEnd] == '\n') {
                         return content.lineEnd + 1;
@@ -2030,13 +2033,18 @@ LogFileReader::RemoveLastIncompleteLog(char* buffer, int32_t size, int32_t& roll
                                            *mMultilineConfig.first->GetStartPatternReg(),
                                            exception)) {
                 // start + continue, start
+                rollbackLineFeedCount += content.forceRollbackLineFeedCount;
                 rollbackLineFeedCount += content.rollbackLineFeedCount;
                 // Keep all the buffer if rollback all
                 return content.lineBegin;
             }
+            rollbackLineFeedCount += content.forceRollbackLineFeedCount;
             rollbackLineFeedCount += content.rollbackLineFeedCount;
             endPs = content.lineBegin - 1;
         }
+    }
+    if (mMultilineConfig.first->GetEndPatternReg() && foundEnd) {
+        return 0;
     }
     // Single line rollback or all unmatch rollback
     rollbackLineFeedCount = 0;
@@ -2047,11 +2055,13 @@ LogFileReader::RemoveLastIncompleteLog(char* buffer, int32_t size, int32_t& roll
     }
     LineInfo content = GetLastLine(StringView(buffer, size), endPs, true);
     // 最后一行是完整行,且以 \n 结尾
-    if (content.fullLine && buffer[endPs] == '\n') {
-        return size;
+    if (content.fullLine && buffer[content.lineEnd] == '\n') {
+        rollbackLineFeedCount += content.forceRollbackLineFeedCount;
+        return content.lineEnd + 1;
     }
     content = GetLastLine(StringView(buffer, size), endPs, false);
-    rollbackLineFeedCount = content.rollbackLineFeedCount;
+    rollbackLineFeedCount += content.forceRollbackLineFeedCount;
+    rollbackLineFeedCount += content.rollbackLineFeedCount;
     return content.lineBegin;
 }
 
@@ -2191,26 +2201,38 @@ LineInfo RawTextParser::GetLastLine(StringView buffer,
                                     bool needSingleLine,
                                     std::vector<BaseLineParse*>* lineParsers) {
     if (end == 0) {
-        return {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+        return {.data = StringView(),
+                .lineBegin = 0,
+                .lineEnd = 0,
+                .rollbackLineFeedCount = 0,
+                .fullLine = false,
+                .forceRollbackLineFeedCount = 0};
     }
     if (protocolFunctionIndex != 0) {
-        return {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+        return {.data = StringView(),
+                .lineBegin = 0,
+                .lineEnd = 0,
+                .rollbackLineFeedCount = 0,
+                .fullLine = false,
+                .forceRollbackLineFeedCount = 0};
     }
 
     for (int32_t begin = end; begin > 0; --begin) {
-        if (begin == 0 || buffer[begin - 1] == '\n') {
+        if (buffer[begin - 1] == '\n') {
             return {.data = StringView(buffer.data() + begin, end - begin),
                     .lineBegin = begin,
                     .lineEnd = end,
                     .rollbackLineFeedCount = 1,
-                    .fullLine = true};
+                    .fullLine = true,
+                    .forceRollbackLineFeedCount = 0};
         }
     }
     return {.data = StringView(buffer.data(), end),
             .lineBegin = 0,
             .lineEnd = end,
             .rollbackLineFeedCount = 1,
-            .fullLine = true};
+            .fullLine = true,
+            .forceRollbackLineFeedCount = 0};
 }
 
 LineInfo DockerJsonFileParser::GetLastLine(StringView buffer,
@@ -2219,38 +2241,50 @@ LineInfo DockerJsonFileParser::GetLastLine(StringView buffer,
                                            bool needSingleLine,
                                            std::vector<BaseLineParse*>* lineParsers) {
     if (end == 0) {
-        return {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+        return {.data = StringView(),
+                .lineBegin = 0,
+                .lineEnd = 0,
+                .rollbackLineFeedCount = 0,
+                .fullLine = false,
+                .forceRollbackLineFeedCount = 0};
     }
     if (protocolFunctionIndex == 0) {
         // 异常情况, DockerJsonFileParse不允许在最后一个解析器
-        return {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+        return {.data = StringView(),
+                .lineBegin = 0,
+                .lineEnd = 0,
+                .rollbackLineFeedCount = 0,
+                .fullLine = false,
+                .forceRollbackLineFeedCount = 0};
     }
 
     size_t nextProtocolFunctionIndex = protocolFunctionIndex - 1;
-    LineInfo finalLine
-        = {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+    LineInfo finalLine;
     while (!finalLine.fullLine) {
         LineInfo rawLine = (*lineParsers)[nextProtocolFunctionIndex]->GetLastLine(
             buffer, end, nextProtocolFunctionIndex, needSingleLine, lineParsers);
-        if (rawLine.data.back() == '\n') {
+        if (rawLine.data.size() > 0 && rawLine.data.back() == '\n') {
             rawLine.data = StringView(rawLine.data.data(), rawLine.data.size() - 1);
         }
 
-        LineInfo line
-            = {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+        LineInfo line;
         parseLine(rawLine, line);
-        finalLine.data = line.data;
-        finalLine.fullLine = line.fullLine;
-        finalLine.lineBegin = line.lineBegin;
-        finalLine.rollbackLineFeedCount += line.rollbackLineFeedCount;
-        finalLine.dataRaw = line.dataRaw;
-        if (finalLine.lineEnd == 0) {
-            finalLine.lineEnd = line.lineEnd;
+        if (line.fullLine) {
+            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
+            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount + line.rollbackLineFeedCount;
+        } else {
+            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
+            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount;
         }
+        finalLine = std::move(line);
         if (!finalLine.fullLine) {
             if (finalLine.lineBegin == 0) {
-                finalLine.data = StringView();
-                return finalLine;
+                return {.data = StringView(),
+                        .lineBegin = 0,
+                        .lineEnd = 0,
+                        .rollbackLineFeedCount = finalLine.rollbackLineFeedCount,
+                        .fullLine = false,
+                        .forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount};
             }
             end = finalLine.lineBegin - 1;
         }
@@ -2261,7 +2295,9 @@ LineInfo DockerJsonFileParser::GetLastLine(StringView buffer,
 bool DockerJsonFileParser::parseLine(LineInfo rawLine, LineInfo& paseLine) {
     paseLine = rawLine;
     paseLine.fullLine = false;
-
+    if (rawLine.data.size() == 0) {
+        return false;
+    }
     rapidjson::Document doc;
     doc.Parse(rawLine.data.data(), rawLine.data.size());
 
@@ -2299,40 +2335,53 @@ LineInfo ContainerdTextParser::GetLastLine(StringView buffer,
                                            bool needSingleLine,
                                            std::vector<BaseLineParse*>* lineParsers) {
     if (end == 0) {
-        return {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+        return {.data = StringView(),
+                .lineBegin = 0,
+                .lineEnd = 0,
+                .rollbackLineFeedCount = 0,
+                .fullLine = false,
+                .forceRollbackLineFeedCount = 0};
     }
     if (protocolFunctionIndex == 0) {
-        // 异常情况, DockerJsonFileParse不允许在最后一个解析器
-        return {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+        // 异常情况, ContainerdTextParser不允许在最后一个解析器
+        return {.data = StringView(),
+                .lineBegin = 0,
+                .lineEnd = 0,
+                .rollbackLineFeedCount = 0,
+                .fullLine = false,
+                .forceRollbackLineFeedCount = 0};
     }
-    LineInfo finalLine
-        = {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
-    // 跳过最后的连续P
+    LineInfo finalLine;
+    finalLine.fullLine = false;
     size_t nextProtocolFunctionIndex = protocolFunctionIndex - 1;
 
+    // 跳过最后的连续P
     while (!finalLine.fullLine) {
         LineInfo rawLine = (*lineParsers)[nextProtocolFunctionIndex]->GetLastLine(
             buffer, end, nextProtocolFunctionIndex, needSingleLine, lineParsers);
-        if (rawLine.data.back() == '\n') {
+        if (rawLine.data.size() > 0 && rawLine.data.back() == '\n') {
             rawLine.data = StringView(rawLine.data.data(), rawLine.data.size() - 1);
         }
 
-        LineInfo line
-            = {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+        LineInfo line;
         parseLine(rawLine, line);
-        // containerd 不需要外层协议的 dataRaw
-        finalLine.data = line.data;
-        finalLine.fullLine = line.fullLine;
-        finalLine.lineBegin = line.lineBegin;
-        finalLine.rollbackLineFeedCount += line.rollbackLineFeedCount;
-        mergeLines(finalLine, finalLine, true);
-        if (finalLine.lineEnd == 0) {
-            finalLine.lineEnd = line.lineEnd;
+        if (line.fullLine) {
+            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
+            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount + line.rollbackLineFeedCount;
+        } else {
+            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
+            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount;
         }
+        finalLine = std::move(line);
+        mergeLines(finalLine, finalLine, true);
         if (!finalLine.fullLine) {
             if (finalLine.lineBegin == 0) {
-                finalLine.data = StringView();
-                return finalLine;
+                return {.data = StringView(),
+                        .lineBegin = 0,
+                        .lineEnd = 0,
+                        .rollbackLineFeedCount = finalLine.rollbackLineFeedCount,
+                        .fullLine = false,
+                        .forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount};
             }
             end = finalLine.lineBegin - 1;
         }
@@ -2352,11 +2401,10 @@ LineInfo ContainerdTextParser::GetLastLine(StringView buffer,
             break;
         }
 
-        LineInfo previousLine
-            = {.data = StringView(), .lineBegin = 0, .lineEnd = 0, .rollbackLineFeedCount = 0, .fullLine = false};
+        LineInfo previousLine;
         LineInfo rawLine = (*lineParsers)[nextProtocolFunctionIndex]->GetLastLine(
             buffer, finalLine.lineBegin - 1, nextProtocolFunctionIndex, needSingleLine, lineParsers);
-        if (rawLine.data.back() == '\n') {
+        if (rawLine.data.size() > 0 && rawLine.data.back() == '\n') {
             rawLine.data = StringView(rawLine.data.data(), rawLine.data.size() - 1);
         }
 
@@ -2393,9 +2441,10 @@ void ContainerdTextParser::parseLine(LineInfo rawLine, LineInfo& paseLine) {
     const char* lineEnd = rawLine.data.data() + rawLine.data.size();
     paseLine = rawLine;
     paseLine.fullLine = true;
-
+    if (rawLine.data.size() == 0) {
+        return;
+    }
     // 寻找第一个分隔符位置 time
-    StringView timeValue;
     const char* pch1 = std::find(rawLine.data.data(), lineEnd, ProcessorParseContainerLogNative::CONTAINERD_DELIMITER);
     if (pch1 == lineEnd) {
         return;
@@ -2411,6 +2460,10 @@ void ContainerdTextParser::parseLine(LineInfo rawLine, LineInfo& paseLine) {
         return;
     }
     // 如果既不以 P 开头,也不以 F 开头
+    if (pch2 + 1 >= lineEnd) {
+        paseLine.data = StringView(pch2 + 1, lineEnd - pch2 - 1);
+        return;
+    }
     if (*(pch2 + 1) != ProcessorParseContainerLogNative::CONTAINERD_PART_TAG
         && *(pch2 + 1) != ProcessorParseContainerLogNative::CONTAINERD_FULL_TAG) {
         paseLine.data = StringView(pch2 + 1, lineEnd - pch2 - 1);

--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -2239,14 +2239,19 @@ LineInfo DockerJsonFileParser::GetLastLine(StringView buffer,
 
         LineInfo line;
         parseLine(rawLine, line);
+        int32_t rollbackLineFeedCount = 0;
+        int32_t forceRollbackLineFeedCount = 0;
         if (line.fullLine) {
-            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
-            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount + line.rollbackLineFeedCount;
+            rollbackLineFeedCount = line.rollbackLineFeedCount;
+            forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
         } else {
-            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
-            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount;
+            forceRollbackLineFeedCount
+                = finalLine.forceRollbackLineFeedCount + line.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
+            rollbackLineFeedCount = 0;
         }
         finalLine = std::move(line);
+        finalLine.rollbackLineFeedCount = rollbackLineFeedCount;
+        finalLine.forceRollbackLineFeedCount = forceRollbackLineFeedCount;
         if (!finalLine.fullLine) {
             if (finalLine.lineBegin == 0) {
                 return LineInfo(
@@ -2321,14 +2326,19 @@ LineInfo ContainerdTextParser::GetLastLine(StringView buffer,
 
         LineInfo line;
         parseLine(rawLine, line);
+        int32_t rollbackLineFeedCount = 0;
+        int32_t forceRollbackLineFeedCount = 0;
         if (line.fullLine) {
-            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
-            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount + line.rollbackLineFeedCount;
+            rollbackLineFeedCount = line.rollbackLineFeedCount;
+            forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount;
         } else {
-            line.forceRollbackLineFeedCount = finalLine.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
-            line.rollbackLineFeedCount = finalLine.rollbackLineFeedCount;
+            forceRollbackLineFeedCount
+                = finalLine.forceRollbackLineFeedCount + line.forceRollbackLineFeedCount + line.rollbackLineFeedCount;
+            rollbackLineFeedCount = 0;
         }
         finalLine = std::move(line);
+        finalLine.rollbackLineFeedCount = rollbackLineFeedCount;
+        finalLine.forceRollbackLineFeedCount = forceRollbackLineFeedCount;
         mergeLines(finalLine, finalLine, true);
         if (!finalLine.fullLine) {
             if (finalLine.lineBegin == 0) {

--- a/core/file_server/reader/LogFileReader.h
+++ b/core/file_server/reader/LogFileReader.h
@@ -31,16 +31,16 @@
 #include "common/StringTools.h"
 #include "common/TimeUtil.h"
 #include "common/memory/SourceBuffer.h"
-#include "file_server/event/Event.h"
 #include "file_server/FileDiscoveryOptions.h"
 #include "file_server/FileServer.h"
 #include "file_server/MultilineOptions.h"
-#include "protobuf/sls/sls_logs.pb.h"
+#include "file_server/event/Event.h"
+#include "file_server/reader/FileReaderOptions.h"
 #include "logger/Logger.h"
 #include "models/StringView.h"
 #include "pipeline/queue/QueueKey.h"
+#include "protobuf/sls/sls_logs.pb.h"
 #include "rapidjson/allocators.h"
-#include "file_server/reader/FileReaderOptions.h"
 
 namespace logtail {
 
@@ -57,6 +57,7 @@ struct LineInfo {
     int32_t lineEnd;
     int32_t rollbackLineFeedCount;
     bool fullLine;
+    int32_t forceRollbackLineFeedCount;
 };
 
 class BaseLineParse {
@@ -234,7 +235,7 @@ public:
 
     /// @return e.g. `/home/admin/access.log`
     const std::string& GetConvertedPath() const;
-    
+
     const std::string& GetHostLogPathFile() const { return mHostLogPathFile; }
 
     int64_t GetFileSize() const { return mLastFileSize; }
@@ -686,6 +687,7 @@ private:
     friend class LogSplitNoDiscardUnmatchUnittest;
     friend class RemoveLastIncompleteLogMultilineUnittest;
     friend class LogFileReaderCheckpointUnittest;
+    friend class GetLastLineUnittest;
     friend class LastMatchedContainerdTextLineUnittest;
     friend class LastMatchedDockerJsonFileUnittest;
     friend class LastMatchedContainerdTextWithDockerJsonUnittest;

--- a/core/file_server/reader/LogFileReader.h
+++ b/core/file_server/reader/LogFileReader.h
@@ -58,6 +58,18 @@ struct LineInfo {
     int32_t rollbackLineFeedCount;
     bool fullLine;
     int32_t forceRollbackLineFeedCount;
+    LineInfo(StringView data = StringView(),
+             int32_t lineBegin = 0,
+             int32_t lineEnd = 0,
+             int32_t rollbackLineFeedCount = 0,
+             bool fullLine = false,
+             int32_t forceRollbackLineFeedCount = 0)
+        : data(data),
+          lineBegin(lineBegin),
+          lineEnd(lineEnd),
+          rollbackLineFeedCount(rollbackLineFeedCount),
+          fullLine(fullLine),
+          forceRollbackLineFeedCount(forceRollbackLineFeedCount) {}
 };
 
 class BaseLineParse {

--- a/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
+++ b/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
@@ -15,6 +15,8 @@
 #include "common/FileSystemUtil.h"
 #include "common/memory/SourceBuffer.h"
 #include "file_server/reader/LogFileReader.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
 #include "unittest/Unittest.h"
 
 namespace logtail {
@@ -186,8 +188,8 @@ void RemoveLastIncompleteLogUnittest::TestMultiline() {
     }
     { // case empty string
         std::string expectMatch = "";
-        std::string testLog2 = expectMatch + "";
         int32_t rollbackLineFeedCount = 0;
+        std::string testLog2 = expectMatch + "";
         int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
             const_cast<char*>(testLog2.data()), testLog2.size(), rollbackLineFeedCount);
         APSARA_TEST_EQUAL_FATAL(int32_t(expectMatch.size()), matchSize);
@@ -417,14 +419,26 @@ void RemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncompleteLogWithEn
         "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(&multilineOpts, &ctx));
     // logFileReader.mDiscardUnmatch = true;
     { // case: end with end
-        std::string expectMatch = LOG_UNMATCH + "\n" + LOG_UNMATCH + "\n" + LOG_END_STRING + '\n';
-        std::string testLog = std::string(expectMatch.data());
-        int32_t rollbackLineFeedCount = 0;
-        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
-            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
-        APSARA_TEST_EQUAL_FATAL(static_cast<int32_t>(expectMatch.size()), matchSize);
-        APSARA_TEST_EQUAL_FATAL(std::string(testLog.data(), matchSize), expectMatch);
-        APSARA_TEST_EQUAL_FATAL(0, rollbackLineFeedCount);
+        {
+            std::string expectMatch = LOG_UNMATCH + "\n" + LOG_UNMATCH + "\n" + LOG_END_STRING + '\n';
+            std::string testLog = std::string(expectMatch.data());
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            APSARA_TEST_EQUAL_FATAL(static_cast<int32_t>(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL_FATAL(std::string(testLog.data(), matchSize), expectMatch);
+            APSARA_TEST_EQUAL_FATAL(0, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = LOG_UNMATCH + "\n" + LOG_UNMATCH + "\n" + LOG_END_STRING;
+            std::string testLog = std::string(expectMatch.data());
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(0, matchSize);
+            APSARA_TEST_EQUAL(std::string(testLog.data(), matchSize), "");
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
     }
     { // case: end with unmatch
         std::string expectMatch = LOG_UNMATCH + "\n" + LOG_UNMATCH + "\n" + LOG_END_STRING + '\n';
@@ -437,17 +451,833 @@ void RemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncompleteLogWithEn
         APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
     }
     { // case: all unmatch
-        std::string expectMatch = "\n\n";
-        std::string testLog = expectMatch + LOG_UNMATCH;
-        int32_t rollbackLineFeedCount = 0;
-        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
-            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
-        APSARA_TEST_EQUAL_FATAL(static_cast<int32_t>(expectMatch.size()), matchSize);
-        APSARA_TEST_EQUAL_FATAL(std::string(testLog.data(), matchSize), expectMatch);
-        APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
+        {
+            std::string expectMatch = "\n\n";
+            std::string testLog = expectMatch + LOG_UNMATCH;
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            APSARA_TEST_EQUAL_FATAL(static_cast<int32_t>(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL_FATAL(std::string(testLog.data(), matchSize), expectMatch);
+            APSARA_TEST_EQUAL_FATAL(1, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n" + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch;
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            APSARA_TEST_EQUAL(static_cast<int32_t>(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(std::string(testLog.data(), matchSize), expectMatch);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
+        }
     }
 }
 
+class GetLastLineUnittest : public ::testing::Test {
+public:
+    void TestGetLastLine();
+    void TestGetLastLineEmpty();
+
+private:
+    FileReaderOptions readerOpts;
+    PipelineContext ctx;
+};
+
+UNIT_TEST_CASE(GetLastLineUnittest, TestGetLastLine);
+UNIT_TEST_CASE(GetLastLineUnittest, TestGetLastLineEmpty);
+
+void GetLastLineUnittest::TestGetLastLine() {
+    std::string testLog = "first line\nsecond line\nthird line";
+    LogFileReader logFileReader(
+        "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(nullptr, &ctx));
+    auto lastLine = logFileReader.GetLastLine(const_cast<char*>(testLog.data()), testLog.size());
+    std::string expectLog = "third line";
+    APSARA_TEST_EQUAL_FATAL(expectLog, std::string(lastLine.data(), lastLine.size()));
+}
+
+void GetLastLineUnittest::TestGetLastLineEmpty() {
+    std::string testLog = "";
+    LogFileReader logFileReader(
+        "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(nullptr, &ctx));
+    auto lastLine = logFileReader.GetLastLine(const_cast<char*>(testLog.data()), testLog.size());
+    APSARA_TEST_EQUAL_FATAL(0, int(lastLine.size()));
+    APSARA_TEST_EQUAL_FATAL("", std::string(lastLine.data(), lastLine.size()));
+    APSARA_TEST_EQUAL_FATAL(testLog.data(), lastLine.data());
+}
+
+class ContainerdTextRemoveLastIncompleteLogMultilineUnittest : public ::testing::Test {
+public:
+    void TestRemoveLastIncompleteLogWithBeginEnd();
+    void TestRemoveLastIncompleteLogWithBegin();
+    void TestRemoveLastIncompleteLogWithEnd();
+    void SetUp() override { readerOpts.mInputType = FileReaderOptions::InputType::InputContainerStdio; }
+
+private:
+    FileReaderOptions readerOpts;
+    PipelineContext ctx;
+    const std::string LOG_PART = "2021-08-25T07:00:00.000000000Z stdout P ";
+    const std::string LOG_FULL = "2021-08-25T07:00:00.000000000Z stdout F ";
+    const std::string LOG_FULL_NOT_FOUND = "2021-08-25T07:00:00.000000000Z stdout ";
+    const std::string LOG_ERROR = "2021-08-25T07:00:00.000000000Z stdout";
+
+    const std::string LOG_BEGIN_STRING = "Exception in thread \"main\" java.lang.NullPointerException";
+    const std::string LOG_BEGIN_REGEX = R"(Exception.*)";
+
+    const std::string LOG_END_STRING = "    ...23 more";
+    const std::string LOG_END_REGEX = R"(\s*\.\.\.\d+ more.*)";
+
+    const std::string LOG_UNMATCH = "unmatch log";
+};
+
+UNIT_TEST_CASE(ContainerdTextRemoveLastIncompleteLogMultilineUnittest, TestRemoveLastIncompleteLogWithBeginEnd);
+UNIT_TEST_CASE(ContainerdTextRemoveLastIncompleteLogMultilineUnittest, TestRemoveLastIncompleteLogWithBegin);
+UNIT_TEST_CASE(ContainerdTextRemoveLastIncompleteLogMultilineUnittest, TestRemoveLastIncompleteLogWithEnd);
+
+void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncompleteLogWithBeginEnd() {
+    Json::Value config;
+    config["StartPattern"] = LOG_BEGIN_REGEX;
+    config["EndPattern"] = LOG_END_REGEX;
+    MultilineOptions multilineOpts;
+    multilineOpts.Init(config, ctx, "");
+    LogFileReader logFileReader(
+        "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(&multilineOpts, &ctx));
+    BaseLineParse* baseLineParsePtr = nullptr;
+    baseLineParsePtr = logFileReader.GetParser<ContainerdTextParser>(LogFileReader::BUFFER_SIZE);
+    logFileReader.mLineParsers.emplace_back(baseLineParsePtr);
+    { // case: end with begin end
+        std::string expectMatch
+            = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + '\n';
+        std::string testLog = std::string(expectMatch.data());
+
+        int32_t rollbackLineFeedCount = 0;
+        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+        const auto& matchLog = std::string(testLog.data(), matchSize);
+
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
+    }
+    { // case: end with begin
+        std::string expectMatch
+            = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + '\n';
+        std::string testLog = expectMatch + LOG_FULL + LOG_BEGIN_STRING + "\n";
+
+        int32_t rollbackLineFeedCount = 0;
+        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+        const auto& matchLog = std::string(testLog.data(), matchSize);
+
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+    }
+    { // case: end with unmatch
+        std::string expectMatch
+            = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + "\n";
+        std::string testLog = expectMatch + LOG_FULL + LOG_UNMATCH + "\n";
+
+        int32_t rollbackLineFeedCount = 0;
+        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+        const auto& matchLog = std::string(testLog.data(), matchSize);
+
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+    }
+    { // case: all unmatch
+        std::string expectMatch = "\n\n";
+        std::string testLog = expectMatch + LOG_FULL + LOG_UNMATCH;
+
+        int32_t rollbackLineFeedCount = 0;
+        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+        const auto& matchLog = std::string(testLog.data(), matchSize);
+
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+    }
+}
+
+void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncompleteLogWithBegin() {
+    Json::Value config;
+    config["StartPattern"] = LOG_BEGIN_REGEX;
+    MultilineOptions multilineOpts;
+    multilineOpts.Init(config, ctx, "");
+    LogFileReader logFileReader(
+        "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(&multilineOpts, &ctx));
+    BaseLineParse* baseLineParsePtr = nullptr;
+    baseLineParsePtr = logFileReader.GetParser<ContainerdTextParser>(LogFileReader::BUFFER_SIZE);
+    logFileReader.mLineParsers.emplace_back(baseLineParsePtr);
+    { // case: end with begin
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + '\n';
+            std::string testLog = expectMatch + LOG_PART + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + '\n';
+            std::string testLog = expectMatch + LOG_PART + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + '\n';
+            std::string testLog = expectMatch + LOG_FULL + LOG_BEGIN_STRING + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + '\n';
+            std::string testLog = expectMatch + LOG_FULL + LOG_BEGIN_STRING;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+        }
+    }
+    { // case: end with unmatch
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch + LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch + LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+    }
+    { // case: all unmatch
+        {
+            std::string expectMatch = "\n\n" + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n";
+            std::string testLog = expectMatch + LOG_FULL + LOG_UNMATCH;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n" + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch + LOG_PART + LOG_BEGIN_STRING + "\n" + LOG_PART + LOG_BEGIN_STRING + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n" + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch + LOG_PART + LOG_BEGIN_STRING + "\n" + LOG_PART + LOG_BEGIN_STRING;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+    }
+    { // case: end with part log
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + '\n';
+            std::string testLog = expectMatch + LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_PART + LOG_BEGIN_STRING + "\n"
+                + LOG_PART + LOG_BEGIN_STRING + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + '\n';
+            std::string testLog = expectMatch + LOG_FULL + LOG_BEGIN_STRING + "\n" + LOG_PART + LOG_BEGIN_STRING + "\n"
+                + LOG_PART + LOG_BEGIN_STRING;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+    }
+}
+
+void ContainerdTextRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncompleteLogWithEnd() {
+    Json::Value config;
+    config["EndPattern"] = LOG_END_REGEX;
+    MultilineOptions multilineOpts;
+    multilineOpts.Init(config, ctx, "");
+    LogFileReader logFileReader(
+        "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(&multilineOpts, &ctx));
+    BaseLineParse* baseLineParsePtr = nullptr;
+    baseLineParsePtr = logFileReader.GetParser<ContainerdTextParser>(LogFileReader::BUFFER_SIZE);
+    logFileReader.mLineParsers.emplace_back(baseLineParsePtr);
+    { // case: end with end
+        {
+            std::string expectMatch = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_PART
+                + LOG_END_STRING + '\n' + LOG_FULL + LOG_UNMATCH;
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(0, matchSize);
+            APSARA_TEST_EQUAL("", matchLog);
+            APSARA_TEST_EQUAL(4, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_PART
+                + LOG_END_STRING + '\n' + LOG_FULL + LOG_UNMATCH + '\n';
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + '\n';
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING;
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(0, matchSize);
+            APSARA_TEST_EQUAL("", matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+    }
+    { // case: end with unmatch
+        std::string expectMatch
+            = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + '\n';
+        std::string testLog = expectMatch + LOG_FULL + LOG_UNMATCH + "\n";
+
+        int32_t rollbackLineFeedCount = 0;
+        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+        const auto& matchLog = std::string(testLog.data(), matchSize);
+
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+    }
+    { // case: all unmatch
+        {
+            std::string expectMatch = "\n\n";
+            std::string testLog = expectMatch + LOG_FULL + LOG_UNMATCH;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n" + LOG_FULL + LOG_UNMATCH + "\n";
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
+        }
+    }
+    { // case: end with part log
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + '\n';
+            std::string testLog
+                = expectMatch + LOG_PART + LOG_UNMATCH + "\n" + LOG_PART + LOG_UNMATCH + "\n" + LOG_PART + LOG_UNMATCH;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + '\n';
+            std::string testLog = expectMatch + LOG_PART + LOG_UNMATCH + "\n" + LOG_PART + LOG_UNMATCH + "\n" + LOG_PART
+                + LOG_UNMATCH + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_UNMATCH + "\n" + LOG_FULL + LOG_END_STRING + '\n';
+            std::string testLog = expectMatch + LOG_PART + LOG_UNMATCH + "\n" + LOG_PART + LOG_UNMATCH + "\n"
+                + "2021-08-25T07:00:00.000000000Z";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+    }
+}
+
+class DockerJsonRemoveLastIncompleteLogMultilineUnittest : public ::testing::Test {
+public:
+    void TestRemoveLastIncompleteLogWithBeginEnd();
+    void TestRemoveLastIncompleteLogWithBegin();
+    void TestRemoveLastIncompleteLogWithEnd();
+    void SetUp() override { readerOpts.mInputType = FileReaderOptions::InputType::InputContainerStdio; }
+
+private:
+    FileReaderOptions readerOpts;
+    PipelineContext ctx;
+
+    const std::string LOG_BEGIN_STRING = "Exception in thread \"main\" java.lang.NullPointerException";
+    const std::string LOG_BEGIN_REGEX = R"(Exception.*)";
+
+    const std::string LOG_END_STRING = "    ...23 more";
+    const std::string LOG_END_REGEX = R"(\s*\.\.\.\d+ more.*)";
+
+    const std::string LOG_UNMATCH = "unmatch log";
+
+    std::string BuildLog(const std::string& log, bool isNormalLog = true) {
+        if (isNormalLog) {
+            rapidjson::StringBuffer buffer;
+            rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+            writer.StartObject();
+            writer.Key("log");
+            writer.String((log + "\\n").c_str());
+            writer.Key("stream");
+            writer.String("stdout");
+            writer.Key("time");
+            writer.String("2024-02-19T03:49:37.793533014Z");
+            writer.EndObject();
+            return buffer.GetString();
+        } else {
+            return R"({"log":")" + log + R"(\n","stream":"stdout","time":"2024-02-19T03:49:37.79)";
+        }
+    }
+};
+
+UNIT_TEST_CASE(DockerJsonRemoveLastIncompleteLogMultilineUnittest, TestRemoveLastIncompleteLogWithBegin);
+UNIT_TEST_CASE(DockerJsonRemoveLastIncompleteLogMultilineUnittest, TestRemoveLastIncompleteLogWithEnd);
+
+void DockerJsonRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncompleteLogWithBegin() {
+    Json::Value config;
+    config["StartPattern"] = LOG_BEGIN_REGEX;
+    MultilineOptions multilineOpts;
+    multilineOpts.Init(config, ctx, "");
+    LogFileReader logFileReader(
+        "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(&multilineOpts, &ctx));
+    BaseLineParse* baseLineParsePtr = nullptr;
+    baseLineParsePtr = logFileReader.GetParser<DockerJsonFileParser>(0);
+    logFileReader.mLineParsers.emplace_back(baseLineParsePtr);
+    { // case: end with begin
+        {
+            std::string expectMatch
+                = BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + '\n';
+            std::string testLog = expectMatch + BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH);
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + '\n';
+            std::string testLog = expectMatch + BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + '\n';
+            std::string testLog = expectMatch + BuildLog(LOG_BEGIN_STRING) + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + '\n';
+            std::string testLog = expectMatch + BuildLog(LOG_BEGIN_STRING);
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+        }
+    }
+    { // case: end with unmatch
+        {
+            std::string expectMatch
+                = BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + "\n";
+            std::string testLog = expectMatch + BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + "\n";
+            std::string testLog = expectMatch + BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH);
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(2, rollbackLineFeedCount);
+        }
+    }
+    { // case: all unmatch
+        {
+            std::string expectMatch = "\n\n" + BuildLog(LOG_UNMATCH) + "\n";
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n";
+            std::string testLog = expectMatch + BuildLog(LOG_UNMATCH);
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+        }
+    }
+    { // case: end with part log
+        {
+            std::string expectMatch
+                = BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + '\n';
+            std::string testLog = expectMatch + BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_BEGIN_STRING, false)
+                + "\n" + BuildLog(LOG_BEGIN_STRING, false) + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + '\n';
+            std::string testLog = expectMatch + BuildLog(LOG_BEGIN_STRING) + "\n" + BuildLog(LOG_BEGIN_STRING, false)
+                + "\n" + BuildLog(LOG_BEGIN_STRING, false);
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+    }
+}
+
+void DockerJsonRemoveLastIncompleteLogMultilineUnittest::TestRemoveLastIncompleteLogWithEnd() {
+    Json::Value config;
+    config["EndPattern"] = LOG_END_REGEX;
+    MultilineOptions multilineOpts;
+    multilineOpts.Init(config, ctx, "");
+    LogFileReader logFileReader(
+        "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(&multilineOpts, &ctx));
+    BaseLineParse* baseLineParsePtr = nullptr;
+    baseLineParsePtr = logFileReader.GetParser<DockerJsonFileParser>(0);
+    logFileReader.mLineParsers.emplace_back(baseLineParsePtr);
+    { // case: end with end
+        {
+            std::string expectMatch
+                = BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_END_STRING);
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(0, matchSize);
+            APSARA_TEST_EQUAL("", matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_END_STRING) + '\n';
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
+        }
+    }
+    { // case: end with unmatch
+        std::string expectMatch
+            = BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_END_STRING) + '\n';
+        std::string testLog = expectMatch + BuildLog(LOG_UNMATCH) + "\n";
+
+        int32_t rollbackLineFeedCount = 0;
+        int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+            const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+        const auto& matchLog = std::string(testLog.data(), matchSize);
+
+        APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+        APSARA_TEST_EQUAL(expectMatch, matchLog);
+        APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+    }
+    { // case: all unmatch
+        {
+            std::string expectMatch = "\n\n";
+            std::string testLog = expectMatch + BuildLog(LOG_UNMATCH);
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(1, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch = "\n\n" + BuildLog(LOG_UNMATCH) + "\n";
+            std::string testLog = expectMatch;
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(0, rollbackLineFeedCount);
+        }
+    }
+    { // case: end with part log
+        {
+            std::string expectMatch
+                = BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_END_STRING) + '\n';
+            std::string testLog = expectMatch + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH, false) + "\n"
+                + BuildLog(LOG_UNMATCH, false);
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_END_STRING) + '\n';
+            std::string testLog = expectMatch + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH, false) + "\n"
+                + BuildLog(LOG_UNMATCH, false) + "\n";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+        {
+            std::string expectMatch
+                = BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_END_STRING) + '\n';
+            std::string testLog = expectMatch + BuildLog(LOG_UNMATCH) + "\n" + BuildLog(LOG_UNMATCH, false) + "\n"
+                + "2021-08-25T07:00:00.000000000Z";
+
+            int32_t rollbackLineFeedCount = 0;
+            int32_t matchSize = logFileReader.RemoveLastIncompleteLog(
+                const_cast<char*>(testLog.data()), testLog.size(), rollbackLineFeedCount);
+            const auto& matchLog = std::string(testLog.data(), matchSize);
+
+            APSARA_TEST_EQUAL(int32_t(expectMatch.size()), matchSize);
+            APSARA_TEST_EQUAL(expectMatch, matchLog);
+            APSARA_TEST_EQUAL(3, rollbackLineFeedCount);
+        }
+    }
+}
 } // namespace logtail
 
 UNIT_TEST_MAIN

--- a/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
+++ b/core/unittest/reader/RemoveLastIncompleteLogUnittest.cpp
@@ -493,7 +493,7 @@ void GetLastLineUnittest::TestGetLastLine() {
         "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(nullptr, &ctx));
     auto lastLine = logFileReader.GetLastLine(const_cast<char*>(testLog.data()), testLog.size());
     std::string expectLog = "third line";
-    APSARA_TEST_EQUAL_FATAL(expectLog, std::string(lastLine.data(), lastLine.size()));
+    APSARA_TEST_EQUAL_FATAL(expectLog, std::string(lastLine.data.data(), lastLine.data.size()));
 }
 
 void GetLastLineUnittest::TestGetLastLineEmpty() {
@@ -501,9 +501,9 @@ void GetLastLineUnittest::TestGetLastLineEmpty() {
     LogFileReader logFileReader(
         "dir", "file", DevInode(), std::make_pair(&readerOpts, &ctx), std::make_pair(nullptr, &ctx));
     auto lastLine = logFileReader.GetLastLine(const_cast<char*>(testLog.data()), testLog.size());
-    APSARA_TEST_EQUAL_FATAL(0, int(lastLine.size()));
-    APSARA_TEST_EQUAL_FATAL("", std::string(lastLine.data(), lastLine.size()));
-    APSARA_TEST_EQUAL_FATAL(testLog.data(), lastLine.data());
+    APSARA_TEST_EQUAL_FATAL(0, int(lastLine.data.size()));
+    APSARA_TEST_EQUAL_FATAL("", std::string(lastLine.data.data(), lastLine.data.size()));
+    APSARA_TEST_EQUAL_FATAL(testLog.data(), lastLine.data);
 }
 
 class ContainerdTextRemoveLastIncompleteLogMultilineUnittest : public ::testing::Test {


### PR DESCRIPTION
- **修复了因特定日志条目导致的崩溃问题**  
  例如：\n2021-08-25T07:00:00.000000000Z stdout F xxx 导致的日志崩溃。

- **优化了在行尾多行模式匹配到 "xxx\nend" 时的日志回退逻辑**  
  这种情况下应该因为end没有换行符，应该回退所有日志

- **解决了行尾多行模式下当 containerd 日志以 "xxx\nend\npart log" 格式出现时的日志回退问题**  
  例如，在遇到以下日志序列时，如果 "end log" 匹配成功，则应将日志回退至 "2021-08-25T07:00:00.000000000Z stdout F end log" 的位置，回退行数为3行：
  ```
  2021-08-25T07:00:00.000000000Z stdout F unmatch log
  2021-08-25T07:00:00.000000000Z stdout F unmatch log
  2021-08-25T07:00:00.000000000Z stdout F unmatch log
  2021-08-25T07:00:00.000000000Z stdout F end log
  2021-08-25T07:00:00.000000000Z stdout P unmatch log
  2021-08-25T07:00:00.000000000Z stdout P unmatch log
  2021-08-25T07:00:00.000000000Z stdout P unmatch log
  ```