### PR TITLE
fix: improve k8s entity relation type name

### DIFF
--- a/docs/cn/plugins/input/extended/service-kubernetesmeta-v2.md
+++ b/docs/cn/plugins/input/extended/service-kubernetesmeta-v2.md
@@ -30,6 +30,19 @@
 | PersistentVolumeClaim | bool, false | 是否采集PersistentVolumeClaim元数据。 |
 | StorageClass | bool, false | 是否采集StorageClass元数据。 |
 | Ingress | bool, false | 是否采集Ingress元数据。 |
+| Node2Pod | string, 无默认值（可选） | Node到Pod的关系名，不填则不生成关系。 |
+| Deployment2Pod | string, 无默认值（可选） | Deployment到Pod的关系名，不填则不生成关系。 |
+| ReplicaSet2Pod | string, 无默认值（可选） | ReplicaSet到Pod的关系名，不填则不生成关系。 |
+| Deployment2ReplicaSet | string, 无默认值（可选） | Deployment到ReplicaSet的关系名，不填则不生成关系。 |
+| StatefulSet2Pod | string, 无默认值（可选） | StatefulSet到Pod的关系名，不填则不生成关系。 |
+| DaemonSet2Pod | string, 无默认值（可选） | DaemonSet到Pod的关系名，不填则不生成关系。 |
+| Service2Pod | string, 无默认值（可选） | Service到Pod的关系名，不填则不生成关系。 |
+| Pod2Container | string, 无默认值（可选） | Pod到Container的关系名，不填则不生成关系。 |
+| CronJob2Job | string, 无默认值（可选） | CronJob到Job的关系名，不填则不生成关系。 |
+| Job2Pod | string, 无默认值（可选） | Job到Pod的关系名，不填则不生成关系。 |
+| Ingress2Service | string, 无默认值（可选） | Ingress到Service的关系名，不填则不生成关系。 |
+| Pod2PersistentVolumeClaim | string, 无默认值（可选） | Pod到PersistentVolumeClaim的关系名，不填则不生成关系。 |
+| Pod2Configmap | string, 无默认值（可选） | Pod到Configmap的关系名，不填则不生成关系。 |
 
 ## 环境变量
 

--- a/pkg/helper/k8smeta/k8s_meta_const.go
+++ b/pkg/helper/k8smeta/k8s_meta_const.go
@@ -4,6 +4,7 @@ import (
 	app "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
 )
 
 const (
@@ -24,12 +25,13 @@ const (
 	STORAGECLASS          = "storageclass"
 	INGRESS               = "ingress"
 	CONTAINER             = "container"
-	// entity link type
+	// entity link type, the direction is from resource which will be trigger to linked resource
 	//revive:disable:var-naming
 	LINK_SPLIT_CHARACTER     = "->"
 	POD_NODE                 = "pod->node"
-	REPLICASET_DEPLOYMENT    = "replicaset->deployment"
+	POD_DEPLOYMENT           = "pod->deployment"
 	POD_REPLICASET           = "pod->replicaset"
+	REPLICASET_DEPLOYMENT    = "replicaset->deployment"
 	POD_STATEFULSET          = "pod->statefulset"
 	POD_DAEMONSET            = "pod->daemonset"
 	JOB_CRONJOB              = "job->cronjob"
@@ -38,7 +40,7 @@ const (
 	POD_CONFIGMAP            = "pod->configmap"
 	POD_SERVICE              = "pod->service"
 	POD_CONTAINER            = "pod->container"
-	POD_PROCESS              = "pod->process"
+	INGRESS_SERVICE          = "ingress->service"
 	//revive:enable:var-naming
 )
 
@@ -63,6 +65,11 @@ var AllResources = []string{
 type NodePod struct {
 	Node *v1.Node
 	Pod  *v1.Pod
+}
+
+type PodDeployment struct {
+	Pod        *v1.Pod
+	Deployment *app.Deployment
 }
 
 type ReplicaSetDeployment struct {
@@ -108,6 +115,11 @@ type PodConfigMap struct {
 type PodService struct {
 	Service *v1.Service
 	Pod     *v1.Pod
+}
+
+type IngressService struct {
+	Ingress *networking.Ingress
+	Service *v1.Service
 }
 
 type PodContainer struct {

--- a/pkg/helper/k8smeta/k8s_meta_const.go
+++ b/pkg/helper/k8smeta/k8s_meta_const.go
@@ -62,9 +62,9 @@ var AllResources = []string{
 	INGRESS,
 }
 
-type NodePod struct {
-	Node *v1.Node
+type PodNode struct {
 	Pod  *v1.Pod
+	Node *v1.Node
 }
 
 type PodDeployment struct {

--- a/pkg/helper/k8smeta/k8s_meta_http_server.go
+++ b/pkg/helper/k8smeta/k8s_meta_http_server.go
@@ -289,7 +289,7 @@ func (m *metadataHandler) handlePodMetaByHostIP(w http.ResponseWriter, r *http.R
 			if !ok {
 				continue
 			}
-			metadata[pod.Status.PodIP] = meta
+			metadata[string(pod.UID)] = meta
 		}
 	}
 	wrapperResponse(w, metadata)
@@ -308,6 +308,7 @@ func (m *metadataHandler) convertObjs2HostResponse(objs []*ObjectWrapper) []*Pod
 			containerIDs = append(containerIDs, truncateContainerID(container.ContainerID))
 		}
 		podMetadata.ContainerIDs = containerIDs
+		podMetadata.PodIP = pod.Status.PodIP
 		metadatas = append(metadatas, podMetadata)
 	}
 	return metadatas

--- a/pkg/helper/k8smeta/k8s_meta_link.go
+++ b/pkg/helper/k8smeta/k8s_meta_link.go
@@ -76,7 +76,7 @@ func (g *LinkGenerator) getPodNodeLink(podList []*K8sMetaEvent) []*K8sMetaEvent 
 					EventType: event.EventType,
 					Object: &ObjectWrapper{
 						ResourceType: POD_NODE,
-						Raw: &NodePod{
+						Raw: &PodNode{
 							Node: n.Raw.(*v1.Node),
 							Pod:  pod,
 						},

--- a/pkg/helper/k8smeta/k8s_meta_link.go
+++ b/pkg/helper/k8smeta/k8s_meta_link.go
@@ -6,6 +6,7 @@ import (
 	app "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -31,10 +32,16 @@ func (g *LinkGenerator) GenerateLinks(events []*K8sMetaEvent, linkType string) [
 	switch linkType {
 	case POD_NODE:
 		return g.getPodNodeLink(events)
-	case REPLICASET_DEPLOYMENT:
-		return g.getReplicaSetDeploymentLink(events)
-	case POD_REPLICASET, POD_STATEFULSET, POD_DAEMONSET, POD_JOB:
-		return g.getParentPodLink(events, linkType)
+	case POD_DEPLOYMENT:
+		return g.getPodDeploymentLink(events)
+	case POD_REPLICASET:
+		return g.getPodReplicaSetLink(events)
+	case POD_STATEFULSET:
+		return g.getPodStatefulSetLink(events)
+	case POD_DAEMONSET:
+		return g.getPodDaemonSetLink(events)
+	case POD_JOB:
+		return g.getPodJobLink(events)
 	case JOB_CRONJOB:
 		return g.getJobCronJobLink(events)
 	case POD_PERSISENTVOLUMECLAIN:
@@ -45,15 +52,19 @@ func (g *LinkGenerator) GenerateLinks(events []*K8sMetaEvent, linkType string) [
 		return g.getPodServiceLink(events)
 	case POD_CONTAINER:
 		return g.getPodContainerLink(events)
+	case REPLICASET_DEPLOYMENT:
+		return g.getReplicaSetDeploymentLink(events)
+	case INGRESS_SERVICE:
+
 	default:
 		return nil
 	}
 }
 
-func (g *LinkGenerator) getPodNodeLink(events []*K8sMetaEvent) []*K8sMetaEvent {
+func (g *LinkGenerator) getPodNodeLink(podList []*K8sMetaEvent) []*K8sMetaEvent {
 	nodeCache := g.metaCache[NODE]
 	result := make([]*K8sMetaEvent, 0)
-	for _, event := range events {
+	for _, event := range podList {
 		pod, ok := event.Object.Raw.(*v1.Pod)
 		if !ok {
 			continue
@@ -79,9 +90,45 @@ func (g *LinkGenerator) getPodNodeLink(events []*K8sMetaEvent) []*K8sMetaEvent {
 	return result
 }
 
-func (g *LinkGenerator) getReplicaSetDeploymentLink(events []*K8sMetaEvent) []*K8sMetaEvent {
+func (g *LinkGenerator) getPodDeploymentLink(podList []*K8sMetaEvent) []*K8sMetaEvent {
 	result := make([]*K8sMetaEvent, 0)
-	for _, event := range events {
+	for _, data := range podList {
+		pod, ok := data.Object.Raw.(*v1.Pod)
+		if !ok || len(pod.OwnerReferences) == 0 || pod.OwnerReferences[0].Kind != "ReplicaSet" {
+			continue
+		}
+		parentName := pod.OwnerReferences[0].Name
+		rsList := g.metaCache[REPLICASET].Get([]string{generateNameWithNamespaceKey(pod.Namespace, parentName)})
+		for _, rs := range rsList {
+			for _, r := range rs {
+				if deploymentName := r.Raw.(*app.ReplicaSet).OwnerReferences[0].Name; deploymentName != "" {
+					deploymentList := g.metaCache[DEPLOYMENT].Get([]string{generateNameWithNamespaceKey(pod.Namespace, deploymentName)})
+					for _, deployments := range deploymentList {
+						for _, d := range deployments {
+							result = append(result, &K8sMetaEvent{
+								EventType: data.EventType,
+								Object: &ObjectWrapper{
+									ResourceType: POD_DEPLOYMENT,
+									Raw: &PodDeployment{
+										Deployment: d.Raw.(*app.Deployment),
+										Pod:        pod,
+									},
+									FirstObservedTime: data.Object.FirstObservedTime,
+									LastObservedTime:  data.Object.LastObservedTime,
+								},
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+	return result
+}
+
+func (g *LinkGenerator) getReplicaSetDeploymentLink(rsList []*K8sMetaEvent) []*K8sMetaEvent {
+	result := make([]*K8sMetaEvent, 0)
+	for _, event := range rsList {
 		replicaset, ok := event.Object.Raw.(*app.ReplicaSet)
 		if !ok || len(replicaset.OwnerReferences) == 0 {
 			continue
@@ -108,86 +155,116 @@ func (g *LinkGenerator) getReplicaSetDeploymentLink(events []*K8sMetaEvent) []*K
 	return result
 }
 
-func (g *LinkGenerator) getParentPodLink(podList []*K8sMetaEvent, linkType string) []*K8sMetaEvent {
+func (g *LinkGenerator) getPodReplicaSetLink(podList []*K8sMetaEvent) []*K8sMetaEvent {
 	result := make([]*K8sMetaEvent, 0)
 	for _, data := range podList {
 		pod, ok := data.Object.Raw.(*v1.Pod)
-		if !ok || len(pod.OwnerReferences) == 0 {
+		if !ok || len(pod.OwnerReferences) == 0 || pod.OwnerReferences[0].Kind != "ReplicaSet" {
 			continue
 		}
 		parentName := pod.OwnerReferences[0].Name
-		switch {
-		case linkType == POD_REPLICASET && pod.OwnerReferences[0].Kind == "ReplicaSet":
-			rsList := g.metaCache[REPLICASET].Get([]string{generateNameWithNamespaceKey(pod.Namespace, parentName)})
-			for _, rs := range rsList {
-				for _, r := range rs {
-					result = append(result, &K8sMetaEvent{
-						EventType: data.EventType,
-						Object: &ObjectWrapper{
-							ResourceType: POD_REPLICASET,
-							Raw: &PodReplicaSet{
-								ReplicaSet: r.Raw.(*app.ReplicaSet),
-								Pod:        pod,
-							},
-							FirstObservedTime: data.Object.FirstObservedTime,
-							LastObservedTime:  data.Object.LastObservedTime,
+		rsList := g.metaCache[REPLICASET].Get([]string{generateNameWithNamespaceKey(pod.Namespace, parentName)})
+		for _, rs := range rsList {
+			for _, r := range rs {
+				result = append(result, &K8sMetaEvent{
+					EventType: data.EventType,
+					Object: &ObjectWrapper{
+						ResourceType: POD_REPLICASET,
+						Raw: &PodReplicaSet{
+							ReplicaSet: r.Raw.(*app.ReplicaSet),
+							Pod:        pod,
 						},
-					})
-				}
+						FirstObservedTime: data.Object.FirstObservedTime,
+						LastObservedTime:  data.Object.LastObservedTime,
+					},
+				})
 			}
-		case linkType == POD_STATEFULSET && pod.OwnerReferences[0].Kind == "StatefulSet":
-			ssList := g.metaCache[STATEFULSET].Get([]string{generateNameWithNamespaceKey(pod.Namespace, parentName)})
-			for _, ss := range ssList {
-				for _, s := range ss {
-					result = append(result, &K8sMetaEvent{
-						EventType: data.EventType,
-						Object: &ObjectWrapper{
-							ResourceType: POD_STATEFULSET,
-							Raw: &PodStatefulSet{
-								StatefulSet: s.Raw.(*app.StatefulSet),
-								Pod:         pod,
-							},
-							FirstObservedTime: data.Object.FirstObservedTime,
-							LastObservedTime:  data.Object.LastObservedTime,
+		}
+	}
+	return result
+}
+
+func (g *LinkGenerator) getPodStatefulSetLink(podList []*K8sMetaEvent) []*K8sMetaEvent {
+	result := make([]*K8sMetaEvent, 0)
+	for _, data := range podList {
+		pod, ok := data.Object.Raw.(*v1.Pod)
+		if !ok || len(pod.OwnerReferences) == 0 || pod.OwnerReferences[0].Kind != "StatefulSet" {
+			continue
+		}
+		parentName := pod.OwnerReferences[0].Name
+		ssList := g.metaCache[STATEFULSET].Get([]string{generateNameWithNamespaceKey(pod.Namespace, parentName)})
+		for _, ss := range ssList {
+			for _, s := range ss {
+				result = append(result, &K8sMetaEvent{
+					EventType: data.EventType,
+					Object: &ObjectWrapper{
+						ResourceType: POD_STATEFULSET,
+						Raw: &PodStatefulSet{
+							StatefulSet: s.Raw.(*app.StatefulSet),
+							Pod:         pod,
 						},
-					})
-				}
+						FirstObservedTime: data.Object.FirstObservedTime,
+						LastObservedTime:  data.Object.LastObservedTime,
+					},
+				})
 			}
-		case linkType == POD_DAEMONSET && pod.OwnerReferences[0].Kind == "DaemonSet":
-			dsList := g.metaCache[DAEMONSET].Get([]string{generateNameWithNamespaceKey(pod.Namespace, parentName)})
-			for _, ds := range dsList {
-				for _, d := range ds {
-					result = append(result, &K8sMetaEvent{
-						EventType: data.EventType,
-						Object: &ObjectWrapper{
-							ResourceType: POD_DAEMONSET,
-							Raw: &PodDaemonSet{
-								DaemonSet: d.Raw.(*app.DaemonSet),
-								Pod:       pod,
-							},
-							FirstObservedTime: data.Object.FirstObservedTime,
-							LastObservedTime:  data.Object.LastObservedTime,
+		}
+	}
+	return result
+}
+
+func (g *LinkGenerator) getPodDaemonSetLink(podList []*K8sMetaEvent) []*K8sMetaEvent {
+	result := make([]*K8sMetaEvent, 0)
+	for _, data := range podList {
+		pod, ok := data.Object.Raw.(*v1.Pod)
+		if !ok || len(pod.OwnerReferences) == 0 || pod.OwnerReferences[0].Kind != "DaemonSet" {
+			continue
+		}
+		parentName := pod.OwnerReferences[0].Name
+		dsList := g.metaCache[DAEMONSET].Get([]string{generateNameWithNamespaceKey(pod.Namespace, parentName)})
+		for _, ds := range dsList {
+			for _, d := range ds {
+				result = append(result, &K8sMetaEvent{
+					EventType: data.EventType,
+					Object: &ObjectWrapper{
+						ResourceType: POD_DAEMONSET,
+						Raw: &PodDaemonSet{
+							DaemonSet: d.Raw.(*app.DaemonSet),
+							Pod:       pod,
 						},
-					})
-				}
+						FirstObservedTime: data.Object.FirstObservedTime,
+						LastObservedTime:  data.Object.LastObservedTime,
+					},
+				})
 			}
-		case linkType == POD_JOB && pod.OwnerReferences[0].Kind == "Job":
-			jobList := g.metaCache[JOB].Get([]string{generateNameWithNamespaceKey(pod.Namespace, parentName)})
-			for _, job := range jobList {
-				for _, j := range job {
-					result = append(result, &K8sMetaEvent{
-						EventType: data.EventType,
-						Object: &ObjectWrapper{
-							ResourceType: POD_JOB,
-							Raw: &PodJob{
-								Job: j.Raw.(*batch.Job),
-								Pod: pod,
-							},
-							FirstObservedTime: data.Object.FirstObservedTime,
-							LastObservedTime:  data.Object.LastObservedTime,
+		}
+	}
+	return result
+}
+
+func (g *LinkGenerator) getPodJobLink(podList []*K8sMetaEvent) []*K8sMetaEvent {
+	result := make([]*K8sMetaEvent, 0)
+	for _, data := range podList {
+		pod, ok := data.Object.Raw.(*v1.Pod)
+		if !ok || len(pod.OwnerReferences) == 0 || pod.OwnerReferences[0].Kind != "Job" {
+			continue
+		}
+		parentName := pod.OwnerReferences[0].Name
+		jobList := g.metaCache[JOB].Get([]string{generateNameWithNamespaceKey(pod.Namespace, parentName)})
+		for _, job := range jobList {
+			for _, j := range job {
+				result = append(result, &K8sMetaEvent{
+					EventType: data.EventType,
+					Object: &ObjectWrapper{
+						ResourceType: POD_JOB,
+						Raw: &PodJob{
+							Job: j.Raw.(*batch.Job),
+							Pod: pod,
 						},
-					})
-				}
+						FirstObservedTime: data.Object.FirstObservedTime,
+						LastObservedTime:  data.Object.LastObservedTime,
+					},
+				})
 			}
 		}
 	}
@@ -358,6 +435,44 @@ func (g *LinkGenerator) getPodContainerLink(podList []*K8sMetaEvent) []*K8sMetaE
 					LastObservedTime:  data.Object.LastObservedTime,
 				},
 			})
+		}
+	}
+	return result
+}
+
+func (g *LinkGenerator) getIngressServiceLink(ingressList []*K8sMetaEvent) []*K8sMetaEvent {
+	result := make([]*K8sMetaEvent, 0)
+	for _, data := range ingressList {
+		ingress, ok := data.Object.Raw.(*networking.Ingress)
+		if !ok {
+			continue
+		}
+		serviceNameSet := make(map[string]struct{}, 0)
+		for _, rule := range ingress.Spec.Rules {
+			for _, path := range rule.HTTP.Paths {
+				serviceNameSet[path.Backend.Service.Name] = struct{}{}
+			}
+		}
+		serviceNameList := make([]string, 0, len(serviceNameSet))
+		for name := range serviceNameSet {
+			serviceNameList = append(serviceNameList, generateNameWithNamespaceKey(ingress.Namespace, name))
+		}
+		serviceList := g.metaCache[SERVICE].Get(serviceNameList)
+		for _, service := range serviceList {
+			for _, s := range service {
+				result = append(result, &K8sMetaEvent{
+					EventType: data.EventType,
+					Object: &ObjectWrapper{
+						ResourceType: INGRESS_SERVICE,
+						Raw: &IngressService{
+							Ingress: ingress,
+							Service: s.Raw.(*v1.Service),
+						},
+						FirstObservedTime: data.Object.FirstObservedTime,
+						LastObservedTime:  data.Object.LastObservedTime,
+					},
+				})
+			}
 		}
 	}
 	return result

--- a/pkg/helper/k8smeta/k8s_meta_link.go
+++ b/pkg/helper/k8smeta/k8s_meta_link.go
@@ -55,7 +55,7 @@ func (g *LinkGenerator) GenerateLinks(events []*K8sMetaEvent, linkType string) [
 	case REPLICASET_DEPLOYMENT:
 		return g.getReplicaSetDeploymentLink(events)
 	case INGRESS_SERVICE:
-
+		return g.getIngressServiceLink(events)
 	default:
 		return nil
 	}

--- a/pkg/helper/k8smeta/k8s_meta_link_test.go
+++ b/pkg/helper/k8smeta/k8s_meta_link_test.go
@@ -4,79 +4,846 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	app "k8s.io/api/apps/v1"
+	batch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestGetPodNodeLink(t *testing.T) {
+	podCache := newK8sMetaCache(make(chan struct{}), POD)
+	nodeCache := newK8sMetaCache(make(chan struct{}), NODE)
+	nodeCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+		},
+	})
+	nodeCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+			},
+		},
+	})
+	pod1 := generateMockPod("1")
+	pod1.Raw.(*corev1.Pod).Spec.NodeName = "node1"
+	pod2 := generateMockPod("2")
+	pod2.Raw.(*corev1.Pod).Spec.NodeName = "node2"
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod1,
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod2,
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		POD:  podCache,
+		NODE: nodeCache,
+	})
+	podList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod1"],
+		},
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod2"],
+		},
+	}
+	results := linkGenerator.getPodNodeLink(podList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "node1", results[0].Object.Raw.(*PodNode).Node.Name)
+	assert.Equal(t, "node2", results[1].Object.Raw.(*PodNode).Node.Name)
+}
+
+func TestGetPodDeploymentLink(t *testing.T) {
+	podCache := newK8sMetaCache(make(chan struct{}), POD)
+	replicasetCache := newK8sMetaCache(make(chan struct{}), REPLICASET)
+	deploymentCache := newK8sMetaCache(make(chan struct{}), DEPLOYMENT)
+	deploymentCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment1",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	deploymentCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment2",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	replicasetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "replicaset1",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "Deployment",
+							Name: "deployment1",
+						},
+					},
+				},
+				Spec: app.ReplicaSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+		},
+	})
+	replicasetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "replicaset2",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "Deployment",
+							Name: "deployment2",
+						},
+					},
+				},
+				Spec: app.ReplicaSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test2",
+						},
+					},
+				},
+			},
+		},
+	})
+	pod1 := generateMockPod("1")
+	pod1.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "ReplicaSet",
+			Name: "replicaset1",
+		},
+	}
+	pod2 := generateMockPod("2")
+	pod2.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "ReplicaSet",
+			Name: "replicaset2",
+		},
+	}
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod1,
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod2,
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		POD:        podCache,
+		REPLICASET: replicasetCache,
+		DEPLOYMENT: deploymentCache,
+	})
+	podList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod1"],
+		},
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod2"],
+		},
+	}
+	results := linkGenerator.getPodDeploymentLink(podList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "deployment1", results[0].Object.Raw.(*PodDeployment).Deployment.Name)
+	assert.Equal(t, "deployment2", results[1].Object.Raw.(*PodDeployment).Deployment.Name)
+}
+
+func TestGetReplicaSetDeploymentLink(t *testing.T) {
+	replicasetCache := newK8sMetaCache(make(chan struct{}), REPLICASET)
+	deploymentCache := newK8sMetaCache(make(chan struct{}), DEPLOYMENT)
+	deploymentCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment1",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	deploymentCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment2",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	replicasetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "replicaset1",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "Deployment",
+							Name: "deployment1",
+						},
+					},
+				},
+				Spec: app.ReplicaSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+		},
+	})
+	replicasetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "replicaset2",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "Deployment",
+							Name: "deployment2",
+						},
+					},
+				},
+				Spec: app.ReplicaSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test2",
+						},
+					},
+				},
+			},
+		},
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		REPLICASET: replicasetCache,
+		DEPLOYMENT: deploymentCache,
+	})
+	replicasetList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    replicasetCache.metaStore.Items["default/replicaset1"],
+		},
+		{
+			EventType: "update",
+			Object:    replicasetCache.metaStore.Items["default/replicaset2"],
+		},
+	}
+	results := linkGenerator.getReplicaSetDeploymentLink(replicasetList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "deployment1", results[0].Object.Raw.(*ReplicaSetDeployment).Deployment.Name)
+	assert.Equal(t, "deployment2", results[1].Object.Raw.(*ReplicaSetDeployment).Deployment.Name)
+}
+
+func TestGetPodReplicaSetLink(t *testing.T) {
+	podCache := newK8sMetaCache(make(chan struct{}), POD)
+	replicasetCache := newK8sMetaCache(make(chan struct{}), REPLICASET)
+	replicasetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "replicaset1",
+					Namespace: "default",
+				},
+				Spec: app.ReplicaSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+		},
+	})
+	replicasetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "replicaset2",
+					Namespace: "default",
+				},
+				Spec: app.ReplicaSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test2",
+						},
+					},
+				},
+			},
+		},
+	})
+	pod1 := generateMockPod("1")
+	pod1.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "ReplicaSet",
+			Name: "replicaset1",
+		},
+	}
+	pod2 := generateMockPod("2")
+	pod2.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "ReplicaSet",
+			Name: "replicaset2",
+		},
+	}
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod1,
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod2,
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		POD:        podCache,
+		REPLICASET: replicasetCache,
+	})
+	podList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod1"],
+		},
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod2"],
+		},
+	}
+	results := linkGenerator.getPodReplicaSetLink(podList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "replicaset1", results[0].Object.Raw.(*PodReplicaSet).ReplicaSet.Name)
+	assert.Equal(t, "replicaset2", results[1].Object.Raw.(*PodReplicaSet).ReplicaSet.Name)
+}
+
+func TestGetPodDaemonSetLink(t *testing.T) {
+	podCache := newK8sMetaCache(make(chan struct{}), POD)
+	daemonsetCache := newK8sMetaCache(make(chan struct{}), DAEMONSET)
+	daemonsetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "daemonset1",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	daemonsetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "daemonset2",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	pod1 := generateMockPod("1")
+	pod1.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "DaemonSet",
+			Name: "daemonset1",
+		},
+	}
+	pod2 := generateMockPod("2")
+	pod2.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "DaemonSet",
+			Name: "daemonset2",
+		},
+	}
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod1,
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod2,
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		POD:       podCache,
+		DAEMONSET: daemonsetCache,
+	})
+	podList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod1"],
+		},
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod2"],
+		},
+	}
+	results := linkGenerator.getPodDaemonSetLink(podList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "daemonset1", results[0].Object.Raw.(*PodDaemonSet).DaemonSet.Name)
+	assert.Equal(t, "daemonset2", results[1].Object.Raw.(*PodDaemonSet).DaemonSet.Name)
+}
+
+func TestGetPodStatefulSetLink(t *testing.T) {
+	podCache := newK8sMetaCache(make(chan struct{}), POD)
+	statefulsetCache := newK8sMetaCache(make(chan struct{}), STATEFULSET)
+	statefulsetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "statefulset1",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	statefulsetCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &app.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "statefulset2",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	pod1 := generateMockPod("1")
+	pod1.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "StatefulSet",
+			Name: "statefulset1",
+		},
+	}
+	pod2 := generateMockPod("2")
+	pod2.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "StatefulSet",
+			Name: "statefulset2",
+		},
+	}
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod1,
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod2,
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		POD:         podCache,
+		STATEFULSET: statefulsetCache,
+	})
+	podList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod1"],
+		},
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod2"],
+		},
+	}
+	results := linkGenerator.getPodStatefulSetLink(podList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "statefulset1", results[0].Object.Raw.(*PodStatefulSet).StatefulSet.Name)
+	assert.Equal(t, "statefulset2", results[1].Object.Raw.(*PodStatefulSet).StatefulSet.Name)
+}
+
+func TestGetPodJobLink(t *testing.T) {
+	podCache := newK8sMetaCache(make(chan struct{}), POD)
+	jobCache := newK8sMetaCache(make(chan struct{}), JOB)
+	jobCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	jobCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job2",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	pod1 := generateMockPod("1")
+	pod1.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "Job",
+			Name: "job1",
+		},
+	}
+	pod2 := generateMockPod("2")
+	pod2.Raw.(*corev1.Pod).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "Job",
+			Name: "job2",
+		},
+	}
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod1,
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod2,
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		POD: podCache,
+		JOB: jobCache,
+	})
+	podList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod1"],
+		},
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod2"],
+		},
+	}
+	results := linkGenerator.getPodJobLink(podList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "job1", results[0].Object.Raw.(*PodJob).Job.Name)
+	assert.Equal(t, "job2", results[1].Object.Raw.(*PodJob).Job.Name)
+}
+
+func TestGetJobCronJobLink(t *testing.T) {
+	jobCache := newK8sMetaCache(make(chan struct{}), JOB)
+	cronJobCache := newK8sMetaCache(make(chan struct{}), CRONJOB)
+	cronJobCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &batch.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cronjob1",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	cronJobCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &batch.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cronjob2",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	job1 := &ObjectWrapper{
+		Raw: &batch.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job1",
+				Namespace: "default",
+			},
+		},
+	}
+	job1.Raw.(*batch.Job).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "CronJob",
+			Name: "cronjob1",
+		},
+	}
+	job2 := &ObjectWrapper{
+		Raw: &batch.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job2",
+				Namespace: "default",
+			},
+		},
+	}
+	job2.Raw.(*batch.Job).OwnerReferences = []metav1.OwnerReference{
+		{
+			Kind: "CronJob",
+			Name: "cronjob2",
+		},
+	}
+	jobCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    job1,
+	})
+	jobCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    job2,
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		JOB:     jobCache,
+		CRONJOB: cronJobCache,
+	})
+	jobList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    jobCache.metaStore.Items["default/job1"],
+		},
+		{
+			EventType: "update",
+			Object:    jobCache.metaStore.Items["default/job2"],
+		},
+	}
+	results := linkGenerator.getJobCronJobLink(jobList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "cronjob1", results[0].Object.Raw.(*JobCronJob).CronJob.Name)
+	assert.Equal(t, "cronjob2", results[1].Object.Raw.(*JobCronJob).CronJob.Name)
+}
+
+func TestGetPodPVCLink(t *testing.T) {
+	podCache := newK8sMetaCache(make(chan struct{}), POD)
+	pvcCache := newK8sMetaCache(make(chan struct{}), PERSISTENTVOLUMECLAIM)
+	pvcCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc1",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	pvcCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc2",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	pod1 := generateMockPod("1")
+	pod1.Raw.(*corev1.Pod).Spec.Volumes = []corev1.Volume{
+		{
+			Name: "volume1",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "pvc1",
+				},
+			},
+		},
+	}
+	pod2 := generateMockPod("2")
+	pod2.Raw.(*corev1.Pod).Spec.Volumes = []corev1.Volume{
+		{
+			Name: "volume2",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "pvc2",
+				},
+			},
+		},
+	}
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod1,
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod2,
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		POD:                   podCache,
+		PERSISTENTVOLUMECLAIM: pvcCache,
+	})
+	podList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod1"],
+		},
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod2"],
+		},
+	}
+	results := linkGenerator.getPodPVCLink(podList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "pvc1", results[0].Object.Raw.(*PodPersistentVolumeClaim).PersistentVolumeClaim.Name)
+	assert.Equal(t, "pvc2", results[1].Object.Raw.(*PodPersistentVolumeClaim).PersistentVolumeClaim.Name)
+}
+
+func TestGetPodConfigMapLink(t *testing.T) {
+	podCache := newK8sMetaCache(make(chan struct{}), POD)
+	configMapCache := newK8sMetaCache(make(chan struct{}), CONFIGMAP)
+	configMapCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "configmap1",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	configMapCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "configmap2",
+					Namespace: "default",
+				},
+			},
+		},
+	})
+	pod1 := generateMockPod("1")
+	pod1.Raw.(*corev1.Pod).Spec.Volumes = []corev1.Volume{
+		{
+			Name: "volume1",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "configmap1",
+					},
+				},
+			},
+		},
+	}
+	pod2 := generateMockPod("2")
+	pod2.Raw.(*corev1.Pod).Spec.Volumes = []corev1.Volume{
+		{
+			Name: "volume2",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "configmap2",
+					},
+				},
+			},
+		},
+	}
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod1,
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod2,
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		POD:       podCache,
+		CONFIGMAP: configMapCache,
+	})
+	podList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod1"],
+		},
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod2"],
+		},
+	}
+	results := linkGenerator.getPodConfigMapLink(podList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "configmap1", results[0].Object.Raw.(*PodConfigMap).ConfigMap.Name)
+	assert.Equal(t, "configmap2", results[1].Object.Raw.(*PodConfigMap).ConfigMap.Name)
+}
 
 func TestGetPodServiceLink(t *testing.T) {
 	podCache := newK8sMetaCache(make(chan struct{}), POD)
 	serviceCache := newK8sMetaCache(make(chan struct{}), SERVICE)
-	serviceCache.metaStore.Items["default/service1"] = &ObjectWrapper{
-		Raw: &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "service1",
-				Namespace: "default",
-			},
-			Spec: corev1.ServiceSpec{
-				Selector: map[string]string{
-					"app": "test",
+	serviceCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "default",
 				},
-			},
-		},
-	}
-	serviceCache.metaStore.Items["default/service2"] = &ObjectWrapper{
-		Raw: &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "service2",
-				Namespace: "default",
-			},
-			Spec: corev1.ServiceSpec{
-				Selector: map[string]string{
-					"app": "test2",
-				},
-			},
-		},
-	}
-	podCache.metaStore.Items["default/pod1"] = &ObjectWrapper{
-		Raw: &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pod1",
-				Namespace: "default",
-				Labels: map[string]string{
-					"app": "test",
-					"env": "test",
-				},
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "test",
-						Image: "test",
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "test",
 					},
 				},
 			},
 		},
-	}
-	podCache.metaStore.Items["default/pod2"] = &ObjectWrapper{
-		Raw: &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pod2",
-				Namespace: "default",
-				Labels: map[string]string{
-					"app": "test2",
-					"env": "test2",
+	})
+	serviceCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service2",
+					Namespace: "default",
 				},
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "test2",
-						Image: "test2",
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "test2",
 					},
 				},
 			},
 		},
+	})
+	pod1 := generateMockPod("1")
+	pod1.Raw.(*corev1.Pod).Labels = map[string]string{
+		"app": "test",
 	}
+	pod2 := generateMockPod("2")
+	pod2.Raw.(*corev1.Pod).Labels = map[string]string{
+		"app": "test2",
+	}
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod1,
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    pod2,
+	})
 	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
 		POD:     podCache,
 		SERVICE: serviceCache,
@@ -95,4 +862,167 @@ func TestGetPodServiceLink(t *testing.T) {
 	assert.Equal(t, 2, len(results))
 	assert.Equal(t, "service1", results[0].Object.Raw.(*PodService).Service.Name)
 	assert.Equal(t, "service2", results[1].Object.Raw.(*PodService).Service.Name)
+}
+
+func TestGetPodContainerLink(t *testing.T) {
+	podCache := newK8sMetaCache(make(chan struct{}), POD)
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    generateMockPod("1"),
+	})
+	podCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object:    generateMockPod("2"),
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		POD: podCache,
+	})
+	podList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod1"],
+		},
+		{
+			EventType: "update",
+			Object:    podCache.metaStore.Items["default/pod2"],
+		},
+	}
+	results := linkGenerator.getPodContainerLink(podList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "test1", results[0].Object.Raw.(*PodContainer).Container.Name)
+	assert.Equal(t, "test2", results[1].Object.Raw.(*PodContainer).Container.Name)
+}
+
+func TestGetIngressServiceLink(t *testing.T) {
+	ingressCache := newK8sMetaCache(make(chan struct{}), INGRESS)
+	serviceCache := newK8sMetaCache(make(chan struct{}), SERVICE)
+	serviceCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "test",
+					},
+				},
+			},
+		},
+	})
+	serviceCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service2",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "test2",
+					},
+				},
+			},
+		},
+	})
+	ingressCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress1",
+					Namespace: "default",
+				},
+				Spec: networking.IngressSpec{
+					Rules: []networking.IngressRule{
+						{
+							IngressRuleValue: networking.IngressRuleValue{
+								HTTP: &networking.HTTPIngressRuleValue{
+									Paths: []networking.HTTPIngressPath{
+										{
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "service1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	ingressCache.metaStore.handleAddOrUpdateEvent(&K8sMetaEvent{
+		EventType: "add",
+		Object: &ObjectWrapper{
+			Raw: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress2",
+					Namespace: "default",
+				},
+				Spec: networking.IngressSpec{
+					Rules: []networking.IngressRule{
+						{
+							IngressRuleValue: networking.IngressRuleValue{
+								HTTP: &networking.HTTPIngressRuleValue{
+									Paths: []networking.HTTPIngressPath{
+										{
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "service2",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	linkGenerator := NewK8sMetaLinkGenerator(map[string]MetaCache{
+		INGRESS: ingressCache,
+		SERVICE: serviceCache,
+	})
+	ingressList := []*K8sMetaEvent{
+		{
+			EventType: "update",
+			Object:    ingressCache.metaStore.Items["default/ingress1"],
+		},
+		{
+			EventType: "update",
+			Object:    ingressCache.metaStore.Items["default/ingress2"],
+		},
+	}
+	results := linkGenerator.getIngressServiceLink(ingressList)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "service1", results[0].Object.Raw.(*IngressService).Service.Name)
+	assert.Equal(t, "service2", results[1].Object.Raw.(*IngressService).Service.Name)
+}
+
+func generateMockPod(index string) *ObjectWrapper {
+	return &ObjectWrapper{
+		Raw: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod" + index,
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test" + index,
+						Image: "test" + index,
+					},
+				},
+			},
+		},
+	}
 }

--- a/plugins/input/kubernetesmetav2/meta_collector.go
+++ b/plugins/input/kubernetesmetav2/meta_collector.go
@@ -353,11 +353,11 @@ func (m *metaCollector) generateEntityClusterLink(entityEvent models.PipelineEve
 	log := &models.Log{}
 	log.Contents = models.NewLogContents()
 	log.Contents.Add(entityLinkSrcDomainFieldName, m.serviceK8sMeta.domain)
-	log.Contents.Add(entityLinkSrcEntityTypeFieldName, content.Get(entityTypeFieldName))
-	log.Contents.Add(entityLinkSrcEntityIDFieldName, content.Get(entityIDFieldName))
+	log.Contents.Add(entityLinkSrcEntityTypeFieldName, m.genEntityTypeKey(clusterTypeName))
+	log.Contents.Add(entityLinkSrcEntityIDFieldName, m.genKey("", "", ""))
 	log.Contents.Add(entityLinkDestDomainFieldName, m.serviceK8sMeta.domain)
-	log.Contents.Add(entityLinkDestEntityTypeFieldName, m.genEntityTypeKey(clusterTypeName))
-	log.Contents.Add(entityLinkDestEntityIDFieldName, m.genKey("", "", ""))
+	log.Contents.Add(entityLinkDestEntityTypeFieldName, content.Get(entityTypeFieldName))
+	log.Contents.Add(entityLinkDestEntityIDFieldName, content.Get(entityIDFieldName))
 
 	log.Contents.Add(entityLinkRelationTypeFieldName, "runs")
 	log.Contents.Add(entityMethodFieldName, content.Get(entityMethodFieldName))

--- a/plugins/input/kubernetesmetav2/meta_collector.go
+++ b/plugins/input/kubernetesmetav2/meta_collector.go
@@ -50,8 +50,9 @@ func (m *metaCollector) Start() error {
 		k8smeta.STORAGECLASS:             m.processStorageClassEntity,
 		k8smeta.INGRESS:                  m.processIngressEntity,
 		k8smeta.POD_NODE:                 m.processPodNodeLink,
-		k8smeta.REPLICASET_DEPLOYMENT:    m.processReplicaSetDeploymentLink,
+		k8smeta.POD_DEPLOYMENT:           m.processPodDeploymentLink,
 		k8smeta.POD_REPLICASET:           m.processPodReplicaSetLink,
+		k8smeta.REPLICASET_DEPLOYMENT:    m.processReplicaSetDeploymentLink,
 		k8smeta.POD_STATEFULSET:          m.processPodStatefulSetLink,
 		k8smeta.POD_DAEMONSET:            m.processPodDaemonSetLink,
 		k8smeta.JOB_CRONJOB:              m.processJobCronJobLink,
@@ -60,6 +61,7 @@ func (m *metaCollector) Start() error {
 		k8smeta.POD_CONFIGMAP:            m.processPodConfigMapLink,
 		k8smeta.POD_SERVICE:              m.processPodServiceLink,
 		k8smeta.POD_CONTAINER:            m.processPodContainerLink,
+		k8smeta.INGRESS_SERVICE:          m.processIngressServiceLink,
 	}
 
 	if m.serviceK8sMeta.Pod {
@@ -107,38 +109,45 @@ func (m *metaCollector) Start() error {
 	if m.serviceK8sMeta.Ingress {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.INGRESS, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.Pod && m.serviceK8sMeta.Node {
+
+	if m.serviceK8sMeta.Pod && m.serviceK8sMeta.Node && m.serviceK8sMeta.Node2Pod != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_NODE, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.Deployment && m.serviceK8sMeta.ReplicaSet {
-		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.REPLICASET_DEPLOYMENT, m.handleEvent, m.serviceK8sMeta.Interval)
+	if m.serviceK8sMeta.Deployment && m.serviceK8sMeta.Pod && m.serviceK8sMeta.Deployment2Pod != "" {
+		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_DEPLOYMENT, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.ReplicaSet && m.serviceK8sMeta.Pod {
+	if m.serviceK8sMeta.ReplicaSet && m.serviceK8sMeta.Pod && m.serviceK8sMeta.ReplicaSet2Pod != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_REPLICASET, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.StatefulSet && m.serviceK8sMeta.Pod {
+	if m.serviceK8sMeta.Deployment && m.serviceK8sMeta.ReplicaSet && m.serviceK8sMeta.Deployment2ReplicaSet != "" {
+		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.REPLICASET_DEPLOYMENT, m.handleEvent, m.serviceK8sMeta.Interval)
+	}
+	if m.serviceK8sMeta.StatefulSet && m.serviceK8sMeta.Pod && m.serviceK8sMeta.StatefulSet2Pod != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_STATEFULSET, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.DaemonSet && m.serviceK8sMeta.Pod {
+	if m.serviceK8sMeta.DaemonSet && m.serviceK8sMeta.Pod && m.serviceK8sMeta.DaemonSet2Pod != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_DAEMONSET, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.CronJob && m.serviceK8sMeta.Job {
+	if m.serviceK8sMeta.CronJob && m.serviceK8sMeta.Job && m.serviceK8sMeta.CronJob2Job != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.JOB_CRONJOB, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.Job && m.serviceK8sMeta.Pod {
+	if m.serviceK8sMeta.Job && m.serviceK8sMeta.Pod && m.serviceK8sMeta.Job2Pod != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_JOB, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.Pod && m.serviceK8sMeta.PersistentVolumeClaim {
+	if m.serviceK8sMeta.Pod && m.serviceK8sMeta.PersistentVolumeClaim && m.serviceK8sMeta.Pod2PersistentVolumeClaim != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_PERSISENTVOLUMECLAIN, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.Pod && m.serviceK8sMeta.Configmap {
+	if m.serviceK8sMeta.Pod && m.serviceK8sMeta.Configmap && m.serviceK8sMeta.Pod2ConfigMap != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_CONFIGMAP, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.Service && m.serviceK8sMeta.Pod {
+	if m.serviceK8sMeta.Service && m.serviceK8sMeta.Pod && m.serviceK8sMeta.Service2Pod != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_SERVICE, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
-	if m.serviceK8sMeta.Pod {
+	if m.serviceK8sMeta.Pod && m.serviceK8sMeta.Container && m.serviceK8sMeta.Pod2Container != "" {
 		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.POD_CONTAINER, m.handleEvent, m.serviceK8sMeta.Interval)
+	}
+	if m.serviceK8sMeta.Ingress && m.serviceK8sMeta.Service && m.serviceK8sMeta.Ingress2Service != "" {
+		m.serviceK8sMeta.metaManager.RegisterSendFunc(m.serviceK8sMeta.context.GetProject(), m.serviceK8sMeta.configName, k8smeta.INGRESS_SERVICE, m.handleEvent, m.serviceK8sMeta.Interval)
 	}
 	go m.sendInBackground()
 	return nil

--- a/plugins/input/kubernetesmetav2/meta_collector_app.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_app.go
@@ -123,12 +123,12 @@ func (m *metaCollector) processReplicaSetEntity(data *k8smeta.ObjectWrapper, met
 	return nil
 }
 
-func (m *metaCollector) processReplicaSetDeploymentLink(data *k8smeta.ObjectWrapper, method string) []models.PipelineEvent {
-	if obj, ok := data.Raw.(*k8smeta.ReplicaSetDeployment); ok {
+func (m *metaCollector) processPodDeploymentLink(data *k8smeta.ObjectWrapper, method string) []models.PipelineEvent {
+	if obj, ok := data.Raw.(*k8smeta.PodDeployment); ok {
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
-		m.processEntityLinkCommonPart(log.Contents, obj.ReplicaSet.Kind, obj.ReplicaSet.Namespace, obj.ReplicaSet.Name, obj.Deployment.Kind, obj.Deployment.Namespace, obj.Deployment.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "related_to")
+		m.processEntityLinkCommonPart(log.Contents, obj.Deployment.Kind, obj.Deployment.Namespace, obj.Deployment.Name, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, method, data.FirstObservedTime, data.LastObservedTime)
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Deployment2Pod)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}
@@ -139,8 +139,20 @@ func (m *metaCollector) processPodReplicaSetLink(data *k8smeta.ObjectWrapper, me
 	if obj, ok := data.Raw.(*k8smeta.PodReplicaSet); ok {
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
-		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, obj.ReplicaSet.Kind, obj.ReplicaSet.Namespace, obj.ReplicaSet.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "related_to")
+		m.processEntityLinkCommonPart(log.Contents, obj.ReplicaSet.Kind, obj.ReplicaSet.Namespace, obj.ReplicaSet.Name, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, method, data.FirstObservedTime, data.LastObservedTime)
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.ReplicaSet2Pod)
+		log.Timestamp = uint64(time.Now().Unix())
+		return []models.PipelineEvent{log}
+	}
+	return nil
+}
+
+func (m *metaCollector) processReplicaSetDeploymentLink(data *k8smeta.ObjectWrapper, method string) []models.PipelineEvent {
+	if obj, ok := data.Raw.(*k8smeta.ReplicaSetDeployment); ok {
+		log := &models.Log{}
+		log.Contents = models.NewLogContents()
+		m.processEntityLinkCommonPart(log.Contents, obj.Deployment.Kind, obj.Deployment.Namespace, obj.Deployment.Name, obj.ReplicaSet.Kind, obj.ReplicaSet.Namespace, obj.ReplicaSet.Name, method, data.FirstObservedTime, data.LastObservedTime)
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Deployment2ReplicaSet)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}
@@ -151,8 +163,8 @@ func (m *metaCollector) processPodStatefulSetLink(data *k8smeta.ObjectWrapper, m
 	if obj, ok := data.Raw.(*k8smeta.PodStatefulSet); ok {
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
-		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, obj.StatefulSet.Kind, obj.StatefulSet.Namespace, obj.StatefulSet.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "related_to")
+		m.processEntityLinkCommonPart(log.Contents, obj.StatefulSet.Kind, obj.StatefulSet.Namespace, obj.StatefulSet.Name, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, method, data.FirstObservedTime, data.LastObservedTime)
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.StatefulSet2Pod)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}
@@ -163,8 +175,8 @@ func (m *metaCollector) processPodDaemonSetLink(data *k8smeta.ObjectWrapper, met
 	if obj, ok := data.Raw.(*k8smeta.PodDaemonSet); ok {
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
-		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, obj.DaemonSet.Kind, obj.DaemonSet.Namespace, obj.DaemonSet.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "related_to")
+		m.processEntityLinkCommonPart(log.Contents, obj.DaemonSet.Kind, obj.DaemonSet.Namespace, obj.DaemonSet.Name, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, method, data.FirstObservedTime, data.LastObservedTime)
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.DaemonSet2Pod)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}

--- a/plugins/input/kubernetesmetav2/meta_collector_batch.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_batch.go
@@ -64,7 +64,7 @@ func (m *metaCollector) processJobCronJobLink(data *k8smeta.ObjectWrapper, metho
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
 		m.processEntityLinkCommonPart(log.Contents, obj.Job.Kind, obj.Job.Namespace, obj.Job.Name, obj.CronJob.Kind, obj.CronJob.Namespace, obj.CronJob.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "related_to")
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.CronJob2Job)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}
@@ -76,7 +76,7 @@ func (m *metaCollector) processPodJobLink(data *k8smeta.ObjectWrapper, method st
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
 		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, obj.Job.Kind, obj.Job.Namespace, obj.Job.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "related_to")
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Job2Pod)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}

--- a/plugins/input/kubernetesmetav2/meta_collector_batch.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_batch.go
@@ -63,7 +63,7 @@ func (m *metaCollector) processJobCronJobLink(data *k8smeta.ObjectWrapper, metho
 	if obj, ok := data.Raw.(*k8smeta.JobCronJob); ok {
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
-		m.processEntityLinkCommonPart(log.Contents, obj.Job.Kind, obj.Job.Namespace, obj.Job.Name, obj.CronJob.Kind, obj.CronJob.Namespace, obj.CronJob.Name, method, data.FirstObservedTime, data.LastObservedTime)
+		m.processEntityLinkCommonPart(log.Contents, obj.CronJob.Kind, obj.CronJob.Namespace, obj.CronJob.Name, obj.Job.Kind, obj.Job.Namespace, obj.Job.Name, method, data.FirstObservedTime, data.LastObservedTime)
 		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.CronJob2Job)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
@@ -75,7 +75,7 @@ func (m *metaCollector) processPodJobLink(data *k8smeta.ObjectWrapper, method st
 	if obj, ok := data.Raw.(*k8smeta.PodJob); ok {
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
-		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, obj.Job.Kind, obj.Job.Namespace, obj.Job.Name, method, data.FirstObservedTime, data.LastObservedTime)
+		m.processEntityLinkCommonPart(log.Contents, obj.Job.Kind, obj.Job.Namespace, obj.Job.Name, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, method, data.FirstObservedTime, data.LastObservedTime)
 		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Job2Pod)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}

--- a/plugins/input/kubernetesmetav2/meta_collector_core.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_core.go
@@ -242,8 +242,8 @@ func (m *metaCollector) processPodNodeLink(data *k8smeta.ObjectWrapper, method s
 	if obj, ok := data.Raw.(*k8smeta.NodePod); ok {
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
-		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, obj.Node.Kind, "", obj.Node.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "runs")
+		m.processEntityLinkCommonPart(log.Contents, obj.Node.Kind, "", obj.Node.Name, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, method, data.FirstObservedTime, data.LastObservedTime)
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Node2Pod)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}
@@ -255,7 +255,7 @@ func (m *metaCollector) processPodPVCLink(data *k8smeta.ObjectWrapper, method st
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
 		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, obj.PersistentVolumeClaim.Kind, obj.PersistentVolumeClaim.Namespace, obj.PersistentVolumeClaim.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "related_to")
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Pod2PersistentVolumeClaim)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}
@@ -267,7 +267,7 @@ func (m *metaCollector) processPodConfigMapLink(data *k8smeta.ObjectWrapper, met
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
 		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, obj.ConfigMap.Kind, obj.ConfigMap.Namespace, obj.ConfigMap.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "related_to")
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Pod2ConfigMap)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}
@@ -278,8 +278,8 @@ func (m *metaCollector) processPodServiceLink(data *k8smeta.ObjectWrapper, metho
 	if obj, ok := data.Raw.(*k8smeta.PodService); ok {
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
-		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, obj.Service.Kind, obj.Service.Namespace, obj.Service.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "related_to")
+		m.processEntityLinkCommonPart(log.Contents, obj.Service.Kind, obj.Service.Namespace, obj.Service.Name, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, method, data.FirstObservedTime, data.LastObservedTime)
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Service2Pod)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}
@@ -291,7 +291,7 @@ func (m *metaCollector) processPodContainerLink(data *k8smeta.ObjectWrapper, met
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
 		m.processEntityLinkCommonPart(log.Contents, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, "container", obj.Pod.Namespace, obj.Pod.Name+obj.Container.Name, method, data.FirstObservedTime, data.LastObservedTime)
-		log.Contents.Add(entityLinkRelationTypeFieldName, "contains")
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Pod2Container)
 		log.Timestamp = uint64(time.Now().Unix())
 		return []models.PipelineEvent{log}
 	}

--- a/plugins/input/kubernetesmetav2/meta_collector_core.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_core.go
@@ -239,7 +239,7 @@ func (m *metaCollector) processPersistentVolumeClaimEntity(data *k8smeta.ObjectW
 }
 
 func (m *metaCollector) processPodNodeLink(data *k8smeta.ObjectWrapper, method string) []models.PipelineEvent {
-	if obj, ok := data.Raw.(*k8smeta.NodePod); ok {
+	if obj, ok := data.Raw.(*k8smeta.PodNode); ok {
 		log := &models.Log{}
 		log.Contents = models.NewLogContents()
 		m.processEntityLinkCommonPart(log.Contents, obj.Node.Kind, "", obj.Node.Name, obj.Pod.Kind, obj.Pod.Namespace, obj.Pod.Name, method, data.FirstObservedTime, data.LastObservedTime)

--- a/plugins/input/kubernetesmetav2/meta_collector_networking.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_networking.go
@@ -25,3 +25,15 @@ func (m *metaCollector) processIngressEntity(data *k8smeta.ObjectWrapper, method
 	}
 	return nil
 }
+
+func (m *metaCollector) processIngressServiceLink(data *k8smeta.ObjectWrapper, method string) []models.PipelineEvent {
+	if obj, ok := data.Raw.(*k8smeta.IngressService); ok {
+		log := &models.Log{}
+		log.Contents = models.NewLogContents()
+		m.processEntityLinkCommonPart(log.Contents, obj.Ingress.Name, obj.Ingress.Kind, obj.Ingress.Namespace, obj.Service.Name, obj.Service.Kind, obj.Service.Namespace, method, data.FirstObservedTime, data.LastObservedTime)
+		log.Contents.Add(entityLinkRelationTypeFieldName, m.serviceK8sMeta.Ingress2Service)
+		log.Timestamp = uint64(time.Now().Unix())
+		return []models.PipelineEvent{log}
+	}
+	return nil
+}

--- a/plugins/input/kubernetesmetav2/service_meta.go
+++ b/plugins/input/kubernetesmetav2/service_meta.go
@@ -31,6 +31,20 @@ type ServiceK8sMeta struct {
 	StorageClass          bool
 	Ingress               bool
 	Container             bool
+	// link switch
+	Node2Pod                  string
+	Deployment2Pod            string
+	ReplicaSet2Pod            string
+	Deployment2ReplicaSet     string
+	StatefulSet2Pod           string
+	DaemonSet2Pod             string
+	Service2Pod               string
+	Pod2Container             string
+	CronJob2Job               string
+	Job2Pod                   string
+	Ingress2Service           string
+	Pod2PersistentVolumeClaim string
+	Pod2ConfigMap             string
 	// other
 	context       pipeline.Context
 	metaManager   *k8smeta.MetaManager


### PR DESCRIPTION
## 问题一
1. K8s Meta中的relation type是个没有标准答案的东西，为了避免之后再反复调整需要重新出版本，不在代码里hardcode，移到配置文件中，让用户自己指定。
2. 之前配置了relation两端的entity之后，自动就生成relation了。relation没法删除。
解决方案：支持K8s Meta中所有关系名可配置化，不配置就默认删除。

## 问题二
一个node上的多个Pod非常可能会复用node ip作为pod ip，导致通过Host IP查询到的K8s Meta数据不全。
解决方案：以Pod UID作为返回值的key。