### PR TITLE
fix ut: http mock server protects the result slice with lock

### DIFF
--- a/plugins/flusher/prometheus/flusher_prometheus_test.go
+++ b/plugins/flusher/prometheus/flusher_prometheus_test.go
@@ -112,6 +112,7 @@ func TestPrometheusFlusher_ShouldInitSuccess_GivenNecessaryConfig(t *testing.T) 
 // 2. “同一个 *models.PipelineGroupEvents”，从实际使用场景看，一般有 1至多组 tags，这里先考虑 仅1组tags 的情况
 func TestPrometheusFlusher_ShouldWriteToRemoteStorageSuccess_GivenCorrectDataWithV2Model_OnlyOneGroupOfTags(t *testing.T) {
 	Convey("Given correct data with []*models.PipelineGroupEvents type", t, func() {
+		var mu sync.Mutex
 		var actualWriteRequests []*prompb.WriteRequest
 		endpoint := "http://localhost:9090/write"
 		expectedUsername, expectedPassword := "user", "password"
@@ -143,6 +144,8 @@ func TestPrometheusFlusher_ShouldWriteToRemoteStorageSuccess_GivenCorrectDataWit
 				return httpmock.NewStringResponse(http.StatusBadRequest, "Invalid Write Request"), fmt.Errorf("parse prometheus write request error: %w", err)
 			}
 
+			mu.Lock()
+			defer mu.Unlock()
 			actualWriteRequests = append(actualWriteRequests, wr)
 
 			return httpmock.NewStringResponse(http.StatusOK, "ok"), nil
@@ -275,6 +278,7 @@ func TestPrometheusFlusher_ShouldWriteToRemoteStorageSuccess_GivenCorrectDataWit
 // 2. “同一个 *models.PipelineGroupEvents”，从实际使用场景看，一般有 1至多组 tags，这里考虑 多组tags 的情况
 func TestPrometheusFlusher_ShouldWriteToRemoteStorageSuccess_GivenCorrectDataWithV2Model_MultiGroupsOfTags(t *testing.T) {
 	Convey("Given correct data with []*models.PipelineGroupEvents type", t, func() {
+		var mu sync.Mutex
 		var actualWriteRequests []*prompb.WriteRequest
 		endpoint := "http://localhost:9090/write"
 		expectedUsername, expectedPassword := "user", "password"
@@ -304,6 +308,8 @@ func TestPrometheusFlusher_ShouldWriteToRemoteStorageSuccess_GivenCorrectDataWit
 				return httpmock.NewStringResponse(http.StatusBadRequest, "Invalid Write Request"), fmt.Errorf("parse prometheus write request error: %w", err)
 			}
 
+			mu.Lock()
+			defer mu.Unlock()
 			actualWriteRequests = append(actualWriteRequests, wr)
 
 			return httpmock.NewStringResponse(http.StatusOK, "ok"), nil
@@ -422,6 +428,7 @@ func TestPrometheusFlusher_ShouldWriteToRemoteStorageSuccess_GivenCorrectDataWit
 // 2. “同一个 *models.PipelineGroupEvents”，从实际使用场景看，一般有 1至多组 tags，这里考虑 多组tags 的情况
 func TestPrometheusFlusher_ShouldNotWriteToRemoteStorage_GivenIncorrectDataWithV2Model_MultiGroupsOfTags(t *testing.T) {
 	Convey("Given incorrect data with []*models.PipelineGroupEvents type", t, func() {
+		var mu sync.Mutex
 		var actualWriteRequests []*prompb.WriteRequest
 		endpoint := "http://localhost:9090/write"
 		expectedUsername, expectedPassword := "user", "password"
@@ -451,6 +458,8 @@ func TestPrometheusFlusher_ShouldNotWriteToRemoteStorage_GivenIncorrectDataWithV
 				return httpmock.NewStringResponse(http.StatusBadRequest, "Invalid Write Request"), fmt.Errorf("parse prometheus write request error: %w", err)
 			}
 
+			mu.Lock()
+			defer mu.Unlock()
 			actualWriteRequests = append(actualWriteRequests, wr)
 
 			return httpmock.NewStringResponse(http.StatusOK, "ok"), nil


### PR DESCRIPTION
flusher_prometheus 的单测有一个 http mock server 去采集数据，将数据填充到 slice时有并发问题，可能会导致漏统计一些数据，加一个锁保护。

本地go test -count 100，未发现问题。
<img width="917" alt="image" src="https://github.com/user-attachments/assets/3b97eeb1-baa9-4fca-a2f9-2a570884d86f" />