### PR TITLE
fix: container mount path corruption due to concurrent sort in info lookup

### DIFF
--- a/pkg/helper/docker_center.go
+++ b/pkg/helper/docker_center.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -623,6 +624,12 @@ func (dc *DockerCenter) CreateInfoDetail(info types.ContainerJSON, envConfigPref
 		info.Mounts[i].Source = filepath.Clean(info.Mounts[i].Source)
 		info.Mounts[i].Destination = filepath.Clean(info.Mounts[i].Destination)
 	}
+	sortMounts := func(mounts []types.MountPoint) {
+		sort.Slice(mounts, func(i, j int) bool {
+			return mounts[i].Source < mounts[j].Source
+		})
+	}
+	sortMounts(info.Mounts)
 	did := &DockerInfoDetail{
 		StdoutPath:       info.LogPath,
 		ContainerInfo:    info,

--- a/pkg/helper/docker_center_file_discover.go
+++ b/pkg/helper/docker_center_file_discover.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -143,6 +144,12 @@ func staticContainerInfoToStandard(staticInfo *staticContainerInfo, stat fs.File
 			Driver:      mount.Driver,
 		})
 	}
+	sortMounts := func(mounts []types.MountPoint) {
+		sort.Slice(mounts, func(i, j int) bool {
+			return mounts[i].Source < mounts[j].Source
+		})
+	}
+	sortMounts(dockerContainer.Mounts)
 	return dockerContainer
 }
 

--- a/plugins/input/docker/logmeta/metric_container_info.go
+++ b/plugins/input/docker/logmeta/metric_container_info.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -316,12 +315,6 @@ func (idf *InputDockerFile) updateMapping(info *helper.DockerInfoDetail, allCmd 
 		}
 	}
 
-	sortMounts := func(mounts []types.MountPoint) {
-		sort.Slice(mounts, func(i, j int) bool {
-			return mounts[i].Source < mounts[j].Source
-		})
-	}
-	sortMounts(mounts)
 	// 判断mounts
 	if !changed {
 		if val, ok := idf.lastContainerInfoCache[id]; ok && !reflect.DeepEqual(val.Mounts, mounts) {


### PR DESCRIPTION
This pull request includes changes to the `docker_center.go` and `metric_container_info.go` files to improve the sorting of mount points and clean up redundant code.

Improvements to mount point sorting:

* [`pkg/helper/docker_center.go`](diffhunk://#diff-c485466656194860a9853656d35422aa2df033cf29c41d0da890b567c4df4a72R23): Added a new `sortMounts` function to sort the `Mounts` slice by the `Source` field and invoked this function within the `CreateInfoDetail` method. [[1]](diffhunk://#diff-c485466656194860a9853656d35422aa2df033cf29c41d0da890b567c4df4a72R23) [[2]](diffhunk://#diff-c485466656194860a9853656d35422aa2df033cf29c41d0da890b567c4df4a72R627-R632)

Code cleanup:

* [`plugins/input/docker/logmeta/metric_container_info.go`](diffhunk://#diff-cc624af54a4fb34dd4be36cb3fa5886a0be04d334a34299ca30c04ba5d95ed2bL27): Removed the redundant import of the `sort` package and the `sortMounts` function, as the sorting logic has been moved to `docker_center.go`. [[1]](diffhunk://#diff-cc624af54a4fb34dd4be36cb3fa5886a0be04d334a34299ca30c04ba5d95ed2bL27) [[2]](diffhunk://#diff-cc624af54a4fb34dd4be36cb3fa5886a0be04d334a34299ca30c04ba5d95ed2bL319-L324)