### PR TITLE
test: support custom log rotate interval

### DIFF
--- a/test/config/context.go
+++ b/test/config/context.go
@@ -24,4 +24,5 @@ const (
 	QueryKey                    ContextKey = "query"
 	AgentPIDKey                 ContextKey = "agentPID"
 	EndpointIPKey               ContextKey = "endpointIP"
+	RotateIntervalKey           ContextKey = "rotateInterval"
 )

--- a/test/engine/steps.go
+++ b/test/engine/steps.go
@@ -72,6 +72,7 @@ func ScenarioInitializer(ctx *godog.ScenarioContext) {
 	ctx.When(`^generate random nginx logs to file, speed \{(\d+)\}MB/s, total \{(\d+)\}min, to file \{(.*)\}`, log.Nginx)
 	ctx.When(`^start monitor \{(\S+)\}`, monitor.StartMonitor)
 	ctx.When(`^wait monitor until log processing finished$`, monitor.WaitMonitorUntilProcessingFinished)
+	ctx.When(`^change log rotate interval to \{(\d+)\}s$`, log.ChangeRotateInterval)
 
 	// ebpf
 	ctx.When(`^execute \{(\d+)\} commands to generate process security events`, ebpf.ProcessSecurityEvents)

--- a/test/engine/trigger/log/remote_file.py
+++ b/test/engine/trigger/log/remote_file.py
@@ -130,13 +130,14 @@ def main():
     parser.add_argument('--count', type=int, default=100, help='Log Count')
     parser.add_argument('--interval', type=int, default=1, help='Log Interval (ms), < 0 means no interval')
     parser.add_argument('--custom', type=parse_custom_arg_to_dict, help='Custom Args, in the format of json')
+    parser.add_argument('--rotate', type=int, default=30, help='Rotate Interval (s)')
 
     args = parser.parse_args()
 
     logger = logging.getLogger('log_generator')
     logger.setLevel(logging.INFO)
     # 快速轮转来模拟比较极端的情况
-    handler = TimedRotatingFileHandler(args.path, when="s", interval=5, backupCount=3)
+    handler = TimedRotatingFileHandler(args.path, when="s", interval=args.rotate, backupCount=3)
     formatter = logging.Formatter('%(message)s')
     handler.setFormatter(formatter)
     handler.flush = lambda: handler.stream.flush()


### PR DESCRIPTION
之前默认5秒轮转导致一些复杂的测试用例不够稳定，新增支持每个测试用例自定义日志轮转的时间间隔。