### PR TITLE
revert: restore direct environment variable to flag mapping for better maintainability

### DIFF
--- a/core/app_config/AppConfig.cpp
+++ b/core/app_config/AppConfig.cpp
@@ -1508,39 +1508,9 @@ void AppConfig::ParseEnvToFlags() {
         }
     }
 #endif
-    std::unordered_set<std::string> sIgnoreFlagSet = {"buffer_file_path",
-                                                      "check_point_filename",
-                                                      "data_server_port",
-                                                      "host_path_blacklist",
-                                                      "process_thread_count",
-                                                      "send_request_concurrency",
-                                                      "check_point_dump_interval",
-                                                      "check_point_max_count",
-                                                      "enable_root_path_collection",
-                                                      "ilogtail_config",
-                                                      "ilogtail_discard_interval",
-                                                      "default_tail_limit_kb",
-                                                      "logreader_max_rotate_queue_size",
-                                                      "force_release_deleted_file_fd_timeout",
-                                                      "batch_send_interval",
-                                                      "ALIYUN_LOG_FILE_TAGS",
-                                                      "default_container_host_path",
-                                                      "default_max_inotify_watch_num",
-                                                      "enable_full_drain_mode",
-                                                      "ilogtail_discard_old_data",
-                                                      "timeout_interval",
-                                                      "enable_env_ref_in_config",
-                                                      "max_watch_dir_count",
-                                                      "polling_max_stat_count",
-                                                      "polling_max_stat_count_per_config",
-                                                      "polling_max_stat_count_per_dir"};
     for (const auto& iter : envMapping) {
         const std::string& value = iter.second;
         std::string key = iter.first;
-        // Skip if key is not in ignore set and doesn't start with prefix
-        if (sIgnoreFlagSet.find(key) == sIgnoreFlagSet.end() && !StartWith(key, LOONGCOLLECTOR_ENV_PREFIX)) {
-            continue;
-        }
         // Convert to lowercase if key has prefix
         if (StartWith(key, LOONGCOLLECTOR_ENV_PREFIX)) {
             key = ToLowerCaseString(key.substr(LOONGCOLLECTOR_ENV_PREFIX.size()));

--- a/core/unittest/app_config/AppConfigUnittest.cpp
+++ b/core/unittest/app_config/AppConfigUnittest.cpp
@@ -174,7 +174,6 @@ void AppConfigUnittest::TestRecurseParseJsonToFlags() {
 }
 
 void AppConfigUnittest::TestParseEnvToFlags() {
-    // 忽略列表中的环境变量，继续可以用小写且允许 LOONG_ 前缀的格式
     {
         SetEnv("host_path_blacklist", "test1");
         AppConfig::GetInstance()->ParseEnvToFlags();
@@ -185,12 +184,10 @@ void AppConfigUnittest::TestParseEnvToFlags() {
         AppConfig::GetInstance()->ParseEnvToFlags();
         APSARA_TEST_EQUAL(STRING_FLAG(host_path_blacklist), "test2");
     }
-    // 不忽略列表中的环境变量，需要为大写,LOONG_ 前缀
     {
         SetEnv("default_machine_cpu_usage_threshold", "1");
         AppConfig::GetInstance()->ParseEnvToFlags();
-        APSARA_TEST_NOT_EQUAL(DOUBLE_FLAG(default_machine_cpu_usage_threshold), 1);
-        APSARA_TEST_EQUAL(DOUBLE_FLAG(default_machine_cpu_usage_threshold), 0.4);
+        APSARA_TEST_EQUAL(DOUBLE_FLAG(default_machine_cpu_usage_threshold), 1);
         UnsetEnv("default_machine_cpu_usage_threshold");
 
         SetEnv("LOONG_DEFAULT_MACHINE_CPU_USAGE_THRESHOLD", "2");

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -249,12 +249,13 @@ func LoadEnvToFlags() {
 		if !found {
 			continue
 		}
-
-		if !strings.HasPrefix(name, LoongcollectorEnvPrefix) {
-			continue
+		var flagName string
+		if strings.HasPrefix(name, LoongcollectorEnvPrefix) {
+			flagName = strings.ToLower(strings.TrimPrefix(name, LoongcollectorEnvPrefix))
+		} else {
+			flagName = name
 		}
 
-		flagName := strings.ToLower(strings.TrimPrefix(name, LoongcollectorEnvPrefix))
 		f := flag.Lookup(flagName)
 		if f == nil {
 			continue


### PR DESCRIPTION
回退 #2037 中不保留gflag同名小写字母环境变量自动转flag的行为

原因：
1. 提升开源友好性：
   - 开源维护者可以直接使用原始flag名称作为环境变量
   - 无需强制使用 LOON_upperflagname 格式，便于开源共建

2. 简化配置管理：
   - 进程级配置参数和环境变量可以使用统一的命名规则
   - 减少维护两套命名规范的心智负担
   - 降低配置出错的可能性

变更内容：
- 移除了 AppConfig.cpp 中的环境变量白名单过滤
- 调整 flags.go 中的环境变量处理逻辑，支持直接使用flag名称作为环境变量