### PR TITLE
register input runner on demand instead of hard code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -67,17 +67,17 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-InsertNewlineAtEOF: true # uncomment when clang-format is upgraded to 16.0.0
+InsertNewlineAtEOF: true
 IncludeCategories:
   - Regex: '^<.*\.h>'
     Priority: 1
-  - Regex: '^<co.*>' # exclude non-c standard library headers like <complex> or <conditional_variable>
+  - Regex: '^<(condition_variable|complex|chrono)>' # exclude non-c standard library headers
     Priority: 2
   - Regex: '^<c.*'
     Priority: 1
   - Regex: '^<.*'
     Priority: 2
-  - Regex: '^"(spl|curl|spdlog|gflags|gperftools|gtest|boost|json|rapidjson|yaml-cpp|re2|lz4|zstd|zlib).*'
+  - Regex: '^"(spl|curl|spdlog|gflags|gperftools|gtest|boost|json|rapidjson|yaml-cpp|re2|lz4|zstd|zlib|leveldb).*'
     Priority: 3
   - Regex: '.*'
     Priority: 4

--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -48,7 +48,6 @@
 #include "plugin/flusher/sls/DiskBufferWriter.h"
 #include "plugin/flusher/sls/FlusherSLS.h"
 #include "plugin/input/InputFeedbackInterfaceRegistry.h"
-#include "prometheus/PrometheusInputRunner.h"
 #include "runner/FlusherRunner.h"
 #include "runner/ProcessorRunner.h"
 #include "runner/sink/http/HttpSink.h"

--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -304,6 +304,7 @@ void Application::Start() { // GCOVR_EXCL_START
             SenderQueueManager::GetInstance()->ClearUnusedQueues();
             lastQueueGCTime = curTime;
         }
+        CollectionPipelineManager::GetInstance()->InputRunnerEventGC();
         if (curTime - lastUpdateMetricTime >= 40) {
             CheckCriticalCondition(curTime);
             lastUpdateMetricTime = curTime;
@@ -325,7 +326,6 @@ void Application::Start() { // GCOVR_EXCL_START
 
         // destruct event handlers here so that it will not block file reading task
         ConfigManager::GetInstance()->DeleteHandlers();
-        PrometheusInputRunner::GetInstance()->CheckGC();
 
         this_thread::sleep_for(chrono::seconds(1));
     }

--- a/core/checkpoint/CheckpointManagerV2.cpp
+++ b/core/checkpoint/CheckpointManagerV2.cpp
@@ -14,7 +14,7 @@
 
 #include "CheckpointManagerV2.h"
 
-#include <leveldb/write_batch.h>
+#include "leveldb/write_batch.h"
 
 #include "app_config/AppConfig.h"
 #include "checkpoint/CheckPointManager.h"

--- a/core/checkpoint/CheckpointManagerV2.h
+++ b/core/checkpoint/CheckpointManagerV2.h
@@ -15,14 +15,14 @@
  */
 
 #pragma once
-#include <leveldb/db.h>
-
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
+
+#include "leveldb/db.h"
 
 #include "plugin/input/InputFile.h"
 #include "protobuf/sls/checkpoint.pb.h"

--- a/core/collection_pipeline/CollectionPipeline.cpp
+++ b/core/collection_pipeline/CollectionPipeline.cpp
@@ -122,7 +122,6 @@ bool CollectionPipeline::Init(CollectionConfig&& config) {
         } else {
             AddPluginToGoPipeline(pluginType, detail, "inputs", mGoPipelineWithInput);
         }
-        ++mPluginCntMap["inputs"][pluginType];
     }
 
     for (size_t i = 0; i < config.mProcessors.size(); ++i) {
@@ -146,7 +145,6 @@ bool CollectionPipeline::Init(CollectionConfig&& config) {
                 AddPluginToGoPipeline(pluginType, detail, "processors", mGoPipelineWithoutInput);
             }
         }
-        ++mPluginCntMap["processors"][pluginType];
     }
 
     if (config.mAggregators.empty() && config.IsFlushingThroughGoPipelineExisted()) {
@@ -163,7 +161,6 @@ bool CollectionPipeline::Init(CollectionConfig&& config) {
         } else {
             AddPluginToGoPipeline(pluginType, detail, "aggregators", mGoPipelineWithoutInput);
         }
-        ++mPluginCntMap["aggregators"][pluginType];
     }
 
     for (size_t i = 0; i < config.mFlushers.size(); ++i) {
@@ -195,7 +192,6 @@ bool CollectionPipeline::Init(CollectionConfig&& config) {
                 AddPluginToGoPipeline(pluginType, detail, "flushers", mGoPipelineWithoutInput);
             }
         }
-        ++mPluginCntMap["flushers"][pluginType];
     }
 
     // route is only enabled in native flushing mode, thus the index in config is the same as that in mFlushers
@@ -213,7 +209,6 @@ bool CollectionPipeline::Init(CollectionConfig&& config) {
         if (!mGoPipelineWithoutInput.isNull()) {
             AddPluginToGoPipeline(pluginType, detail, "extensions", mGoPipelineWithoutInput);
         }
-        ++mPluginCntMap["extensions"][pluginType];
     }
 
     // global module must be initialized at last, since native input or flusher plugin may generate global param in Go
@@ -495,7 +490,7 @@ void CollectionPipeline::MergeGoPipeline(const Json::Value& src, Json::Value& ds
     }
 }
 
-std::string CollectionPipeline::GenPluginTypeWithID(std::string pluginType, std::string pluginID) {
+string CollectionPipeline::GenPluginTypeWithID(const string& pluginType, const string& pluginID) {
     return pluginType + "/" + pluginID;
 }
 
@@ -589,13 +584,13 @@ bool CollectionPipeline::LoadGoPipelines() const {
     return true;
 }
 
-std::string CollectionPipeline::GetNowPluginID() {
-    return std::to_string(mPluginID.load());
+string CollectionPipeline::GetNowPluginID() {
+    return to_string(mPluginID.load());
 }
 
 PluginInstance::PluginMeta CollectionPipeline::GenNextPluginMeta(bool lastOne) {
     mPluginID.fetch_add(1);
-    return PluginInstance::PluginMeta(std::to_string(mPluginID.load()));
+    return PluginInstance::PluginMeta(to_string(mPluginID.load()));
 }
 
 void CollectionPipeline::WaitAllItemsInProcessFinished() {
@@ -608,7 +603,7 @@ void CollectionPipeline::WaitAllItemsInProcessFinished() {
             LOG_ERROR(sLogger, ("pipeline stop", "too slow")("config", mName)("cost", duration));
             AlarmManager::GetInstance()->SendAlarm(CONFIG_UPDATE_ALARM,
                                                    string("pipeline stop too slow, config: ") + mName
-                                                       + "; cost:" + std::to_string(duration),
+                                                       + "; cost:" + to_string(duration),
                                                    mContext.GetRegion(),
                                                    mContext.GetProjectName(),
                                                    mContext.GetConfigName(),

--- a/core/collection_pipeline/CollectionPipeline.cpp
+++ b/core/collection_pipeline/CollectionPipeline.cpp
@@ -16,9 +16,9 @@
 
 #include "collection_pipeline/CollectionPipeline.h"
 
-#include <chrono>
 #include <cstdint>
 
+#include <chrono>
 #include <memory>
 #include <utility>
 

--- a/core/collection_pipeline/CollectionPipeline.h
+++ b/core/collection_pipeline/CollectionPipeline.h
@@ -16,9 +16,10 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
+#include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "json/json.h"
@@ -38,6 +39,8 @@ namespace logtail {
 
 class CollectionPipeline {
 public:
+    static std::string GenPluginTypeWithID(const std::string& pluginType, const std::string& pluginID);
+
     // copy/move control functions are deleted because of mContext
     bool Init(CollectionConfig&& config);
     void Start();
@@ -69,7 +72,6 @@ public:
     const std::vector<std::unique_ptr<InputInstance>>& GetInputs() const { return mInputs; }
 
     std::string GetNowPluginID();
-    static std::string GenPluginTypeWithID(std::string pluginType, std::string pluginID);
     PluginInstance::PluginMeta GenNextPluginMeta(bool lastOne);
 
     bool HasGoPipelineWithInput() const { return !mGoPipelineWithInput.isNull(); }

--- a/core/collection_pipeline/CollectionPipeline.h
+++ b/core/collection_pipeline/CollectionPipeline.h
@@ -64,9 +64,6 @@ public:
     const std::optional<std::string>& GetSingletonInput() const { return mSingletonInput; }
     const std::vector<std::unique_ptr<FlusherInstance>>& GetFlushers() const { return mFlushers; }
     bool IsFlushingThroughGoPipeline() const { return !mGoPipelineWithoutInput.isNull(); }
-    const std::unordered_map<std::string, std::unordered_map<std::string, uint32_t>>& GetPluginStatistics() const {
-        return mPluginCntMap;
-    }
 
     // only for input_file
     const std::vector<std::unique_ptr<InputInstance>>& GetInputs() const { return mInputs; }
@@ -101,7 +98,6 @@ private:
     Json::Value mGoPipelineWithInput;
     Json::Value mGoPipelineWithoutInput;
     mutable CollectionPipelineContext mContext;
-    std::unordered_map<std::string, std::unordered_map<std::string, uint32_t>> mPluginCntMap;
     std::unique_ptr<Json::Value> mConfig;
     std::optional<std::string> mSingletonInput;
     std::atomic_uint16_t mPluginID;

--- a/core/collection_pipeline/CollectionPipelineManager.cpp
+++ b/core/collection_pipeline/CollectionPipelineManager.cpp
@@ -39,16 +39,6 @@ using namespace std;
 
 namespace logtail {
 
-CollectionPipelineManager::CollectionPipelineManager()
-    : mInputRunners({
-          PrometheusInputRunner::GetInstance(),
-#if defined(__linux__) && !defined(__ANDROID__)
-          ebpf::eBPFServer::GetInstance(),
-          HostMonitorInputRunner::GetInstance(),
-#endif
-      }) {
-}
-
 static shared_ptr<CollectionPipeline> sEmptyPipeline;
 
 void logtail::CollectionPipelineManager::UpdatePipelines(CollectionConfigDiff& diff) {

--- a/core/collection_pipeline/CollectionPipelineManager.cpp
+++ b/core/collection_pipeline/CollectionPipelineManager.cpp
@@ -21,14 +21,10 @@
 #include <shared_mutex>
 #include <unordered_map>
 
+#include "common/timer/Timer.h"
+#include "config/feedbacker/ConfigFeedbackReceiver.h"
 #include "file_server/FileServer.h"
 #include "go_pipeline/LogtailPlugin.h"
-#include "host_monitor/HostMonitorInputRunner.h"
-#include "prometheus/PrometheusInputRunner.h"
-#if defined(__linux__) && !defined(__ANDROID__)
-#include "ebpf/eBPFServer.h"
-#endif
-#include "config/feedbacker/ConfigFeedbackReceiver.h"
 #include "runner/ProcessorRunner.h"
 #if defined(__ENTERPRISE__) && defined(__linux__) && !defined(__ANDROID__)
 #include "app_config/AppConfig.h"
@@ -60,7 +56,6 @@ void logtail::CollectionPipelineManager::UpdatePipelines(CollectionConfigDiff& d
     for (const auto& name : diff.mRemoved) {
         auto iter = mPipelineNameEntityMap.find(name);
         iter->second->Stop(true);
-        DecreasePluginUsageCnt(iter->second->GetPluginStatistics());
         iter->second->RemoveProcessQueue();
         {
             unique_lock<shared_mutex> lock(mPipelineNameEntityMapMutex);
@@ -91,12 +86,10 @@ void logtail::CollectionPipelineManager::UpdatePipelines(CollectionConfigDiff& d
                   "stop the old pipeline and start the new one")("config", config.mName));
         auto iter = mPipelineNameEntityMap.find(config.mName);
         iter->second->Stop(false);
-        DecreasePluginUsageCnt(iter->second->GetPluginStatistics());
         {
             unique_lock<shared_mutex> lock(mPipelineNameEntityMapMutex);
             mPipelineNameEntityMap[config.mName] = p;
         }
-        IncreasePluginUsageCnt(p->GetPluginStatistics());
         p->Start();
         ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(config.mName,
                                                                                      ConfigFeedbackStatus::APPLIED);
@@ -123,7 +116,6 @@ void logtail::CollectionPipelineManager::UpdatePipelines(CollectionConfigDiff& d
             unique_lock<shared_mutex> lock(mPipelineNameEntityMapMutex);
             mPipelineNameEntityMap[config.mName] = p;
         }
-        IncreasePluginUsageCnt(p->GetPluginStatistics());
         p->Start();
         ConfigFeedbackReceiver::GetInstance().FeedbackContinuousPipelineConfigStatus(config.mName,
                                                                                      ConfigFeedbackStatus::APPLIED);
@@ -174,17 +166,6 @@ vector<string> CollectionPipelineManager::GetAllConfigNames() const {
     return res;
 }
 
-string CollectionPipelineManager::GetPluginStatistics() const {
-    Json::Value root;
-    ScopedSpinLock lock(mPluginCntMapLock);
-    for (const auto& item : mPluginCntMap) {
-        for (const auto& plugin : item.second) {
-            root[item.first][plugin.first] = Json::Value(plugin.second);
-        }
-    }
-    return root.toStyledString();
-}
-
 void CollectionPipelineManager::StopAllPipelines() {
     LOG_INFO(sLogger, ("stop all pipelines", "starts"));
     for (auto& item : mInputRunners) {
@@ -223,24 +204,6 @@ void CollectionPipelineManager::FlushAllBatch() {
     shared_lock<shared_mutex> lock(mPipelineNameEntityMapMutex);
     for (const auto& item : mPipelineNameEntityMap) {
         item.second->FlushBatch();
-    }
-}
-
-void CollectionPipelineManager::IncreasePluginUsageCnt(
-    const unordered_map<string, unordered_map<string, uint32_t>>& statistics) {
-    for (const auto& item : statistics) {
-        for (const auto& plugin : item.second) {
-            mPluginCntMap[item.first][plugin.first] += plugin.second;
-        }
-    }
-}
-
-void CollectionPipelineManager::DecreasePluginUsageCnt(
-    const unordered_map<string, unordered_map<string, uint32_t>>& statistics) {
-    for (const auto& item : statistics) {
-        for (const auto& plugin : item.second) {
-            mPluginCntMap[item.first][plugin.first] -= plugin.second;
-        }
     }
 }
 

--- a/core/collection_pipeline/CollectionPipelineManager.h
+++ b/core/collection_pipeline/CollectionPipelineManager.h
@@ -38,6 +38,14 @@ public:
         return &instance;
     }
 
+    void RegisterInputRunner(InputRunner* runner) { mInputRunners.push_back(runner); }
+
+    void InputRunnerEventGC() {
+        for (auto runner : mInputRunners) {
+            runner->EventGC();
+        }
+    }
+
     void UpdatePipelines(CollectionConfigDiff& diff);
     const std::shared_ptr<CollectionPipeline>& FindConfigByName(const std::string& configName) const;
     std::vector<std::string> GetAllConfigNames() const;
@@ -52,7 +60,7 @@ public:
     void ClearAllPipelines(); // only used when exiting
 
 private:
-    CollectionPipelineManager();
+    CollectionPipelineManager() = default;
     ~CollectionPipelineManager() = default;
 
     virtual std::shared_ptr<CollectionPipeline> BuildPipeline(CollectionConfig&& config); // virtual for ut

--- a/core/collection_pipeline/CollectionPipelineManager.h
+++ b/core/collection_pipeline/CollectionPipelineManager.h
@@ -16,13 +16,15 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <memory>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "collection_pipeline/CollectionPipeline.h"
-#include "common/Lock.h"
 #include "config/ConfigDiff.h"
 #include "runner/InputRunner.h"
 
@@ -39,43 +41,34 @@ public:
     }
 
     void RegisterInputRunner(InputRunner* runner) { mInputRunners.push_back(runner); }
-
     void InputRunnerEventGC() {
         for (auto runner : mInputRunners) {
             runner->EventGC();
         }
     }
 
-    void UpdatePipelines(CollectionConfigDiff& diff);
     const std::shared_ptr<CollectionPipeline>& FindConfigByName(const std::string& configName) const;
+    void UpdatePipelines(CollectionConfigDiff& diff);
+    void StopAllPipelines();
+    void ClearAllPipelines();
     std::vector<std::string> GetAllConfigNames() const;
-    std::string GetPluginStatistics() const;
 
     // for shennong only
     const std::unordered_map<std::string, std::shared_ptr<CollectionPipeline>>& GetAllPipelines() const {
         return mPipelineNameEntityMap;
     }
-    // 过渡使用
-    void StopAllPipelines();
-    void ClearAllPipelines(); // only used when exiting
 
 private:
     CollectionPipelineManager() = default;
     ~CollectionPipelineManager() = default;
 
     virtual std::shared_ptr<CollectionPipeline> BuildPipeline(CollectionConfig&& config); // virtual for ut
-    void IncreasePluginUsageCnt(
-        const std::unordered_map<std::string, std::unordered_map<std::string, uint32_t>>& statistics);
-    void DecreasePluginUsageCnt(
-        const std::unordered_map<std::string, std::unordered_map<std::string, uint32_t>>& statistics);
     void FlushAllBatch();
     // TODO: 长期过渡使用
     bool CheckIfFileServerUpdated(CollectionConfigDiff& diff);
 
     mutable std::shared_mutex mPipelineNameEntityMapMutex;
     std::unordered_map<std::string, std::shared_ptr<CollectionPipeline>> mPipelineNameEntityMap;
-    mutable SpinLock mPluginCntMapLock;
-    std::unordered_map<std::string, std::unordered_map<std::string, uint32_t>> mPluginCntMap;
 
     std::vector<InputRunner*> mInputRunners;
 

--- a/core/collection_pipeline/limiter/ConcurrencyLimiter.h
+++ b/core/collection_pipeline/limiter/ConcurrencyLimiter.h
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstdint>
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
 #include <string>
 

--- a/core/collection_pipeline/queue/ProcessQueueItem.h
+++ b/core/collection_pipeline/queue/ProcessQueueItem.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <chrono>
-
 #include <memory>
 
 #include "collection_pipeline/CollectionPipelineManager.h"

--- a/core/collection_pipeline/queue/SenderQueueItem.h
+++ b/core/collection_pipeline/queue/SenderQueueItem.h
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstdint>
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <string>
 

--- a/core/collection_pipeline/serializer/Serializer.h
+++ b/core/collection_pipeline/serializer/Serializer.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <chrono>
-
 #include <string>
 
 #include "collection_pipeline/batch/BatchedEvents.h"

--- a/core/common/LRUCache.h
+++ b/core/common/LRUCache.h
@@ -30,11 +30,11 @@
  */
 
 #pragma once
-#include <chrono>
 #include <cstdint>
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <list>
 #include <mutex>
 #include <stdexcept>

--- a/core/common/TimeUtil.cpp
+++ b/core/common/TimeUtil.cpp
@@ -14,11 +14,11 @@
 
 #include "TimeUtil.h"
 
-#include <chrono>
 #include <cmath>
 #include <memory.h>
 
 #include <atomic>
+#include <chrono>
 #include <limits>
 #if defined(__linux__)
 #include <sys/sysinfo.h>

--- a/core/common/WaitObject.h
+++ b/core/common/WaitObject.h
@@ -15,9 +15,9 @@
  */
 
 #pragma once
-#include <chrono>
 #include <cstdint>
 
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
 

--- a/core/common/http/HttpRequest.h
+++ b/core/common/http/HttpRequest.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstdint>
 
+#include <chrono>
 #include <map>
 #include <optional>
 #include <string>

--- a/core/common/http/HttpResponse.h
+++ b/core/common/http/HttpResponse.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstdint>
 
+#include <chrono>
 #include <functional>
 #include <map>
 #include <memory>

--- a/core/ebpf/SourceManager.h
+++ b/core/ebpf/SourceManager.h
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstring>
 #include <dlfcn.h>
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <iostream>
 #include <map>
 #include <string>

--- a/core/host_monitor/HostMonitorInputRunner.cpp
+++ b/core/host_monitor/HostMonitorInputRunner.cpp
@@ -16,9 +16,9 @@
 
 #include "host_monitor/HostMonitorInputRunner.h"
 
-#include <chrono>
 #include <cstdint>
 
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>

--- a/core/host_monitor/HostMonitorInputRunner.h
+++ b/core/host_monitor/HostMonitorInputRunner.h
@@ -16,9 +16,8 @@
 
 #pragma once
 
-#include <chrono>
-
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <shared_mutex>
 #include <string>

--- a/core/host_monitor/HostMonitorTimerEvent.h
+++ b/core/host_monitor/HostMonitorTimerEvent.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <chrono>
-
 #include <string>
 
 #include "collection_pipeline/queue/QueueKey.h"

--- a/core/host_monitor/collector/ProcessEntityCollector.cpp
+++ b/core/host_monitor/collector/ProcessEntityCollector.cpp
@@ -16,12 +16,12 @@
 
 #include "ProcessEntityCollector.h"
 
-#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <sched.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <exception>
 #include <functional>
 #include <memory>

--- a/core/metadata/K8sMetadata.cpp
+++ b/core/metadata/K8sMetadata.cpp
@@ -13,9 +13,9 @@
 
 #include "K8sMetadata.h"
 
-#include <chrono>
 #include <ctime>
 
+#include <chrono>
 #include <thread>
 
 #include "common/MachineInfoUtil.h"

--- a/core/monitor/metric_models/MetricTypes.h
+++ b/core/monitor/metric_models/MetricTypes.h
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstdint>
 
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>

--- a/core/prometheus/PrometheusInputRunner.cpp
+++ b/core/prometheus/PrometheusInputRunner.cpp
@@ -17,7 +17,6 @@
 #include "PrometheusInputRunner.h"
 
 #include <chrono>
-
 #include <memory>
 #include <string>
 

--- a/core/prometheus/PrometheusInputRunner.cpp
+++ b/core/prometheus/PrometheusInputRunner.cpp
@@ -240,6 +240,10 @@ bool PrometheusInputRunner::HasRegisteredPlugins() const {
     return !mTargetSubscriberSchedulerMap.empty();
 }
 
+void PrometheusInputRunner::EventGC() {
+    mEventPool.CheckGC();
+}
+
 HttpResponse PrometheusInputRunner::SendRegisterMessage(const string& url) const {
     HttpResponse httpResponse;
 #ifdef APSARA_UNIT_TEST_MAIN
@@ -287,7 +291,4 @@ string PrometheusInputRunner::GetAllProjects() {
     return result;
 }
 
-void PrometheusInputRunner::CheckGC() {
-    mEventPool.CheckGC();
-}
 }; // namespace logtail

--- a/core/prometheus/PrometheusInputRunner.h
+++ b/core/prometheus/PrometheusInputRunner.h
@@ -41,7 +41,6 @@ public:
         static PrometheusInputRunner sInstance;
         return &sInstance;
     }
-    void CheckGC();
 
     // input plugin update
     void UpdateScrapeInput(std::shared_ptr<TargetSubscriberScheduler> targetSubscriber,
@@ -53,6 +52,7 @@ public:
     void Init() override;
     void Stop() override;
     bool HasRegisteredPlugins() const override;
+    void EventGC() override;
 
 private:
     PrometheusInputRunner();

--- a/core/prometheus/async/PromHttpRequest.cpp
+++ b/core/prometheus/async/PromHttpRequest.cpp
@@ -1,8 +1,8 @@
 #include "prometheus/async/PromHttpRequest.h"
 
-#include <chrono>
 #include <cstdint>
 
+#include <chrono>
 #include <string>
 #include <utility>
 

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
@@ -16,9 +16,9 @@
 
 #include "prometheus/schedulers/TargetSubscriberScheduler.h"
 
-#include <chrono>
 #include <cstdlib>
 
+#include <chrono>
 #include <memory>
 #include <string>
 

--- a/core/runner/InputRunner.cpp
+++ b/core/runner/InputRunner.cpp
@@ -1,0 +1,27 @@
+// Copyright 2024 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runner/InputRunner.h"
+
+#include "collection_pipeline/CollectionPipelineManager.h"
+
+using namespace std;
+
+namespace logtail {
+
+InputRunner::InputRunner() {
+    CollectionPipelineManager::GetInstance()->RegisterInputRunner(this);
+}
+
+} // namespace logtail

--- a/core/runner/InputRunner.h
+++ b/core/runner/InputRunner.h
@@ -20,11 +20,13 @@ namespace logtail {
 
 class InputRunner {
 public:
+    InputRunner();
     virtual ~InputRunner() = default;
 
     virtual void Init() = 0;
     virtual void Stop() = 0;
     virtual bool HasRegisteredPlugins() const = 0;
+    virtual void EventGC() {}
 };
 
 } // namespace logtail

--- a/core/unittest/config/PipelineManagerMock.h
+++ b/core/unittest/config/PipelineManagerMock.h
@@ -45,7 +45,6 @@ public:
             it.second->Stop(true);
         }
         mPipelineNameEntityMap.clear();
-        mPluginCntMap.clear();
     }
 
 private:

--- a/core/unittest/host_monitor/HostMonitorInputRunnerUnittest.cpp
+++ b/core/unittest/host_monitor/HostMonitorInputRunnerUnittest.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-
 #include <memory>
 
 #include "HostMonitorInputRunner.h"

--- a/core/unittest/polling/PollingPreservedDirDepthUnittest.cpp
+++ b/core/unittest/polling/PollingPreservedDirDepthUnittest.cpp
@@ -1,6 +1,5 @@
 
 #include <chrono> // Include the <chrono> header for sleep_for
-
 #include <thread> // Include the <thread> header for this_thread
 
 #include "json/json.h"

--- a/core/unittest/processor/ProcessorParseContainerLogNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseContainerLogNativeUnittest.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <chrono>
 #include <cstdlib>
 
 #include <algorithm>
+#include <chrono>
 #include <iostream>
 #include <random>
 #include <string>


### PR DESCRIPTION
之前input runner注册是直接写死了，不管有没有相关的插件，所有的input runner都会构造一个对象，像inputhostmonitor这种构造函数会起线程池的，显然没有用到这个插件的时候是浪费资源的，所以需要优化input runner注册方式，等真的用到的时候再注册。