### PR TITLE
Chore: Add env to control max sample length

### DIFF
--- a/core/prometheus/component/StreamScraper.cpp
+++ b/core/prometheus/component/StreamScraper.cpp
@@ -17,6 +17,7 @@
 #include "runner/ProcessorRunner.h"
 
 DEFINE_FLAG_INT64(prom_stream_bytes_size, "stream bytes size", 1024 * 1024);
+DEFINE_FLAG_INT64(prom_max_sample_length, "max sample length", 8 * 1024);
 
 DEFINE_FLAG_BOOL(enable_prom_stream_scrape, "enable prom stream scrape", true);
 
@@ -48,8 +49,8 @@ size_t StreamScraper::MetricWriteCallback(char* buffer, size_t size, size_t nmem
 
     if (begin < sizes) {
         body->mCache.append(buffer + begin, sizes - begin);
-        // limit the last line cache size to 8K bytes
-        if (body->mCache.size() > 8192) {
+        // limit the last line cache size to prom_max_sample_length bytes
+        if (body->mCache.size() > (size_t)INT64_FLAG(prom_max_sample_length)) {
             LOG_WARNING(sLogger, ("stream scraper", "cache is too large, drop it."));
             body->mCache.clear();
         }

--- a/core/prometheus/component/StreamScraper.h
+++ b/core/prometheus/component/StreamScraper.h
@@ -22,17 +22,7 @@ public:
                   size_t inputIndex,
                   std::string hash,
                   EventPool* eventPool,
-                  std::chrono::system_clock::time_point scrapeTime)
-        : mEventGroup(PipelineEventGroup(std::make_shared<SourceBuffer>())),
-          mHash(std::move(hash)),
-          mEventPool(eventPool),
-          mQueueKey(queueKey),
-          mInputIndex(inputIndex),
-          mTargetLabels(std::move(labels)) {
-        mScrapeTimestampMilliSec
-            = std::chrono::duration_cast<std::chrono::milliseconds>(scrapeTime.time_since_epoch()).count();
-    }
-
+                  std::chrono::system_clock::time_point scrapeTime);
     static size_t MetricWriteCallback(char* buffer, size_t size, size_t nmemb, void* data);
     void FlushCache();
     void SendMetrics();
@@ -40,6 +30,7 @@ public:
     void SetAutoMetricMeta(double scrapeDurationSeconds, bool upState, const std::string& scrapeState);
 
     size_t mRawSize = 0;
+    static size_t mMaxSampleLength;
     uint64_t mStreamIndex = 0;
 
 private:


### PR DESCRIPTION
When the length of a single sample exceeds 8192 bytes, the scraper will drop the sample. Set this value via an environment variable to make it configurable.