### PR TITLE
handle multiple consecutive slashes in the path string.

### DIFF
--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -17,7 +17,7 @@ package helper
 import (
 	"context"
 	"hash/fnv"
-	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -331,7 +331,7 @@ func isPathSeparator(c byte) bool {
 }
 
 func (did *DockerInfoDetail) FindBestMatchedPath(pth string) (sourcePath, containerPath string) {
-	pth = path.Clean(pth)
+	pth = filepath.Clean(pth)
 	pthSize := len(pth)
 
 	// logger.Debugf(context.Background(), "FindBestMatchedPath for container %s, target path: %s, containerInfo: %+v", did.IDPrefix(), pth, did.ContainerInfo)
@@ -341,7 +341,7 @@ func (did *DockerInfoDetail) FindBestMatchedPath(pth string) (sourcePath, contai
 	for _, mount := range did.ContainerInfo.Mounts {
 		// logger.Debugf("container(%s-%s) mount: source-%s destination-%s", did.IDPrefix(), did.ContainerInfo.Name, mount.Source, mount.Destination)
 
-		dst := path.Clean(mount.Destination)
+		dst := filepath.Clean(mount.Destination)
 		dstSize := len(dst)
 
 		if strings.HasPrefix(pth, dst) &&
@@ -627,6 +627,10 @@ func (dc *DockerCenter) CreateInfoDetail(info types.ContainerJSON, envConfigPref
 		K8SInfo:          &k8sInfo,
 		ContainerIP:      ip,
 		lastUpdateTime:   time.Now(),
+	}
+	for _, mount := range info.Mounts {
+		mount.Source = filepath.Clean(mount.Source)
+		mount.Destination = filepath.Clean(mount.Destination)
 	}
 
 	// Find Env Log Configs

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -619,7 +619,10 @@ func (dc *DockerCenter) CreateInfoDetail(info types.ContainerJSON, envConfigPref
 	if len(ip) > 0 {
 		containerNameTag["_container_ip_"] = ip
 	}
-
+	for i := range info.Mounts {
+		info.Mounts[i].Source = filepath.Clean(info.Mounts[i].Source)
+		info.Mounts[i].Destination = filepath.Clean(info.Mounts[i].Destination)
+	}
 	did := &DockerInfoDetail{
 		StdoutPath:       info.LogPath,
 		ContainerInfo:    info,
@@ -627,10 +630,6 @@ func (dc *DockerCenter) CreateInfoDetail(info types.ContainerJSON, envConfigPref
 		K8SInfo:          &k8sInfo,
 		ContainerIP:      ip,
 		lastUpdateTime:   time.Now(),
-	}
-	for i := range info.Mounts {
-		info.Mounts[i].Source = filepath.Clean(info.Mounts[i].Source)
-		info.Mounts[i].Destination = filepath.Clean(info.Mounts[i].Destination)
 	}
 
 	// Find Env Log Configs

--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -628,9 +628,9 @@ func (dc *DockerCenter) CreateInfoDetail(info types.ContainerJSON, envConfigPref
 		ContainerIP:      ip,
 		lastUpdateTime:   time.Now(),
 	}
-	for _, mount := range info.Mounts {
-		mount.Source = filepath.Clean(mount.Source)
-		mount.Destination = filepath.Clean(mount.Destination)
+	for i := range info.Mounts {
+		info.Mounts[i].Source = filepath.Clean(info.Mounts[i].Source)
+		info.Mounts[i].Destination = filepath.Clean(info.Mounts[i].Destination)
 	}
 
 	// Find Env Log Configs

--- a/pkg/helper/docker_center_file_discover.go
+++ b/pkg/helper/docker_center_file_discover.go
@@ -138,8 +138,8 @@ func staticContainerInfoToStandard(staticInfo *staticContainerInfo, stat fs.File
 
 	for _, mount := range staticInfo.Mounts {
 		dockerContainer.Mounts = append(dockerContainer.Mounts, types.MountPoint{
-			Source:      mount.Source,
-			Destination: mount.Destination,
+			Source:      filepath.Clean(mount.Source),
+			Destination: filepath.Clean(mount.Destination),
 			Driver:      mount.Driver,
 		})
 	}

--- a/pkg/helper/docker_cri_adapter.go
+++ b/pkg/helper/docker_cri_adapter.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -290,8 +291,8 @@ func (cw *CRIRuntimeWrapper) createContainerInfo(containerID string) (detail *Do
 				hostnamePath = mount.Source
 			}
 			dockerContainer.Mounts = append(dockerContainer.Mounts, types.MountPoint{
-				Source:      mount.Source,
-				Destination: mount.Destination,
+				Source:      filepath.Clean(mount.Source),
+				Destination: filepath.Clean(mount.Destination),
 				Driver:      mount.Type,
 			})
 		}

--- a/plugins/input/docker/logmeta/metric_container_info.go
+++ b/plugins/input/docker/logmeta/metric_container_info.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"sort"
@@ -117,10 +118,7 @@ func formatPath(path string) string {
 	if len(path) == 0 {
 		return path
 	}
-	// 处理开头的多个/
-	if strings.HasPrefix(path, "/") {
-		path = "/" + strings.TrimLeft(path, "/")
-	}
+	path = filepath.Clean(path)
 	if path[len(path)-1] == '/' {
 		return path[0 : len(path)-1]
 	}

--- a/plugins/input/docker/logmeta/metric_container_info.go
+++ b/plugins/input/docker/logmeta/metric_container_info.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -213,8 +212,8 @@ func (idf *InputDockerFile) Description() string {
 func (idf *InputDockerFile) addMappingToLogtail(info *helper.DockerInfoDetail, containerInfo ContainerInfoCache, allCmd *DockerFileUpdateCmdAll) {
 	var cmd DockerFileUpdateCmd
 	cmd.ID = info.ContainerInfo.ID
-	cmd.UpperDir = path.Clean(containerInfo.UpperDir)
-	cmd.LogPath = path.Clean(containerInfo.LogPath)
+	cmd.UpperDir = filepath.Clean(containerInfo.UpperDir)
+	cmd.LogPath = filepath.Clean(containerInfo.LogPath)
 	// tags
 	tags := info.GetExternalTags(idf.ExternalEnvTag, idf.ExternalK8sLabelTag)
 	cmd.Tags = make([]string, 0, len(tags)*2)
@@ -231,8 +230,8 @@ func (idf *InputDockerFile) addMappingToLogtail(info *helper.DockerInfoDetail, c
 	cmd.Mounts = make([]Mount, 0, len(containerInfo.Mounts))
 	for _, mount := range containerInfo.Mounts {
 		cmd.Mounts = append(cmd.Mounts, Mount{
-			Source:      path.Clean(mount.Source),
-			Destination: path.Clean(mount.Destination),
+			Source:      filepath.Clean(mount.Source),
+			Destination: filepath.Clean(mount.Destination),
 		})
 	}
 	cmdBuf, _ := json.Marshal(&cmd)
@@ -282,7 +281,7 @@ func (idf *InputDockerFile) updateAll(allCmd *DockerFileUpdateCmdAll) {
 }
 
 func (idf *InputDockerFile) updateMapping(info *helper.DockerInfoDetail, allCmd *DockerFileUpdateCmdAll) {
-	logPath := path.Clean(info.StdoutPath)
+	logPath := filepath.Clean(info.StdoutPath)
 	id := info.ContainerInfo.ID
 	mounts := info.ContainerInfo.Mounts
 	upperDir := info.DefaultRootPath

--- a/plugins/input/docker/logmeta/metric_container_info.go
+++ b/plugins/input/docker/logmeta/metric_container_info.go
@@ -117,6 +117,10 @@ func formatPath(path string) string {
 	if len(path) == 0 {
 		return path
 	}
+	// 处理开头的多个/
+	if strings.HasPrefix(path, "/") {
+		path = "/" + strings.TrimLeft(path, "/")
+	}
 	if path[len(path)-1] == '/' {
 		return path[0 : len(path)-1]
 	}

--- a/plugins/input/docker/logmeta/metric_container_info_test.go
+++ b/plugins/input/docker/logmeta/metric_container_info_test.go
@@ -124,3 +124,56 @@ func TestServiceDockerStdout_Init(t *testing.T) {
 
 	assert.NoError(t, err)
 }
+
+func TestFormatPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty path",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "normal path without trailing slash",
+			input: "/path/to/somewhere",
+			want:  "/path/to/somewhere",
+		},
+		{
+			name:  "path with trailing forward slash",
+			input: "/path/to/somewhere/",
+			want:  "/path/to/somewhere",
+		},
+		{
+			name:  "path with trailing backslash",
+			input: "/path/to/somewhere\\",
+			want:  "/path/to/somewhere",
+		},
+		{
+			name:  "path with dots",
+			input: "/path/./to/../somewhere",
+			want:  "/path/somewhere",
+		},
+		{
+			name:  "path with multiple slashes",
+			input: "/path//to///somewhere",
+			want:  "/path/to/somewhere",
+		},
+		{
+			name:  "path with multiple slashes",
+			input: "/////path//////to///somewhere",
+			want:  "/path/to/somewhere",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatPath(tt.input)
+			if got != tt.want {
+				t.Errorf("formatPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/input/journal/unit.go
+++ b/plugins/input/journal/unit.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -172,12 +173,12 @@ func unitNameMangle(name, suffix string) (string, error) {
 
 	if isDevicePath(name) {
 		// chop off path and put .device on the end
-		return path.Base(path.Clean(name)) + "device", nil
+		return path.Base(filepath.Clean(name)) + "device", nil
 	}
 
 	if pathIsAbsolute(name) {
 		// chop path and put .mount on the end
-		return path.Base(path.Clean(name)) + ".mount", nil
+		return path.Base(filepath.Clean(name)) + ".mount", nil
 	}
 
 	name = doEscapeMangle(name)


### PR DESCRIPTION
**问题描述:**
当用户在 Kubernetes 配置中使用以多个斜杠开头的挂载路径时(如 `//test/log`),会导致 formateContainerPath 获取到的挂载路径与采集配置中的 idf.LogPath 路径(`/test/log`)不匹配,从而引发数组越界问题。

![image](https://github.com/user-attachments/assets/20bc423e-ba00-414c-af36-caba953cc1e7)


例如以下挂载配置:
```yaml
volumeMounts:
- mountPath: //test/log/
  name: volume-123123 
  subPath: test
```
采集路径为`/test/log/**/*.log`

**修复方案:**
优化 formatPath 函数,确保当路径以斜杠开头时,只保留一个斜杠,使路径格式符合标准规范。
