### PR TITLE
fix: pipelineupdateunittest enterprise ut

### DIFF
--- a/test/engine/setup/subscriber/sls.go
+++ b/test/engine/setup/subscriber/sls.go
@@ -273,11 +273,6 @@ func init() {
 		} else {
 			l.Project = config.TestConfig.Project
 		}
-		if v, ok := spec["logstore"]; ok {
-			l.Logstore = v.(string)
-		} else {
-			l.Logstore = config.TestConfig.Logstore
-		}
 		if v, ok := spec["query_endpoint"]; ok {
 			l.QueryEndpoint = v.(string)
 		} else {
@@ -287,6 +282,11 @@ func init() {
 			l.TelemetryType = v.(string)
 		} else {
 			l.TelemetryType = "logs"
+		}
+		if v, ok := spec["logstore"]; ok {
+			l.Logstore = v.(string)
+		} else {
+			l.Logstore = config.TestConfig.GetLogstore(l.TelemetryType)
 		}
 		l.client = createSLSClient(config.TestConfig.AccessKeyID, config.TestConfig.AccessKeySecret, l.QueryEndpoint)
 		return l, nil

--- a/tools/coverage-diff/main.py
+++ b/tools/coverage-diff/main.py
@@ -94,8 +94,8 @@ if __name__ == '__main__':
 
     coverage_rate = ((satified_count) / (not_satified_count + satified_count) ) * 100
     print('='*20)
-    if coverage_rate < 50:
-        print(f'{ERROR_COLOR}Diff coverage rate is less than 50%: {coverage_rate:.1f}%{RESET_COLOR}', flush=True)
+    if coverage_rate < 60:
+        print(f'{ERROR_COLOR}Diff coverage rate is less than 60%: {coverage_rate:.1f}%{RESET_COLOR}', flush=True)
         print('='*20)
         sys.exit(1)
     else:


### PR DESCRIPTION
1. 修复商业版 PipelineUpdateUnittest
2. 目前整体覆盖率已经到达60%，提高单测准入门槛到 60%