### PR TITLE
prevents potential deadlocks and improves thread safety.

### DIFF
--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -135,8 +135,6 @@ void CommonConfigProvider::Stop() {
 
 void CommonConfigProvider::LoadConfigFile() {
     error_code ec;
-    lock_guard<mutex> pipelineInfomaplock(mContinuousPipelineInfoMapMux);
-    lock_guard<mutex> lockPipeline(mContinuousPipelineMux);
     for (auto const& entry : filesystem::directory_iterator(mContinuousPipelineConfigDir, ec)) {
         Json::Value detail;
         if (LoadConfigDetailFromFile(entry, detail)) {
@@ -148,12 +146,13 @@ void CommonConfigProvider::LoadConfigFile() {
             }
             info.status = ConfigFeedbackStatus::APPLYING;
             info.detail = detail.toStyledString();
-            mContinuousPipelineConfigInfoMap[info.name] = info;
+            {
+                lock_guard<mutex> lockPipeline(mContinuousPipelineMux);
+                mContinuousPipelineConfigInfoMap[info.name] = info;
+            }
             ConfigFeedbackReceiver::GetInstance().RegisterContinuousPipelineConfig(info.name, this);
         }
     }
-    lock_guard<mutex> instanceInfomaplock(mInstanceInfoMapMux);
-    lock_guard<mutex> lockInstance(mInstanceMux);
     for (auto const& entry : filesystem::directory_iterator(mInstanceSourceDir, ec)) {
         Json::Value detail;
         if (LoadConfigDetailFromFile(entry, detail)) {
@@ -165,7 +164,10 @@ void CommonConfigProvider::LoadConfigFile() {
             }
             info.status = ConfigFeedbackStatus::APPLYING;
             info.detail = detail.toStyledString();
-            mInstanceConfigInfoMap[info.name] = info;
+            {
+                lock_guard<mutex> lockInstance(mInstanceMux);
+                mInstanceConfigInfoMap[info.name] = info;
+            }
             ConfigFeedbackReceiver::GetInstance().RegisterInstanceConfig(info.name, this);
         }
     }
@@ -283,19 +285,27 @@ configserver::proto::v2::HeartbeatRequest CommonConfigProvider::PrepareHeartbeat
     heartbeatReq.set_running_status("running");
     heartbeatReq.set_startup_time(mStartTime);
 
-    lock_guard<mutex> pipelineinfomaplock(mContinuousPipelineInfoMapMux);
-    for (const auto& configInfo : mContinuousPipelineConfigInfoMap) {
-        addConfigInfoToRequest(configInfo, heartbeatReq.add_continuous_pipeline_configs());
-    }
-    lock_guard<mutex> instanceinfomaplock(mInstanceInfoMapMux);
-    for (const auto& configInfo : mInstanceConfigInfoMap) {
-        addConfigInfoToRequest(configInfo, heartbeatReq.add_instance_configs());
+    {
+        lock_guard<mutex> pipelineinfomaplock(mContinuousPipelineMux);
+        for (const auto& configInfo : mContinuousPipelineConfigInfoMap) {
+            addConfigInfoToRequest(configInfo, heartbeatReq.add_continuous_pipeline_configs());
+        }
     }
 
-    lock_guard<mutex> onetimeinfomaplock(mOnetimePipelineInfoMapMux);
-    for (const auto& configInfo : mOnetimePipelineConfigInfoMap) {
-        addConfigInfoToRequest(configInfo, heartbeatReq.add_onetime_pipeline_configs());
+    {
+        lock_guard<mutex> instanceinfomaplock(mInstanceMux);
+        for (const auto& configInfo : mInstanceConfigInfoMap) {
+            addConfigInfoToRequest(configInfo, heartbeatReq.add_instance_configs());
+        }
     }
+
+    {
+        lock_guard<mutex> onetimeinfomaplock(mOnetimePipelineMux);
+        for (const auto& configInfo : mOnetimePipelineConfigInfoMap) {
+            addConfigInfoToRequest(configInfo, heartbeatReq.add_onetime_pipeline_configs());
+        }
+    }
+
     return heartbeatReq;
 }
 
@@ -411,26 +421,33 @@ void CommonConfigProvider::UpdateRemotePipelineConfig(
         return;
     }
 
-    lock_guard<mutex> lock(mContinuousPipelineMux);
-    lock_guard<mutex> infomaplock(mContinuousPipelineInfoMapMux);
     for (const auto& config : configs) {
         filesystem::path filePath = sourceDir / (config.name() + ".json");
         if (config.version() == -1) {
-            mContinuousPipelineConfigInfoMap.erase(config.name());
+            {
+                lock_guard<mutex> lock(mContinuousPipelineMux);
+                mContinuousPipelineConfigInfoMap.erase(config.name());
+            }
             filesystem::remove(filePath, ec);
             ConfigFeedbackReceiver::GetInstance().UnregisterContinuousPipelineConfig(config.name());
         } else {
             if (!DumpConfigFile(config, sourceDir)) {
-                mContinuousPipelineConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
-                                                                             .version = config.version(),
-                                                                             .status = ConfigFeedbackStatus::FAILED,
-                                                                             .detail = config.detail()};
+                {
+                    lock_guard<mutex> lock(mContinuousPipelineMux);
+                    mContinuousPipelineConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
+                                                                                 .version = config.version(),
+                                                                                 .status = ConfigFeedbackStatus::FAILED,
+                                                                                 .detail = config.detail()};
+                }
                 continue;
             }
-            mContinuousPipelineConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
-                                                                         .version = config.version(),
-                                                                         .status = ConfigFeedbackStatus::APPLYING,
-                                                                         .detail = config.detail()};
+            {
+                lock_guard<mutex> lock(mContinuousPipelineMux);
+                mContinuousPipelineConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
+                                                                             .version = config.version(),
+                                                                             .status = ConfigFeedbackStatus::APPLYING,
+                                                                             .detail = config.detail()};
+            }
             ConfigFeedbackReceiver::GetInstance().RegisterContinuousPipelineConfig(config.name(), this);
         }
     }
@@ -449,34 +466,34 @@ void CommonConfigProvider::UpdateRemoteInstanceConfig(
         return;
     }
 
-    lock_guard<mutex> lock(mInstanceMux);
-    lock_guard<mutex> infomaplock(mInstanceInfoMapMux);
     for (const auto& config : configs) {
         filesystem::path filePath = sourceDir / (config.name() + ".json");
         if (config.version() == -1) {
-            mInstanceConfigInfoMap.erase(config.name());
+            {
+                lock_guard<mutex> lock(mInstanceMux);
+                mInstanceConfigInfoMap.erase(config.name());
+            }
             filesystem::remove(filePath, ec);
             ConfigFeedbackReceiver::GetInstance().UnregisterInstanceConfig(config.name());
         } else {
-            filesystem::path filePath = sourceDir / (config.name() + ".json");
-            if (config.version() == -1) {
-                mInstanceConfigInfoMap.erase(config.name());
-                filesystem::remove(filePath, ec);
-                ConfigFeedbackReceiver::GetInstance().UnregisterInstanceConfig(config.name());
-            } else {
-                if (!DumpConfigFile(config, sourceDir)) {
+            if (!DumpConfigFile(config, sourceDir)) {
+                {
+                    lock_guard<mutex> lock(mInstanceMux);
                     mInstanceConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
                                                                        .version = config.version(),
                                                                        .status = ConfigFeedbackStatus::FAILED,
                                                                        .detail = config.detail()};
-                    continue;
                 }
+                continue;
+            }
+            {
+                lock_guard<mutex> lock(mInstanceMux);
                 mInstanceConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
                                                                    .version = config.version(),
                                                                    .status = ConfigFeedbackStatus::APPLYING,
                                                                    .detail = config.detail()};
-                ConfigFeedbackReceiver::GetInstance().RegisterInstanceConfig(config.name(), this);
             }
+            ConfigFeedbackReceiver::GetInstance().RegisterInstanceConfig(config.name(), this);
         }
     }
 }
@@ -537,7 +554,7 @@ bool CommonConfigProvider::FetchPipelineConfigFromServer(
 
 void CommonConfigProvider::FeedbackContinuousPipelineConfigStatus(const std::string& name,
                                                                   ConfigFeedbackStatus status) {
-    lock_guard<mutex> infomaplock(mContinuousPipelineInfoMapMux);
+    lock_guard<mutex> infomaplock(mContinuousPipelineMux);
     auto info = mContinuousPipelineConfigInfoMap.find(name);
     if (info != mContinuousPipelineConfigInfoMap.end()) {
         info->second.status = status;
@@ -547,7 +564,7 @@ void CommonConfigProvider::FeedbackContinuousPipelineConfigStatus(const std::str
                                                                                                ToStringView(status)));
 }
 void CommonConfigProvider::FeedbackInstanceConfigStatus(const std::string& name, ConfigFeedbackStatus status) {
-    lock_guard<mutex> infomaplock(mInstanceInfoMapMux);
+    lock_guard<mutex> infomaplock(mInstanceMux);
     auto info = mInstanceConfigInfoMap.find(name);
     if (info != mInstanceConfigInfoMap.end()) {
         info->second.status = status;
@@ -558,7 +575,7 @@ void CommonConfigProvider::FeedbackInstanceConfigStatus(const std::string& name,
 void CommonConfigProvider::FeedbackOnetimePipelineConfigStatus(const std::string& type,
                                                                const std::string& name,
                                                                ConfigFeedbackStatus status) {
-    lock_guard<mutex> infomaplock(mOnetimePipelineInfoMapMux);
+    lock_guard<mutex> infomaplock(mOnetimePipelineMux);
     auto info = mOnetimePipelineConfigInfoMap.find(GenerateOnetimePipelineConfigFeedBackKey(type, name));
     if (info != mOnetimePipelineConfigInfoMap.end()) {
         info->second.status = status;

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -420,6 +420,7 @@ void CommonConfigProvider::UpdateRemotePipelineConfig(
                       "dir", sourceDir.string())("error code", ec.value())("error msg", ec.message()));
         return;
     }
+    // 保证每次往磁盘上dump文件的时候，config watcher不会读到一半的内容，相当于是个目录锁
     lock_guard<mutex> lock(mContinuousPipelineMux);
     for (const auto& config : configs) {
         filesystem::path filePath = sourceDir / (config.name() + ".json");
@@ -465,6 +466,7 @@ void CommonConfigProvider::UpdateRemoteInstanceConfig(
                       "dir", sourceDir.string())("error code", ec.value())("error msg", ec.message()));
         return;
     }
+    // 保证每次往磁盘上dump文件的时候，config watcher不会读到一半的内容，相当于是个目录锁
     lock_guard<mutex> lock(mInstanceMux);
     for (const auto& config : configs) {
         filesystem::path filePath = sourceDir / (config.name() + ".json");

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -290,17 +290,11 @@ configserver::proto::v2::HeartbeatRequest CommonConfigProvider::PrepareHeartbeat
         for (const auto& configInfo : mContinuousPipelineConfigInfoMap) {
             addConfigInfoToRequest(configInfo, heartbeatReq.add_continuous_pipeline_configs());
         }
-    }
 
-    {
-        lock_guard<mutex> lockInfoMap(mInfoMapMux);
         for (const auto& configInfo : mInstanceConfigInfoMap) {
             addConfigInfoToRequest(configInfo, heartbeatReq.add_instance_configs());
         }
-    }
 
-    {
-        lock_guard<mutex> lockInfoMap(mInfoMapMux);
         for (const auto& configInfo : mOnetimePipelineConfigInfoMap) {
             addConfigInfoToRequest(configInfo, heartbeatReq.add_onetime_pipeline_configs());
         }
@@ -433,13 +427,11 @@ void CommonConfigProvider::UpdateRemotePipelineConfig(
             ConfigFeedbackReceiver::GetInstance().UnregisterContinuousPipelineConfig(config.name());
         } else {
             if (!DumpConfigFile(config, sourceDir)) {
-                {
-                    lock_guard<mutex> lockInfoMap(mInfoMapMux);
-                    mContinuousPipelineConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
-                                                                                 .version = config.version(),
-                                                                                 .status = ConfigFeedbackStatus::FAILED,
-                                                                                 .detail = config.detail()};
-                }
+                lock_guard<mutex> lockInfoMap(mInfoMapMux);
+                mContinuousPipelineConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
+                                                                             .version = config.version(),
+                                                                             .status = ConfigFeedbackStatus::FAILED,
+                                                                             .detail = config.detail()};
                 continue;
             }
             {
@@ -479,13 +471,11 @@ void CommonConfigProvider::UpdateRemoteInstanceConfig(
             ConfigFeedbackReceiver::GetInstance().UnregisterInstanceConfig(config.name());
         } else {
             if (!DumpConfigFile(config, sourceDir)) {
-                {
-                    lock_guard<mutex> lockInfoMap(mInfoMapMux);
-                    mInstanceConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
-                                                                       .version = config.version(),
-                                                                       .status = ConfigFeedbackStatus::FAILED,
-                                                                       .detail = config.detail()};
-                }
+                lock_guard<mutex> lockInfoMap(mInfoMapMux);
+                mInstanceConfigInfoMap[config.name()] = ConfigInfo{.name = config.name(),
+                                                                   .version = config.version(),
+                                                                   .status = ConfigFeedbackStatus::FAILED,
+                                                                   .detail = config.detail()};
                 continue;
             }
             {

--- a/core/config/common_provider/CommonConfigProvider.h
+++ b/core/config/common_provider/CommonConfigProvider.h
@@ -99,6 +99,8 @@ protected:
     mutable std::condition_variable mStopCV;
     bool mConfigServerAvailable = false;
 
+    mutable std::mutex mInfoMapMux;
+
     std::unordered_map<std::string, ConfigInfo> mContinuousPipelineConfigInfoMap;
     std::unordered_map<std::string, ConfigInfo> mInstanceConfigInfoMap;
     std::unordered_map<std::string, ConfigInfo> mOnetimePipelineConfigInfoMap;

--- a/core/config/common_provider/CommonConfigProvider.h
+++ b/core/config/common_provider/CommonConfigProvider.h
@@ -99,10 +99,6 @@ protected:
     mutable std::condition_variable mStopCV;
     bool mConfigServerAvailable = false;
 
-    mutable std::mutex mInstanceInfoMapMux;
-    mutable std::mutex mContinuousPipelineInfoMapMux;
-    mutable std::mutex mOnetimePipelineInfoMapMux;
-
     std::unordered_map<std::string, ConfigInfo> mContinuousPipelineConfigInfoMap;
     std::unordered_map<std::string, ConfigInfo> mInstanceConfigInfoMap;
     std::unordered_map<std::string, ConfigInfo> mOnetimePipelineConfigInfoMap;

--- a/core/config/feedbacker/ConfigFeedbackReceiver.cpp
+++ b/core/config/feedbacker/ConfigFeedbackReceiver.cpp
@@ -69,7 +69,6 @@ void ConfigFeedbackReceiver::FeedbackContinuousPipelineConfigStatus(const std::s
             feedbackable = iter->second;
         }
     }
-
     if (feedbackable) {
         feedbackable->FeedbackContinuousPipelineConfigStatus(name, status);
     }
@@ -84,7 +83,6 @@ void ConfigFeedbackReceiver::FeedbackInstanceConfigStatus(const std::string& nam
             feedbackable = iter->second;
         }
     }
-
     if (feedbackable) {
         feedbackable->FeedbackInstanceConfigStatus(name, status);
     }
@@ -101,7 +99,6 @@ void ConfigFeedbackReceiver::FeedbackOnetimePipelineConfigStatus(const std::stri
             feedbackable = iter->second;
         }
     }
-
     if (feedbackable) {
         feedbackable->FeedbackOnetimePipelineConfigStatus(type, name, status);
     }

--- a/core/config/feedbacker/ConfigFeedbackReceiver.cpp
+++ b/core/config/feedbacker/ConfigFeedbackReceiver.cpp
@@ -61,28 +61,49 @@ void ConfigFeedbackReceiver::UnregisterOnetimePipelineConfig(const std::string& 
 
 void ConfigFeedbackReceiver::FeedbackContinuousPipelineConfigStatus(const std::string& name,
                                                                     ConfigFeedbackStatus status) {
-    std::lock_guard<std::mutex> lock(mMutex);
-    auto iter = mContinuousPipelineConfigFeedbackableMap.find(name);
-    if (iter != mContinuousPipelineConfigFeedbackableMap.end()) {
-        iter->second->FeedbackContinuousPipelineConfigStatus(name, status);
+    ConfigFeedbackable* feedbackable = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        auto iter = mContinuousPipelineConfigFeedbackableMap.find(name);
+        if (iter != mContinuousPipelineConfigFeedbackableMap.end()) {
+            feedbackable = iter->second;
+        }
+    }
+
+    if (feedbackable) {
+        feedbackable->FeedbackContinuousPipelineConfigStatus(name, status);
     }
 }
 
 void ConfigFeedbackReceiver::FeedbackInstanceConfigStatus(const std::string& name, ConfigFeedbackStatus status) {
-    std::lock_guard<std::mutex> lock(mMutex);
-    auto iter = mInstanceConfigFeedbackableMap.find(name);
-    if (iter != mInstanceConfigFeedbackableMap.end()) {
-        iter->second->FeedbackInstanceConfigStatus(name, status);
+    ConfigFeedbackable* feedbackable = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        auto iter = mInstanceConfigFeedbackableMap.find(name);
+        if (iter != mInstanceConfigFeedbackableMap.end()) {
+            feedbackable = iter->second;
+        }
+    }
+
+    if (feedbackable) {
+        feedbackable->FeedbackInstanceConfigStatus(name, status);
     }
 }
 
 void ConfigFeedbackReceiver::FeedbackOnetimePipelineConfigStatus(const std::string& type,
                                                                  const std::string& name,
                                                                  ConfigFeedbackStatus status) {
-    std::lock_guard<std::mutex> lock(mMutex);
-    auto iter = mOnetimePipelineConfigFeedbackableMap.find(GenerateOnetimePipelineConfigFeedBackKey(type, name));
-    if (iter != mOnetimePipelineConfigFeedbackableMap.end()) {
-        iter->second->FeedbackOnetimePipelineConfigStatus(type, name, status);
+    ConfigFeedbackable* feedbackable = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        auto iter = mOnetimePipelineConfigFeedbackableMap.find(GenerateOnetimePipelineConfigFeedBackKey(type, name));
+        if (iter != mOnetimePipelineConfigFeedbackableMap.end()) {
+            feedbackable = iter->second;
+        }
+    }
+
+    if (feedbackable) {
+        feedbackable->FeedbackOnetimePipelineConfigStatus(type, name, status);
     }
 }
 

--- a/core/config/provider/ConfigProvider.h
+++ b/core/config/provider/ConfigProvider.h
@@ -38,6 +38,7 @@ protected:
     std::filesystem::path mInstanceSourceDir;
     mutable std::mutex mContinuousPipelineMux;
     mutable std::mutex mInstanceMux;
+    mutable std::mutex mOnetimePipelineMux;
 };
 
 } // namespace logtail

--- a/core/config/provider/ConfigProvider.h
+++ b/core/config/provider/ConfigProvider.h
@@ -38,7 +38,6 @@ protected:
     std::filesystem::path mInstanceSourceDir;
     mutable std::mutex mContinuousPipelineMux;
     mutable std::mutex mInstanceMux;
-    mutable std::mutex mOnetimePipelineMux;
 };
 
 } // namespace logtail


### PR DESCRIPTION
This pull request includes changes to the `ConfigFeedbackReceiver` class in the `core/config/feedbacker/ConfigFeedbackReceiver.cpp` file. The main goal of these changes is to improve thread safety by ensuring that the `Feedback*ConfigStatus` methods do not hold a lock while calling the `Feedback*ConfigStatus` methods on the `feedbackable` objects.

Thread safety improvements:

* [`core/config/feedbacker/ConfigFeedbackReceiver.cpp`](diffhunk://#diff-8e6ba8f0972071604471fb465367c2fedfb5ce7b16daebf70d630cace661bc93R64-R106): Modified the `FeedbackContinuousPipelineConfigStatus`, `FeedbackInstanceConfigStatus`, and `FeedbackOnetimePipelineConfigStatus` methods to first find and store the `feedbackable` object under a lock, and then call the corresponding `Feedback*ConfigStatus` method outside the lock. This prevents potential deadlocks and improves thread safety.