### PR TITLE
ParseContainerLogLine when no new line

### DIFF
--- a/plugins/input/docker/stdout/docker_stdout_processor.go
+++ b/plugins/input/docker/stdout/docker_stdout_processor.go
@@ -272,9 +272,12 @@ func (p *DockerStdoutProcessor) Process(fileBlock []byte, noChangeInterval time.
 
 	// no new line
 	if nowIndex == 0 && len(fileBlock) > 0 {
-		l := &LogMessage{Time: "_time_", StreamType: "_source_", Content: fileBlock}
-		p.collector.AddRawLogWithContext(p.newRawLogBySingleLine(l), map[string]interface{}{"source": p.source})
-		processedCount = len(fileBlock)
+		thisLog := p.ParseContainerLogLine(fileBlock)
+		if p.StreamAllowed(thisLog) {
+			l := &LogMessage{Time: "_time_", StreamType: "_source_", Content: fileBlock}
+			p.collector.AddRawLogWithContext(p.newRawLogBySingleLine(l), map[string]interface{}{"source": p.source})
+			processedCount = len(fileBlock)
+		}
 	}
 	return processedCount
 }

--- a/plugins/input/docker/stdout/docker_stdout_processor.go
+++ b/plugins/input/docker/stdout/docker_stdout_processor.go
@@ -274,8 +274,7 @@ func (p *DockerStdoutProcessor) Process(fileBlock []byte, noChangeInterval time.
 	if nowIndex == 0 && len(fileBlock) > 0 {
 		thisLog := p.ParseContainerLogLine(fileBlock)
 		if p.StreamAllowed(thisLog) {
-			l := &LogMessage{Time: "_time_", StreamType: "_source_", Content: fileBlock}
-			p.collector.AddRawLogWithContext(p.newRawLogBySingleLine(l), map[string]interface{}{"source": p.source})
+			p.collector.AddRawLogWithContext(p.newRawLogBySingleLine(thisLog), map[string]interface{}{"source": p.source})
 			processedCount = len(fileBlock)
 		}
 	}

--- a/plugins/input/docker/stdout/docker_stdout_processor_test.go
+++ b/plugins/input/docker/stdout/docker_stdout_processor_test.go
@@ -203,21 +203,40 @@ func (s *inputProcessorTestSuite) TestNormal(c *check.C) {
 }
 
 func (s *inputProcessorTestSuite) TestStreamAllowed(c *check.C) {
-	splitedlogNoNewLine := `{"log":"123456","stream":"stdout", "time":"2018-05-16T06:28:41.2195434Z"}`
+	stdoutAllowed := true
+	stderrAllowed := false
+	// stdout
+	{
+		s.collector.Logs = s.collector.Logs[:0]
+		s.context.InitContext("project", "logstore", "config")
 
-	processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, true, true, &s.context, &s.collector, s.tag, s.source)
-	splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
-	processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
+		splitedlogNoNewLine := `{"log":"123456","stream":"stdout", "time":"2018-05-16T06:28:41.2195434Z"}`
+		processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
+		splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
+		processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
 
-	c.Assert(len(s.collector.Logs), check.Equals, 1)
+		c.Assert(len(s.collector.Logs), check.Equals, 1)
 
-	c.Assert(s.collector.Logs[0].Contents[0].GetKey(), check.Equals, "content")
-	c.Assert(s.collector.Logs[0].Contents[1].GetKey(), check.Equals, "_time_")
-	c.Assert(s.collector.Logs[0].Contents[2].GetKey(), check.Equals, "_source_")
+		c.Assert(s.collector.Logs[0].Contents[0].GetKey(), check.Equals, "content")
+		c.Assert(s.collector.Logs[0].Contents[1].GetKey(), check.Equals, "_time_")
+		c.Assert(s.collector.Logs[0].Contents[2].GetKey(), check.Equals, "_source_")
 
-	c.Assert(s.collector.Logs[0].Contents[0].GetValue(), check.Equals, "123456")
-	c.Assert(s.collector.Logs[0].Contents[1].GetValue(), check.Equals, "2018-05-16T06:28:41.2195434Z")
-	c.Assert(s.collector.Logs[0].Contents[2].GetValue(), check.Equals, "stdout")
+		c.Assert(s.collector.Logs[0].Contents[0].GetValue(), check.Equals, "123456")
+		c.Assert(s.collector.Logs[0].Contents[1].GetValue(), check.Equals, "2018-05-16T06:28:41.2195434Z")
+		c.Assert(s.collector.Logs[0].Contents[2].GetValue(), check.Equals, "stdout")
+	}
+	// stderr
+	{
+		s.collector.Logs = s.collector.Logs[:0]
+		s.context.InitContext("project", "logstore", "config")
+
+		splitedlogNoNewLine := `{"log":"123456","stream":"stderr", "time":"2018-05-16T06:28:41.2195434Z"}`
+		processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
+		splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
+		processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
+		fmt.Println(s.collector.Logs)
+		c.Assert(len(s.collector.Logs), check.Equals, 0)
+	}
 }
 
 func (s *inputProcessorTestSuite) TestSplitedLine(c *check.C) {

--- a/plugins/input/docker/stdout/docker_stdout_processor_test.go
+++ b/plugins/input/docker/stdout/docker_stdout_processor_test.go
@@ -246,7 +246,7 @@ func (s *inputProcessorTestSuite) TestStreamAllowed(c *check.C) {
 			s.collector.Logs = s.collector.Logs[:0]
 			s.context.InitContext("project", "logstore", "config")
 
-			splitedlogNoNewLine := `2021-07-13T16:32:21.212861448Z stdout F 123456`
+			splitedlogNoNewLine := `2018-05-16T06:28:41.2195434Z stdout F 123456`
 			processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
 			splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
 			processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
@@ -266,7 +266,7 @@ func (s *inputProcessorTestSuite) TestStreamAllowed(c *check.C) {
 			s.collector.Logs = s.collector.Logs[:0]
 			s.context.InitContext("project", "logstore", "config")
 
-			splitedlogNoNewLine := `2021-07-13T16:32:21.212861448Z stderr F 123456`
+			splitedlogNoNewLine := `2018-05-16T06:28:41.2195434Z stderr F 123456`
 			processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
 			splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
 			processor.Process(splitedlogNoNewLineBytes, time.Duration(0))

--- a/plugins/input/docker/stdout/docker_stdout_processor_test.go
+++ b/plugins/input/docker/stdout/docker_stdout_processor_test.go
@@ -202,6 +202,42 @@ func (s *inputProcessorTestSuite) TestNormal(c *check.C) {
 	}
 }
 
+func (s *inputProcessorTestSuite) TestStreamAllowed(c *check.C) {
+	processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, true, true, &s.context, &s.collector, s.tag, s.source)
+	splitedlog1Bytes := []byte(splitedlog1)
+	str1 := util.ZeroCopyBytesToString(splitedlog1Bytes)
+	splited2og1Bytes := []byte(splitedlog2)
+	str2 := util.ZeroCopyBytesToString(splited2og1Bytes)
+	splited3og1Bytes := []byte(splitedlog3)
+	str3 := util.ZeroCopyBytesToString(splited3og1Bytes)
+
+	n1 := processor.Process(splitedlog1Bytes, time.Duration(0))
+	c.Assert(util.IsSafeString(str1, util.ZeroCopyBytesToString(processor.lastLogs[0].Content)), check.IsTrue)
+	c.Assert(n1, check.Equals, len(splitedlog1))
+
+	n2 := processor.Process(splited2og1Bytes, time.Duration(0))
+	c.Assert(util.IsSafeString(str2, util.ZeroCopyBytesToString(processor.lastLogs[1].Content)), check.IsTrue)
+	c.Assert(n2, check.Equals, len(splitedlog2))
+
+	n3 := processor.Process(splited3og1Bytes, time.Duration(0))
+	c.Assert(n3, check.Equals, len(splitedlog3))
+
+	c.Assert(len(s.collector.Logs), check.Equals, 1)
+	value := s.collector.Logs[0].Contents[0].GetValue()
+	c.Assert(len(value), check.Equals, 1+2+3)
+	c.Assert(value, check.Equals, "122333")
+	c.Assert(util.IsSafeString(str1, value), check.IsTrue)
+	c.Assert(util.IsSafeString(str2, value), check.IsTrue)
+	c.Assert(util.IsSafeString(str3, value), check.IsTrue)
+
+	nTimeout := processor.Process(splitedlog1Bytes, time.Minute)
+	c.Assert(nTimeout, check.Equals, len(splitedlog1))
+	c.Assert(len(s.collector.Logs), check.Equals, 2)
+	value = s.collector.Logs[1].Contents[0].GetValue()
+	c.Assert(value, check.Equals, "1")
+	c.Assert(util.IsSafeString(str1, value), check.IsTrue)
+}
+
 func (s *inputProcessorTestSuite) TestSplitedLine(c *check.C) {
 	processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, true, true, &s.context, &s.collector, s.tag, s.source)
 	splitedlog1Bytes := []byte(splitedlog1)

--- a/plugins/input/docker/stdout/docker_stdout_processor_test.go
+++ b/plugins/input/docker/stdout/docker_stdout_processor_test.go
@@ -205,37 +205,73 @@ func (s *inputProcessorTestSuite) TestNormal(c *check.C) {
 func (s *inputProcessorTestSuite) TestStreamAllowed(c *check.C) {
 	stdoutAllowed := true
 	stderrAllowed := false
-	// stdout
+	// docker
 	{
-		s.collector.Logs = s.collector.Logs[:0]
-		s.context.InitContext("project", "logstore", "config")
+		// stdout
+		{
+			s.collector.Logs = s.collector.Logs[:0]
+			s.context.InitContext("project", "logstore", "config")
 
-		splitedlogNoNewLine := `{"log":"123456","stream":"stdout", "time":"2018-05-16T06:28:41.2195434Z"}`
-		processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
-		splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
-		processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
+			splitedlogNoNewLine := `{"log":"123456","stream":"stdout", "time":"2018-05-16T06:28:41.2195434Z"}`
+			processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
+			splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
+			processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
 
-		c.Assert(len(s.collector.Logs), check.Equals, 1)
+			c.Assert(len(s.collector.Logs), check.Equals, 1)
 
-		c.Assert(s.collector.Logs[0].Contents[0].GetKey(), check.Equals, "content")
-		c.Assert(s.collector.Logs[0].Contents[1].GetKey(), check.Equals, "_time_")
-		c.Assert(s.collector.Logs[0].Contents[2].GetKey(), check.Equals, "_source_")
+			c.Assert(s.collector.Logs[0].Contents[0].GetKey(), check.Equals, "content")
+			c.Assert(s.collector.Logs[0].Contents[1].GetKey(), check.Equals, "_time_")
+			c.Assert(s.collector.Logs[0].Contents[2].GetKey(), check.Equals, "_source_")
 
-		c.Assert(s.collector.Logs[0].Contents[0].GetValue(), check.Equals, "123456")
-		c.Assert(s.collector.Logs[0].Contents[1].GetValue(), check.Equals, "2018-05-16T06:28:41.2195434Z")
-		c.Assert(s.collector.Logs[0].Contents[2].GetValue(), check.Equals, "stdout")
+			c.Assert(s.collector.Logs[0].Contents[0].GetValue(), check.Equals, "123456")
+			c.Assert(s.collector.Logs[0].Contents[1].GetValue(), check.Equals, "2018-05-16T06:28:41.2195434Z")
+			c.Assert(s.collector.Logs[0].Contents[2].GetValue(), check.Equals, "stdout")
+		}
+		// stderr
+		{
+			s.collector.Logs = s.collector.Logs[:0]
+			s.context.InitContext("project", "logstore", "config")
+
+			splitedlogNoNewLine := `{"log":"123456","stream":"stderr", "time":"2018-05-16T06:28:41.2195434Z"}`
+			processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
+			splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
+			processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
+			c.Assert(len(s.collector.Logs), check.Equals, 0)
+		}
 	}
-	// stderr
+	// containerd
 	{
-		s.collector.Logs = s.collector.Logs[:0]
-		s.context.InitContext("project", "logstore", "config")
+		// stdout
+		{
+			s.collector.Logs = s.collector.Logs[:0]
+			s.context.InitContext("project", "logstore", "config")
 
-		splitedlogNoNewLine := `{"log":"123456","stream":"stderr", "time":"2018-05-16T06:28:41.2195434Z"}`
-		processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
-		splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
-		processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
-		fmt.Println(s.collector.Logs)
-		c.Assert(len(s.collector.Logs), check.Equals, 0)
+			splitedlogNoNewLine := `2021-07-13T16:32:21.212861448Z stdout F full line`
+			processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
+			splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
+			processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
+
+			c.Assert(len(s.collector.Logs), check.Equals, 1)
+
+			c.Assert(s.collector.Logs[0].Contents[0].GetKey(), check.Equals, "content")
+			c.Assert(s.collector.Logs[0].Contents[1].GetKey(), check.Equals, "_time_")
+			c.Assert(s.collector.Logs[0].Contents[2].GetKey(), check.Equals, "_source_")
+
+			c.Assert(s.collector.Logs[0].Contents[0].GetValue(), check.Equals, "123456")
+			c.Assert(s.collector.Logs[0].Contents[1].GetValue(), check.Equals, "2018-05-16T06:28:41.2195434Z")
+			c.Assert(s.collector.Logs[0].Contents[2].GetValue(), check.Equals, "stdout")
+		}
+		// stderr
+		{
+			s.collector.Logs = s.collector.Logs[:0]
+			s.context.InitContext("project", "logstore", "config")
+
+			splitedlogNoNewLine := `2021-07-13T16:32:21.212861448Z stderr F full line`
+			processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
+			splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
+			processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
+			c.Assert(len(s.collector.Logs), check.Equals, 0)
+		}
 	}
 }
 

--- a/plugins/input/docker/stdout/docker_stdout_processor_test.go
+++ b/plugins/input/docker/stdout/docker_stdout_processor_test.go
@@ -246,7 +246,7 @@ func (s *inputProcessorTestSuite) TestStreamAllowed(c *check.C) {
 			s.collector.Logs = s.collector.Logs[:0]
 			s.context.InitContext("project", "logstore", "config")
 
-			splitedlogNoNewLine := `2021-07-13T16:32:21.212861448Z stdout F full line`
+			splitedlogNoNewLine := `2021-07-13T16:32:21.212861448Z stdout F 123456`
 			processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
 			splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
 			processor.Process(splitedlogNoNewLineBytes, time.Duration(0))
@@ -266,7 +266,7 @@ func (s *inputProcessorTestSuite) TestStreamAllowed(c *check.C) {
 			s.collector.Logs = s.collector.Logs[:0]
 			s.context.InitContext("project", "logstore", "config")
 
-			splitedlogNoNewLine := `2021-07-13T16:32:21.212861448Z stderr F full line`
+			splitedlogNoNewLine := `2021-07-13T16:32:21.212861448Z stderr F 123456`
 			processor := NewDockerStdoutProcessor(nil, time.Second, 0, 512*1024, stdoutAllowed, stderrAllowed, &s.context, &s.collector, s.tag, s.source)
 			splitedlogNoNewLineBytes := []byte(splitedlogNoNewLine)
 			processor.Process(splitedlogNoNewLineBytes, time.Duration(0))


### PR DESCRIPTION
This pull request introduces changes to the Docker stdout processor to enhance log processing and adds new test cases to verify the functionality. The most important changes include modifying the log processing logic to filter logs based on stream type and adding comprehensive tests for the new functionality.

### Enhancements to log processing:

* [`plugins/input/docker/stdout/docker_stdout_processor.go`](diffhunk://#diff-0892f73f0b37e73b5a4270b51cb70eb5549fa79c0981a8fdb697423ce3d22542L275-R280): Updated the `Process` method to use `ParseContainerLogLine` for parsing log lines and `StreamAllowed` for filtering logs based on their stream type before adding them to the collector.

### New test cases:

* [`plugins/input/docker/stdout/docker_stdout_processor_test.go`](diffhunk://#diff-27e2f18dd541229952d24ff41aaa5a31cc36a81a4350d3df880dfc8c370bd93bR205-R277): Added the `TestStreamAllowed` method to test the log processing for different stream types (`stdout` and `stderr`) for both Docker and containerd logs. This ensures that only allowed streams are processed and collected.