### PR TITLE
Fix LogtailMonitor's deadlock when suicide

### DIFF
--- a/core/monitor/Monitor.cpp
+++ b/core/monitor/Monitor.cpp
@@ -94,6 +94,7 @@ LogtailMonitor* LogtailMonitor::GetInstance() {
 bool LogtailMonitor::Init() {
     mScaledCpuUsageUpLimit = AppConfig::GetInstance()->GetCpuUsageUpLimit();
     mStatusCount = 0;
+    mShouldSuicide.store(false);
 
     // Reset process and realtime CPU statistics.
     mCpuStat.Reset();

--- a/core/monitor/Monitor.cpp
+++ b/core/monitor/Monitor.cpp
@@ -182,7 +182,6 @@ void LogtailMonitor::Monitor() {
                     LOG_ERROR(sLogger,
                               ("Resource used by program exceeds hard limit",
                                "prepare restart Logtail")("mem_rss", mMemStat.mRss));
-                    mIsThreadRunning = false;
                     mShouldSuicide.store(true);
                     break;
                 }
@@ -209,13 +208,11 @@ void LogtailMonitor::Monitor() {
                     LOG_ERROR(sLogger,
                               ("Resource used by program exceeds upper limit for some time",
                                "prepare restart Logtail")("cpu_usage", mCpuStat.mCpuUsage)("mem_rss", mMemStat.mRss));
-                    mIsThreadRunning = false;
                     mShouldSuicide.store(true);
                     break;
                 }
 
                 if (IsHostIpChanged()) {
-                    mIsThreadRunning = false;
                     mShouldSuicide.store(true);
                     break;
                 }

--- a/core/monitor/Monitor.cpp
+++ b/core/monitor/Monitor.cpp
@@ -181,7 +181,7 @@ void LogtailMonitor::Monitor() {
                     LOG_ERROR(sLogger,
                               ("Resource used by program exceeds hard limit",
                                "prepare restart Logtail")("mem_rss", mMemStat.mRss));
-                    Suicide();
+                    break;
                 }
             }
 
@@ -206,11 +206,11 @@ void LogtailMonitor::Monitor() {
                     LOG_ERROR(sLogger,
                               ("Resource used by program exceeds upper limit for some time",
                                "prepare restart Logtail")("cpu_usage", mCpuStat.mCpuUsage)("mem_rss", mMemStat.mRss));
-                    Suicide();
+                    break;
                 }
 
-                if (IsHostIpChanged()) {
-                    Suicide();
+                if (IsHostIpChanged()) { 
+                    break;
                 }
 
                 SendStatusProfile(false);
@@ -221,7 +221,7 @@ void LogtailMonitor::Monitor() {
             }
         }
     }
-    SendStatusProfile(true);
+    Suicide();
 }
 
 bool LogtailMonitor::SendStatusProfile(bool suicide) {

--- a/core/monitor/Monitor.h
+++ b/core/monitor/Monitor.h
@@ -148,7 +148,7 @@ private:
     std::future<void> mThreadRes;
     std::mutex mThreadRunningMux;
     bool mIsThreadRunning = true;
-    std::atomic_bool mShouldSuicide = false;
+    std::atomic_bool mShouldSuicide;
     std::condition_variable mStopCV;
 
     // Control report status profile frequency.

--- a/core/monitor/Monitor.h
+++ b/core/monitor/Monitor.h
@@ -148,6 +148,7 @@ private:
     std::future<void> mThreadRes;
     std::mutex mThreadRunningMux;
     bool mIsThreadRunning = true;
+    std::atomic_bool mShouldSuicide = false;
     std::condition_variable mStopCV;
 
     // Control report status profile frequency.


### PR DESCRIPTION
资源超限时候，LogtailMonitor有个死锁，会导致进程一分钟强制退出。
![image](https://github.com/user-attachments/assets/b88a82e8-76d8-4814-872e-39d1ae422c78)
suicide发出stop信号后，主线程会逐一进行stop，但这个monitor的stop中又去尝试获取同一把锁
![image](https://github.com/user-attachments/assets/9292b488-30b3-4247-adf1-e55ba4a3f3d3)
导致stop死锁，无法正常退出。
需要确保发出stop信号时，这个锁已经释放，才能正常执行stop操作。

