### PR TITLE
fix: C++ source tag

### DIFF
--- a/core/plugin/processor/inner/ProcessorTagNative.cpp
+++ b/core/plugin/processor/inner/ProcessorTagNative.cpp
@@ -95,19 +95,15 @@ bool ProcessorTagNative::Init(const Json::Value& config) {
 // should keep same with Go addAllConfigurableTags
 void ProcessorTagNative::Process(PipelineEventGroup& logGroup) {
     AddTag(logGroup, TagKey::HOST_NAME_TAG_KEY, LoongCollectorMonitor::GetInstance()->mHostname);
+#ifdef __ENTERPRISE__
     auto entity = InstanceIdentity::Instance()->GetEntity();
     if (entity != nullptr) {
         AddTag(logGroup, TagKey::HOST_ID_TAG_KEY, entity->GetHostID());
-#ifdef __ENTERPRISE__
         ECSMeta meta = entity->GetECSMeta();
         const string cloudProvider
             = meta.GetInstanceID().empty() ? DEFAULT_VALUE_DOMAIN_INFRA : DEFAULT_VALUE_DOMAIN_ACS;
-#else
-        const string cloudProvider = DEFAULT_VALUE_DOMAIN_INFRA;
-#endif
         AddTag(logGroup, TagKey::CLOUD_PROVIDER_TAG_KEY, cloudProvider);
     }
-#ifdef __ENTERPRISE__
     AddTag(logGroup, TagKey::AGENT_TAG_TAG_KEY, EnterpriseConfigProvider::GetInstance()->GetUserDefinedIdSet());
 #else
     AddTag(logGroup, TagKey::HOST_IP_TAG_KEY, LoongCollectorMonitor::GetInstance()->mIpAddr);
@@ -145,6 +141,7 @@ void ProcessorTagNative::Process(PipelineEventGroup& logGroup) {
     // When flushing through Go pipeline, it will skip serializer, add a new unexpected tag
     auto sb = logGroup.GetSourceBuffer()->CopyString(Application::GetInstance()->GetUUID());
     logGroup.SetTagNoCopy(LOG_RESERVED_KEY_MACHINE_UUID, StringView(sb.data, sb.size));
+    logGroup.SetTagNoCopy(LOG_RESERVED_KEY_SOURCE, LoongCollectorMonitor::mIpAddr);
 }
 
 bool ProcessorTagNative::IsSupportedEvent(const PipelineEventPtr& /*e*/) const {

--- a/core/unittest/processor/ProcessorTagNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorTagNativeUnittest.cpp
@@ -108,6 +108,8 @@ void ProcessorTagNativeUnittest::TestProcess() {
         APSARA_TEST_EQUAL_FATAL(LoongCollectorMonitor::GetInstance()->mIpAddr,
                                 eventGroup.GetTag(GetDefaultTagKeyString(TagKey::HOST_IP_TAG_KEY)));
 #endif
+        APSARA_TEST_TRUE_FATAL(eventGroup.HasTag(LOG_RESERVED_KEY_SOURCE));
+        APSARA_TEST_TRUE_FATAL(eventGroup.HasTag(LOG_RESERVED_KEY_MACHINE_UUID));
     }
     { // native branch default
         Json::Value config;
@@ -161,6 +163,8 @@ void ProcessorTagNativeUnittest::TestProcess() {
         APSARA_TEST_EQUAL_FATAL(LoongCollectorMonitor::GetInstance()->mIpAddr,
                                 eventGroup.GetTag(GetDefaultTagKeyString(TagKey::HOST_IP_TAG_KEY)));
 #endif
+        APSARA_TEST_TRUE_FATAL(eventGroup.HasTag(LOG_RESERVED_KEY_SOURCE));
+        APSARA_TEST_TRUE_FATAL(eventGroup.HasTag(LOG_RESERVED_KEY_MACHINE_UUID));
     }
     { // native branch rename
         Json::Value config;
@@ -217,6 +221,8 @@ void ProcessorTagNativeUnittest::TestProcess() {
         APSARA_TEST_TRUE_FATAL(eventGroup.HasTag("test_host_ip"));
         APSARA_TEST_EQUAL_FATAL(LoongCollectorMonitor::GetInstance()->mIpAddr, eventGroup.GetTag("test_host_ip"));
 #endif
+        APSARA_TEST_TRUE_FATAL(eventGroup.HasTag(LOG_RESERVED_KEY_SOURCE));
+        APSARA_TEST_TRUE_FATAL(eventGroup.HasTag(LOG_RESERVED_KEY_MACHINE_UUID));
     }
     { // native branch delete
         Json::Value config;
@@ -266,6 +272,8 @@ void ProcessorTagNativeUnittest::TestProcess() {
 #else
         APSARA_TEST_FALSE_FATAL(eventGroup.HasTag(GetDefaultTagKeyString(TagKey::HOST_IP_TAG_KEY)));
 #endif
+        APSARA_TEST_TRUE_FATAL(eventGroup.HasTag(LOG_RESERVED_KEY_SOURCE));
+        APSARA_TEST_TRUE_FATAL(eventGroup.HasTag(LOG_RESERVED_KEY_MACHINE_UUID));
     }
 }
 


### PR DESCRIPTION
开发Tag处理插件的时候，__source__是个特殊的tag，需要在处理插件临时设置一个tag，然后在序列化的时候填入到PB的source字段。处理插件中遗漏设置临时tag了。