### PR TITLE
feat: enhance encoder interface

### DIFF
--- a/pkg/pipeline/extensions/encoder.go
+++ b/pkg/pipeline/extensions/encoder.go
@@ -47,6 +47,11 @@ type EncoderV2 interface {
 	EncodeBatchV2([]*models.PipelineGroupEvents, []string) ([][]byte, []map[string]string, error)
 }
 
+// Recycler recyles the buffer
+type BufferRecycler interface {
+	Recycle([]byte)
+}
+
 type EncoderExtension interface {
 	Encoder
 	pipeline.Extension

--- a/pkg/pipeline/extensions/encoder.go
+++ b/pkg/pipeline/extensions/encoder.go
@@ -34,8 +34,8 @@ type Encoder interface {
 //
 // drivers: sls, influxdb, ...
 type EncoderV1 interface {
-	EncodeV1(*protocol.LogGroup) ([][]byte, error)
-	EncodeBatchV1([]*protocol.LogGroup) ([][]byte, error)
+	EncodeV1(*protocol.LogGroup, []string) ([][]byte, []map[string]string, error)
+	EncodeBatchV1([]*protocol.LogGroup, []string) ([][]byte, []map[string]string, error)
 }
 
 // EncoderV2 supports v2 pipeline plugin interface,
@@ -43,8 +43,8 @@ type EncoderV1 interface {
 //
 // drivers: raw, influxdb, prometheus, ...
 type EncoderV2 interface {
-	EncodeV2(*models.PipelineGroupEvents) ([][]byte, error)
-	EncodeBatchV2([]*models.PipelineGroupEvents) ([][]byte, error)
+	EncodeV2(*models.PipelineGroupEvents, []string) ([][]byte, []map[string]string, error)
+	EncodeBatchV2([]*models.PipelineGroupEvents, []string) ([][]byte, []map[string]string, error)
 }
 
 type EncoderExtension interface {

--- a/pkg/protocol/encoder/prometheus/encoder_prometheus.go
+++ b/pkg/protocol/encoder/prometheus/encoder_prometheus.go
@@ -128,3 +128,7 @@ func (p *Encoder) EncodeBatchV2(groupEventsSlice []*models.PipelineGroupEvents, 
 
 	return res, varValues, nil
 }
+
+// Recycle implements Extension.BufferRecycler
+// But Prometheus Encoder doesn't actually recycle the buffer since its Encode implementation cannot reuse the buffer now.
+func (p *Encoder) Recycle(buf []byte) {}

--- a/plugins/flusher/http/flusher_http.go
+++ b/plugins/flusher/http/flusher_http.go
@@ -479,6 +479,14 @@ func (f *FlusherHTTP) flushWithRetry(data []byte, varValues map[string]string) e
 		err = e
 		<-time.After(f.getNextRetryDelay(i))
 	}
+
+	if f.encoder != nil {
+		if recycler, ok := f.encoder.(extensions.BufferRecycler); ok {
+			recycler.Recycle(data)
+			return err
+		}
+	}
+
 	converter.PutPooledByteBuf(&data)
 	return err
 }


### PR DESCRIPTION
Enhance encoder api to support variable keys, i.e. %{metadata.xxx}, ${tag.xxx}, and ${content.xxxx}, just like the converter struct.
<img width="985" alt="image" src="https://github.com/user-attachments/assets/7c746826-e69e-4647-928f-56b3afcfd21c" />

converter:
<img width="980" alt="image" src="https://github.com/user-attachments/assets/bcb06865-7389-44da-9d77-4c3a1807694e" />


```
enable: true
global: 
   StrucureType:"v2"
inputs:
  - Type: service_http_server
    Format: influxdb
    Address: "http://127.0.0.1:12345"
    QueryParams:
      - db
aggregators:
  - Type: aggregator_metadata_group
    GroupMetadataKeys:
      - db
flushers:
  - Type: flusher_http
    RemoteURL: "http://127.0.0.1:8086/write"
    Query:
      db: "%{metadata.db}"
    Encoder:
      Type: ext_default_encoder/prometheus
```