### PR TITLE
fix deadlock in TimeoutFlush

### DIFF
--- a/core/collection_pipeline/CollectionPipeline.cpp
+++ b/core/collection_pipeline/CollectionPipeline.cpp
@@ -439,7 +439,11 @@ bool CollectionPipeline::FlushBatch() {
     for (auto& flusher : mFlushers) {
         allSucceeded = flusher->FlushAll() && allSucceeded;
     }
-    TimeoutFlushManager::GetInstance()->ClearRecords(mName);
+    vector<const Flusher*> flushers;
+    for (const auto& flusher : mFlushers) {
+        flushers.push_back(flusher->GetPlugin());
+    }
+    TimeoutFlushManager::GetInstance()->ClearRecords(mName, flushers);
     return allSucceeded;
 }
 

--- a/core/collection_pipeline/CollectionPipeline.cpp
+++ b/core/collection_pipeline/CollectionPipeline.cpp
@@ -359,7 +359,7 @@ bool CollectionPipeline::Init(CollectionConfig&& config) {
 }
 
 void CollectionPipeline::Start() {
-    // #ifndef APSARA_UNIT_TEST_MAIN
+    TimeoutFlushManager::GetInstance()->RegisterFlushers(mName, mFlushers);
     //  TODO: 应该保证指定时间内返回，如果无法返回，将配置放入startDisabled里
     for (const auto& flusher : mFlushers) {
         flusher->Start();
@@ -381,7 +381,6 @@ void CollectionPipeline::Start() {
 
     SET_GAUGE(mStartTime,
               chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count());
-    // #endif
     LOG_INFO(sLogger, ("pipeline start", "succeeded")("config", mName));
 }
 
@@ -439,11 +438,7 @@ bool CollectionPipeline::FlushBatch() {
     for (auto& flusher : mFlushers) {
         allSucceeded = flusher->FlushAll() && allSucceeded;
     }
-    vector<const Flusher*> flushers;
-    for (const auto& flusher : mFlushers) {
-        flushers.push_back(flusher->GetPlugin());
-    }
-    TimeoutFlushManager::GetInstance()->ClearRecords(mName, flushers);
+    TimeoutFlushManager::GetInstance()->UnregisterFlushers(mName, mFlushers);
     return allSucceeded;
 }
 

--- a/core/collection_pipeline/batch/TimeoutFlushManager.cpp
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.cpp
@@ -48,19 +48,21 @@ void TimeoutFlushManager::FlushTimeoutBatch() {
         }
     }
     {
-        lock_guard<mutex> lock(mDeletedConfigsMux);
+        lock_guard<mutex> lock(mDeletedFlushersMux);
         for (auto& item : records) {
-            if (mDeletedConfigs.find(item.first) == mDeletedConfigs.end()) {
+            if (mDeletedFlushers.find(make_pair(item.first, item.second.first)) == mDeletedFlushers.end()) {
                 item.second.first->Flush(item.second.second);
             }
         }
-        mDeletedConfigs.clear();
+        mDeletedFlushers.clear();
     }
 }
 
-void TimeoutFlushManager::ClearRecords(const string& config) {
-    lock_guard<mutex> lock(mDeletedConfigsMux);
-    mDeletedConfigs.insert(config);
+void TimeoutFlushManager::ClearRecords(const string& config, const vector<const Flusher*>& flushers) {
+    lock_guard<mutex> lock(mDeletedFlushersMux);
+    for (const auto& flusher : flushers) {
+        mDeletedFlushers.emplace(make_pair(config, flusher));
+    }
 }
 
 } // namespace logtail

--- a/core/collection_pipeline/batch/TimeoutFlushManager.cpp
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.cpp
@@ -58,10 +58,17 @@ void TimeoutFlushManager::FlushTimeoutBatch() {
     }
 }
 
-void TimeoutFlushManager::UnregisterFlushers(const string& config, const vector<unique_ptr<FlusherInstance>>& flushers) {
-    lock_guard<mutex> lock(mDeletedFlushersMux);
-    for (const auto& flusher : flushers) {
-        mDeletedFlushers.emplace(make_pair(config, flusher->GetPlugin()));
+void TimeoutFlushManager::UnregisterFlushers(const string& config,
+                                             const vector<unique_ptr<FlusherInstance>>& flushers) {
+    {
+        lock_guard<mutex> lock(mTimeoutRecordsMux);
+        mTimeoutRecords.erase(config);
+    }
+    {
+        lock_guard<mutex> lock(mDeletedFlushersMux);
+        for (const auto& flusher : flushers) {
+            mDeletedFlushers.emplace(make_pair(config, flusher->GetPlugin()));
+        }
     }
 }
 

--- a/core/collection_pipeline/batch/TimeoutFlushManager.cpp
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.cpp
@@ -65,7 +65,7 @@ void TimeoutFlushManager::UnregisterFlushers(const string& config, const vector<
     }
 }
 
-void TimeoutFlushManager::RegisterFlushers(const std::string& config, const vector<unique_ptr<FlusherInstance>>& flushers) {
+void TimeoutFlushManager::RegisterFlushers(const string& config, const vector<unique_ptr<FlusherInstance>>& flushers) {
     lock_guard<mutex> lock(mDeletedFlushersMux);
     for (const auto& flusher : flushers) {
         mDeletedFlushers.erase(make_pair(config, flusher->GetPlugin()));

--- a/core/collection_pipeline/batch/TimeoutFlushManager.cpp
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.cpp
@@ -58,10 +58,17 @@ void TimeoutFlushManager::FlushTimeoutBatch() {
     }
 }
 
-void TimeoutFlushManager::ClearRecords(const string& config, const vector<const Flusher*>& flushers) {
+void TimeoutFlushManager::UnregisterFlushers(const string& config, const vector<unique_ptr<FlusherInstance>>& flushers) {
     lock_guard<mutex> lock(mDeletedFlushersMux);
     for (const auto& flusher : flushers) {
-        mDeletedFlushers.emplace(make_pair(config, flusher));
+        mDeletedFlushers.emplace(make_pair(config, flusher->GetPlugin()));
+    }
+}
+
+void TimeoutFlushManager::RegisterFlushers(const std::string& config, const vector<unique_ptr<FlusherInstance>>& flushers) {
+    lock_guard<mutex> lock(mDeletedFlushersMux);
+    for (const auto& flusher : flushers) {
+        mDeletedFlushers.erase(make_pair(config, flusher->GetPlugin()));
     }
 }
 

--- a/core/collection_pipeline/batch/TimeoutFlushManager.cpp
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.cpp
@@ -39,7 +39,7 @@ void TimeoutFlushManager::FlushTimeoutBatch() {
     multimap<string, pair<Flusher*, size_t>> records;
     {
         lock_guard<mutex> lock(mTimeoutRecordsMux);
-        for (const auto& config: deletedConfigs) {
+        for (const auto& config : deletedConfigs) {
             mTimeoutRecords.erase(config);
         }
         for (auto& item : mTimeoutRecords) {

--- a/core/collection_pipeline/batch/TimeoutFlushManager.h
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "collection_pipeline/plugin/interface/Flusher.h"
+#include "collection_pipeline/plugin/instance/FlusherInstance.h"
 
 namespace logtail {
 
@@ -53,7 +54,8 @@ public:
 
     void UpdateRecord(const std::string& config, size_t index, size_t key, uint32_t timeoutSecs, Flusher* f);
     void FlushTimeoutBatch();
-    void ClearRecords(const std::string& config, const std::vector<const Flusher*>& flushers);
+    void UnregisterFlushers(const std::string& config, const std::vector<std::unique_ptr<FlusherInstance>>& flushers);
+    void RegisterFlushers(const std::string& config, const std::vector<std::unique_ptr<FlusherInstance>>& flushers);
 
 private:
     TimeoutFlushManager() = default;

--- a/core/collection_pipeline/batch/TimeoutFlushManager.h
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.h
@@ -21,6 +21,7 @@
 
 #include <map>
 #include <mutex>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -58,8 +59,13 @@ private:
     TimeoutFlushManager() = default;
     ~TimeoutFlushManager() = default;
 
-    std::recursive_mutex mMux;
+    // visited by all processor runner threads
+    mutable std::mutex mTimeoutRecordsMux;
     std::map<std::string, std::map<std::pair<size_t, size_t>, TimeoutRecord>> mTimeoutRecords;
+
+    // visited by main thread and num 0 processor runner thread
+    mutable std::mutex mDeletedConfigsMux;
+    std::set<std::string> mDeletedConfigs;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class PipelineUnittest;

--- a/core/collection_pipeline/batch/TimeoutFlushManager.h
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.h
@@ -25,8 +25,8 @@
 #include <string>
 #include <vector>
 
-#include "collection_pipeline/plugin/interface/Flusher.h"
 #include "collection_pipeline/plugin/instance/FlusherInstance.h"
+#include "collection_pipeline/plugin/interface/Flusher.h"
 
 namespace logtail {
 

--- a/core/collection_pipeline/batch/TimeoutFlushManager.h
+++ b/core/collection_pipeline/batch/TimeoutFlushManager.h
@@ -53,7 +53,7 @@ public:
 
     void UpdateRecord(const std::string& config, size_t index, size_t key, uint32_t timeoutSecs, Flusher* f);
     void FlushTimeoutBatch();
-    void ClearRecords(const std::string& config);
+    void ClearRecords(const std::string& config, const std::vector<const Flusher*>& flushers);
 
 private:
     TimeoutFlushManager() = default;
@@ -64,8 +64,8 @@ private:
     std::map<std::string, std::map<std::pair<size_t, size_t>, TimeoutRecord>> mTimeoutRecords;
 
     // visited by main thread and num 0 processor runner thread
-    mutable std::mutex mDeletedConfigsMux;
-    std::set<std::string> mDeletedConfigs;
+    mutable std::mutex mDeletedFlushersMux;
+    std::set<std::pair<std::string, const Flusher*>> mDeletedFlushers;
 
 #ifdef APSARA_UNIT_TEST_MAIN
     friend class PipelineUnittest;

--- a/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
+++ b/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
@@ -79,7 +79,7 @@ void TimeoutFlushManagerUnittest::TestFlushTimeoutBatch() {
 
 void TimeoutFlushManagerUnittest::TestClearRecords() {
     TimeoutFlushManager::GetInstance()->UpdateRecord("test_config", 0, 1, 3, sFlusher.get());
-    TimeoutFlushManager::GetInstance()->ClearRecords(
+    TimeoutFlushManager::GetInstance()->UnregisterFlushers(
         "test_config", vector<const Flusher*>{const_cast<const Flusher*>(static_cast<Flusher*>(sFlusher.get()))});
 
     APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mDeletedFlushers.size());

--- a/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
+++ b/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
@@ -79,13 +79,14 @@ void TimeoutFlushManagerUnittest::TestFlushTimeoutBatch() {
 
 void TimeoutFlushManagerUnittest::TestClearRecords() {
     TimeoutFlushManager::GetInstance()->UpdateRecord("test_config", 0, 1, 3, sFlusher.get());
-    TimeoutFlushManager::GetInstance()->ClearRecords("test_config");
+    TimeoutFlushManager::GetInstance()->ClearRecords(
+        "test_config", vector<const Flusher*>{const_cast<const Flusher*>(static_cast<Flusher*>(sFlusher.get()))});
 
-    APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mDeletedConfigs.size());
+    APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mDeletedFlushers.size());
     APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
 
     TimeoutFlushManager::GetInstance()->FlushTimeoutBatch();
-    APSARA_TEST_TRUE(TimeoutFlushManager::GetInstance()->mDeletedConfigs.empty());
+    APSARA_TEST_TRUE(TimeoutFlushManager::GetInstance()->mDeletedFlushers.empty());
     APSARA_TEST_TRUE(TimeoutFlushManager::GetInstance()->mTimeoutRecords.empty());
 }
 

--- a/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
+++ b/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
@@ -81,7 +81,12 @@ void TimeoutFlushManagerUnittest::TestClearRecords() {
     TimeoutFlushManager::GetInstance()->UpdateRecord("test_config", 0, 1, 3, sFlusher.get());
     TimeoutFlushManager::GetInstance()->ClearRecords("test_config");
 
-    APSARA_TEST_EQUAL(0U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
+    APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mDeletedConfigs.size());
+    APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
+
+    TimeoutFlushManager::GetInstance()->FlushTimeoutBatch();
+    APSARA_TEST_TRUE(TimeoutFlushManager::GetInstance()->mDeletedConfigs.empty());
+    APSARA_TEST_TRUE(TimeoutFlushManager::GetInstance()->mTimeoutRecords.empty());
 }
 
 UNIT_TEST_CASE(TimeoutFlushManagerUnittest, TestUpdateRecord)

--- a/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
+++ b/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
@@ -24,7 +24,7 @@ class TimeoutFlushManagerUnittest : public ::testing::Test {
 public:
     void TestUpdateRecord();
     void TestFlushTimeoutBatch();
-    void TestClearRecords();
+    void TestUnregisterFlushers();
 
 protected:
     static void SetUpTestCase() {
@@ -77,13 +77,19 @@ void TimeoutFlushManagerUnittest::TestFlushTimeoutBatch() {
     APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
 }
 
-void TimeoutFlushManagerUnittest::TestClearRecords() {
-    TimeoutFlushManager::GetInstance()->UpdateRecord("test_config", 0, 1, 3, sFlusher.get());
-    TimeoutFlushManager::GetInstance()->UnregisterFlushers(
-        "test_config", vector<const Flusher*>{const_cast<const Flusher*>(static_cast<Flusher*>(sFlusher.get()))});
+void TimeoutFlushManagerUnittest::TestUnregisterFlushers() {
+    auto flusher = new FlusherMock();
+    flusher->SetContext(sCtx);
+    flusher->SetMetricsRecordRef(FlusherMock::sName, "1");
+    auto instance = unique_ptr<FlusherInstance>(new FlusherInstance(flusher, PluginInstance::PluginMeta("1")));
+    vector<unique_ptr<FlusherInstance>> flushers;
+    flushers.push_back(std::move(instance));
+
+    TimeoutFlushManager::GetInstance()->UpdateRecord("test_config", 0, 1, 3, flusher);
+    TimeoutFlushManager::GetInstance()->UnregisterFlushers("test_config", flushers);
 
     APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mDeletedFlushers.size());
-    APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
+    APSARA_TEST_EQUAL(0U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
 
     TimeoutFlushManager::GetInstance()->FlushTimeoutBatch();
     APSARA_TEST_TRUE(TimeoutFlushManager::GetInstance()->mDeletedFlushers.empty());
@@ -92,7 +98,7 @@ void TimeoutFlushManagerUnittest::TestClearRecords() {
 
 UNIT_TEST_CASE(TimeoutFlushManagerUnittest, TestUpdateRecord)
 UNIT_TEST_CASE(TimeoutFlushManagerUnittest, TestFlushTimeoutBatch)
-UNIT_TEST_CASE(TimeoutFlushManagerUnittest, TestClearRecords)
+UNIT_TEST_CASE(TimeoutFlushManagerUnittest, TestUnregisterFlushers)
 
 } // namespace logtail
 

--- a/core/unittest/pipeline/PipelineUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUnittest.cpp
@@ -2917,7 +2917,7 @@ void PipelineUnittest::TestFlushBatch() const {
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 0, 1, 3, nullptr);
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 1, 1, 3, nullptr);
         APSARA_TEST_TRUE(pipeline.FlushBatch());
-        APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
+        APSARA_TEST_EQUAL(0U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
         APSARA_TEST_EQUAL(2U, TimeoutFlushManager::GetInstance()->mDeletedFlushers.size());
         TimeoutFlushManager::GetInstance()->FlushTimeoutBatch();
     }
@@ -2927,7 +2927,7 @@ void PipelineUnittest::TestFlushBatch() const {
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 0, 1, 3, nullptr);
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 1, 1, 3, nullptr);
         APSARA_TEST_FALSE(pipeline.FlushBatch());
-        APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
+        APSARA_TEST_EQUAL(0U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
         APSARA_TEST_EQUAL(2U, TimeoutFlushManager::GetInstance()->mDeletedFlushers.size());
         TimeoutFlushManager::GetInstance()->FlushTimeoutBatch();
     }

--- a/core/unittest/pipeline/PipelineUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUnittest.cpp
@@ -2917,7 +2917,9 @@ void PipelineUnittest::TestFlushBatch() const {
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 0, 1, 3, nullptr);
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 1, 1, 3, nullptr);
         APSARA_TEST_TRUE(pipeline.FlushBatch());
-        APSARA_TEST_TRUE(TimeoutFlushManager::GetInstance()->mTimeoutRecords.empty());
+        APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
+        APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mDeletedConfigs.size());
+        TimeoutFlushManager::GetInstance()->FlushTimeoutBatch();
     }
     {
         // some failed
@@ -2925,7 +2927,9 @@ void PipelineUnittest::TestFlushBatch() const {
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 0, 1, 3, nullptr);
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 1, 1, 3, nullptr);
         APSARA_TEST_FALSE(pipeline.FlushBatch());
-        APSARA_TEST_TRUE(TimeoutFlushManager::GetInstance()->mTimeoutRecords.empty());
+        APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
+        APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mDeletedConfigs.size());
+        TimeoutFlushManager::GetInstance()->FlushTimeoutBatch();
     }
 }
 

--- a/core/unittest/pipeline/PipelineUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUnittest.cpp
@@ -2918,7 +2918,7 @@ void PipelineUnittest::TestFlushBatch() const {
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 1, 1, 3, nullptr);
         APSARA_TEST_TRUE(pipeline.FlushBatch());
         APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
-        APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mDeletedConfigs.size());
+        APSARA_TEST_EQUAL(2U, TimeoutFlushManager::GetInstance()->mDeletedFlushers.size());
         TimeoutFlushManager::GetInstance()->FlushTimeoutBatch();
     }
     {
@@ -2928,7 +2928,7 @@ void PipelineUnittest::TestFlushBatch() const {
         TimeoutFlushManager::GetInstance()->UpdateRecord(configName, 1, 1, 3, nullptr);
         APSARA_TEST_FALSE(pipeline.FlushBatch());
         APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mTimeoutRecords.size());
-        APSARA_TEST_EQUAL(1U, TimeoutFlushManager::GetInstance()->mDeletedConfigs.size());
+        APSARA_TEST_EQUAL(2U, TimeoutFlushManager::GetInstance()->mDeletedFlushers.size());
         TimeoutFlushManager::GetInstance()->FlushTimeoutBatch();
     }
 }


### PR DESCRIPTION
- 原因：
  - 处理线程：Batcher.Add (加锁1）-> TimeoutFlushManager.UpdateRecord （加可重入锁2）
  - 0号处理线程：TimeoutFlushManager.FlushoutBatch（加可重入锁2）-> Batcher.FlushQueue（加锁1） -> TimeoutFlushManager.UpdateRecord （加可重入锁2）
  - 主线程：Batcher.FlushAll（加锁1）->（释放锁1）-> TimeoutFlushManager.ClearRecords（加可重入锁2）
- 影响：LoongCollector 3.0.7 且开启多个处理线程
- 解决：打破TimeoutFlushManager.FlushoutBatch（加可重入锁2）-> Batcher.FlushQueue（加锁1）的锁嵌套，回到上次代码修改前的状态，重新解决之前的core问题，通过标记删除的方式来避免指针失效。
- 结果：
  - 处理线程：Batcher.Add (加锁1）-> TimeoutFlushManager.UpdateRecord （加锁2）
  - 0号处理线程：TimeoutFlushManager.FlushoutBatch（加锁2）->（释放锁2）-> （加锁3） -> Batcher.FlushQueue（加锁1） -> TimeoutFlushManager.UpdateRecord （加锁2）
  - 主线程：Batcher.FlushAll（加锁1）->（释放锁1）-> TimeoutFlushManager.ClearRecords（加锁3）