### PR TITLE
[backport 2.0] allowing for the forced release of stopped container files based on an environment variable(FORCE_RELEASE_STOP_CONTAINER_FILE)

### DIFF
--- a/plugins/input/docker/logmeta/metric_container_info.go
+++ b/plugins/input/docker/logmeta/metric_container_info.go
@@ -111,6 +111,8 @@ type InputDockerFile struct {
 	matchList                map[string]*helper.DockerInfoDetail
 	CollectingContainersMeta bool
 	firstStart               bool
+
+	forceReleaseStopContainerFile bool
 }
 
 func formatPath(path string) string {
@@ -132,6 +134,8 @@ func (idf *InputDockerFile) Name() string {
 
 func (idf *InputDockerFile) Init(context pipeline.Context) (int, error) {
 	idf.context = context
+
+	idf.forceReleaseStopContainerFile = os.Getenv("FORCE_RELEASE_STOP_CONTAINER_FILE") == "true"
 
 	idf.lastContainerInfoCache = make(map[string]ContainerInfoCache)
 
@@ -476,9 +480,14 @@ func (idf *InputDockerFile) Collect(collector pipeline.Collector) error {
 			idf.deleteMetric.Add(1)
 			idf.notifyStop(id)
 			idf.deleteMapping(id)
-		} else if c.Status() != helper.ContainerStatusRunning && len(idf.LogPath) > 0 {
-			// input_file时会触发
-			idf.notifyStop(id)
+		} else if c.Status() != helper.ContainerStatusRunning && len(idf.LogPath) > 0 { // input_file时会触发
+			if idf.forceReleaseStopContainerFile {
+				idf.deleteMetric.Add(1)
+				idf.notifyStop(id)
+				idf.deleteMapping(id)
+			} else {
+				idf.notifyStop(id)
+			}
 		}
 	}
 	if allCmd != nil {


### PR DESCRIPTION
This pull request introduces changes to the `InputDockerFile` struct and related methods in the `plugins/input/docker/logmeta/metric_container_info.go` file to support a new feature for forcefully releasing stopped container files based on an environment variable.

Key changes include:

* **Struct Modification:**
  * Added a new boolean field `forceReleaseStopContainerFile` to the `InputDockerFile` struct to track the environment variable status.

* **Initialization:**
  * Modified the `Init` method to set the `forceReleaseStopContainerFile` field based on the `FORCE_RELEASE_STOP_CONTAINER_FILE` environment variable.

* **Collect Method:**
  * Updated the `Collect` method to conditionally delete metrics and mappings of stopped containers based on the `forceReleaseStopContainerFile` flag.