### PR TITLE
fix: merge old pipeline data to new pipeline when flusher is unready

### DIFF
--- a/plugins/flusher/checker/flusher_checker.go
+++ b/plugins/flusher/checker/flusher_checker.go
@@ -29,10 +29,12 @@ type FlusherChecker struct {
 	context  pipeline.Context
 	LogGroup protocol.LogGroup
 	Lock     sync.RWMutex
+	Ready    bool
 }
 
 func (p *FlusherChecker) Init(context pipeline.Context) error {
 	p.context = context
+	p.Ready = true
 	return nil
 }
 
@@ -139,7 +141,7 @@ func (p *FlusherChecker) Flush(projectName string, logstoreName string, configNa
 
 // IsReady is ready to flush
 func (p *FlusherChecker) IsReady(projectName string, logstoreName string, logstoreKey int64) bool {
-	return true
+	return p.Ready
 }
 
 // Stop ...


### PR DESCRIPTION
## 问题
在flusher不ready的情况下，go流水线会将数据先暂存在flusheroutStore。当配置重新加载时，需要将旧流水线发送不出去的数据迁移到新流水线继续发送。