### PR TITLE
fix: handle error in kafka consumer loop to prevent premature return

### DIFF
--- a/plugins/input/kafka/input_kafka.go
+++ b/plugins/input/kafka/input_kafka.go
@@ -161,7 +161,6 @@ func (k *InputKafka) Init(context pipeline.Context) (int, error) {
 		for {
 			if err := k.consumerGroupClient.Consume(cancelCtx, k.Topics, k); err != nil {
 				logger.Error(k.context.GetRuntimeContext(), "INPUT_KAFKA_ALARM", "Error from kafka consumer", err)
-				return
 			}
 			// check if context was canceled, signaling that the consumer should stop
 			if cancelCtx.Err() != nil {


### PR DESCRIPTION
When there are short-term network jitters or brief service outages in the Kafka cluster, it causes the Logtail program to fail in consumption and exit the consumption process. As a result, even after Kafka resumes normal operation, Logtail cannot continue consuming messages, leading to constant message accumulation. The only solution is to restart Logtail to restore normal operations.

# Root Cause:

After reviewing portions of the code for the open-source ilogtail component, we discovered that the error handling logic in the Kafka consumption part of LoongCollector (input_kafka) does not meet the requirements of the Sarama client. Specifically, when the k.consumerGroupClient.Consume() call returns an error (e.g., due to network instability exhausting Sarama's internal retries), the current code simply exits the goroutine by returning. This approach lacks upper-layer fault tolerance and retry mechanisms. Our tests have confirmed this issue.

According to Sarama Issue [#2381](https://github.com/IBM/sarama/issues/2381) , when network jitters or short-term network unavailability occur, and multiple retries still fail, the current ConsumeGroupSession will exit and return an error. It requires the upper layer to handle the exception and implement recovery and retry operations.

I believe that in such logtail scenarios, LoongCollector should continuously retry until Kafka recovers, instead of exiting directly.
