### PR TITLE
fix use after free core in timeout flush manager during pipeline update

### DIFF
--- a/core/collection_pipeline/batch/TimeoutFlushManager.h
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.h
@@ -58,7 +58,7 @@ private:
     TimeoutFlushManager() = default;
     ~TimeoutFlushManager() = default;
 
-    std::mutex mMux;
+    std::recursive_mutex mMux;
     std::map<std::string, std::map<std::pair<size_t, size_t>, TimeoutRecord>> mTimeoutRecords;
 
 #ifdef APSARA_UNIT_TEST_MAIN


### PR DESCRIPTION
- 问题：处理线程会定时调用FlushTimeouBatch，原有代码为了避免死锁，将遍历map和执行flush操作分开来了，但是导致了非原子性。如果遍历完map后，pipeline正好析够掉，那么flush的时候flusher指针就是非法的。
- 影响：配置更新时小概率会触发，版本为loongcollector
- 解决：普通锁改成可重入锁，保证FlushTimeouBatch的原子性