### PR TITLE
chore: move self monitor to init func

### DIFF
--- a/core/prometheus/PrometheusInputRunner.h
+++ b/core/prometheus/PrometheusInputRunner.h
@@ -83,6 +83,7 @@ private:
     std::atomic<uint64_t> mUnRegisterMs;
 
     // self monitor
+    bool mStartSelfMonitor = false;
     ReadWriteLock mProjectRWLock;
     std::map<std::string, std::string> mJobNameToProjectNameMap;
     MetricsRecordRef mMetricsRecordRef;


### PR DESCRIPTION
单例模式下，由于自监控的部分代码在构造函数中注册了，即便是不启动 Prom 的功能，仍旧会发 Prom 相关的自监控指标 