### PR TITLE
[backport 2.0] fix the issue where flusher_sls does not work when coexisting with extended flushers && core caused by invalid flusher_sls pointer in enterprise mode

### DIFF
--- a/core/flusher/FlusherSLS.cpp
+++ b/core/flusher/FlusherSLS.cpp
@@ -316,7 +316,7 @@ void FlusherSLS::GenerateGoPlugin(const Json::Value& config, Json::Value& res) c
             detail[itr.name()] = *itr;
         }
     }
-    if (!detail.empty()) {
+    if (mContext->IsFlushingThroughGoPipeline()) {
         Json::Value plugin(Json::objectValue);
         plugin["type"] = "flusher_sls";
         plugin["detail"] = detail;

--- a/core/pipeline/PipelineContext.h
+++ b/core/pipeline/PipelineContext.h
@@ -78,6 +78,8 @@ public:
     void SetRequiringJsonReaderFlag(bool flag) { mRequiringJsonReader = flag; }
     bool IsFirstProcessorApsara() const { return mIsFirstProcessorApsara; }
     void SetIsFirstProcessorApsaraFlag(bool flag) { mIsFirstProcessorApsara = flag; }
+    bool IsFlushingThroughGoPipeline() const { return mIsFlushingThroughGoPipeline; }
+    void SetIsFlushingThroughGoPipelineFlag(bool flag) { mIsFlushingThroughGoPipeline = flag; }
 
     ProcessProfile& GetProcessProfile() const { return mProcessProfile; }
     // LogFileProfiler& GetProfiler() { return *mProfiler; }
@@ -95,6 +97,7 @@ private:
     const FlusherSLS* mSLSInfo = nullptr;
     bool mRequiringJsonReader = false;
     bool mIsFirstProcessorApsara = false;
+    bool mIsFlushingThroughGoPipeline = false;
 
     mutable ProcessProfile mProcessProfile;
     // LogFileProfiler* mProfiler = LogFileProfiler::GetInstance();

--- a/core/unittest/config/ConfigUnittest.cpp
+++ b/core/unittest/config/ConfigUnittest.cpp
@@ -80,7 +80,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ],
             "extensions": [
@@ -486,7 +486,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -523,7 +523,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -556,7 +556,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -581,7 +581,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -613,7 +613,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -653,7 +653,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -681,7 +681,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -721,7 +721,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -757,7 +757,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -777,7 +777,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -804,7 +804,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -839,7 +839,7 @@ void ConfigUnittest::HandleValidConfig() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -867,7 +867,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -907,7 +907,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -943,7 +943,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -971,7 +971,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1006,7 +1006,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1049,7 +1049,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1080,7 +1080,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1123,7 +1123,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1162,7 +1162,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1185,7 +1185,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1215,7 +1215,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1253,7 +1253,7 @@ void ConfigUnittest::HandleValidConfig() const {
                     "Type": "flusher_sls"
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1942,7 +1942,7 @@ void ConfigUnittest::HandleInvalidAggregators() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }

--- a/core/unittest/pipeline/PipelineUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUnittest.cpp
@@ -109,7 +109,7 @@ void PipelineUnittest::OnSuccessfulInit() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -148,7 +148,7 @@ void PipelineUnittest::OnSuccessfulInit() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ],
             "extensions": [
@@ -195,7 +195,7 @@ void PipelineUnittest::OnSuccessfulInit() const {
             },
             "flushers": [
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ],
@@ -363,6 +363,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
 
     // topology 2: extended -> native -> native
     configStr = R"(
@@ -508,6 +509,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 5: extended -> extended -> native
@@ -586,6 +588,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithInput.clear();
 
     // topology 6: (native, extended) -> extended -> native
@@ -709,6 +712,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 8: extended -> (native -> extended) -> native
@@ -832,6 +836,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
 
     // topology 11: extended -> none -> native (future changes maybe applied)
     configStr = R"(
@@ -898,6 +903,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithInput.clear();
 
     // topology 12: (native, extended) -> none -> native
@@ -962,7 +968,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -982,7 +988,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -1000,6 +1006,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(0, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 14: extended -> native -> extended
@@ -1025,7 +1032,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1064,7 +1071,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1097,7 +1104,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1123,7 +1130,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -1141,6 +1148,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(0, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 17: extended -> extended -> extended
@@ -1163,7 +1171,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1194,7 +1202,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -1212,6 +1220,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(0, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
+    APSARA_TEST_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithInput.clear();
 
     // topology 18: (native, extended) -> extended -> extended
@@ -1240,7 +1249,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1279,7 +1288,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1305,7 +1314,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -1323,6 +1332,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(0, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 20: extended -> (native -> extended) -> extended
@@ -1351,7 +1361,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1393,7 +1403,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1421,7 +1431,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1441,7 +1451,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -1459,6 +1469,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(0, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 23: extended -> none -> extended
@@ -1476,7 +1487,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1501,7 +1512,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -1519,6 +1530,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(0, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
+    APSARA_TEST_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithInput.clear();
 
     // topology 24: (native, extended) -> none -> extended
@@ -1542,7 +1554,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
             ],
             "flushers": [
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1586,7 +1598,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1612,7 +1624,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     }
                 },
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -1630,6 +1642,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 26: extended -> native -> (native, extended)
@@ -1663,7 +1676,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1710,7 +1723,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1751,7 +1764,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1783,7 +1796,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     }
                 },
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -1801,6 +1814,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 29: extended -> extended -> (native, extended)
@@ -1831,7 +1845,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1868,7 +1882,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     }
                 },
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -1886,6 +1900,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithInput.clear();
 
     // topology 30: (native, extended) -> extended -> (native, extended)
@@ -1922,7 +1937,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -1969,7 +1984,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -2001,7 +2016,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     }
                 },
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -2019,6 +2034,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 32: extended -> (native -> extended) -> (native, extended)
@@ -2055,7 +2071,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -2105,7 +2121,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -2141,7 +2157,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -2167,7 +2183,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     }
                 },
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -2185,6 +2201,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithInput.isNull());
     APSARA_TEST_TRUE(goPipelineWithoutInput == pipeline->mGoPipelineWithoutInput);
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithoutInput.clear();
 
     // topology 35: extended -> none -> (native, extended)
@@ -2210,7 +2227,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }
@@ -2241,7 +2258,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     }
                 },
                 {
-                    "type": "flusher_kafka_v2",
+                    "type": "flusher_http",
                     "detail": {}
                 }
             ]
@@ -2259,6 +2276,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
     APSARA_TEST_EQUAL(1, pipeline->GetFlushers().size());
     APSARA_TEST_TRUE(goPipelineWithInput == pipeline->mGoPipelineWithInput);
     APSARA_TEST_TRUE(pipeline->mGoPipelineWithoutInput.isNull());
+    APSARA_TEST_NOT_EQUAL(nullptr, pipeline->GetContext().GetSLSInfo());
     goPipelineWithInput.clear();
 
     // topology 36: (native, extended) -> none -> (native, extended)
@@ -2290,7 +2308,7 @@ void PipelineUnittest::OnInitVariousTopology() const {
                     "EnableShardHash": false
                 },
                 {
-                    "Type": "flusher_kafka_v2"
+                    "Type": "flusher_http"
                 }
             ]
         }


### PR DESCRIPTION
- 问题：
  1. 商业版配置如果没有flusher_sls会core；
  2. 同时配置flusher_sls和go输出插件，sls输出插件不生效
- 影响：
  问题1为2.0系列，不包括loongcollector；问题2从2.0开始便存在
- 原因：
  1. 没有flusher_sls时，context里存了一个临时的指针，后续使用可能会core