### PR TITLE
fix: skip broken disk buffer

### DIFF
--- a/core/plugin/flusher/sls/DiskBufferWriter.cpp
+++ b/core/plugin/flusher/sls/DiskBufferWriter.cpp
@@ -490,9 +490,15 @@ void DiskBufferWriter::SendEncryptionBuffer(const std::string& filename, int32_t
     while (ReadNextEncryption(pos, filename, encryption, meta, readResult, bufferMeta)) {
         logData.clear();
         bool sendResult = false;
-        if (!readResult || bufferMeta.project().empty()) {
+        if (!readResult || bufferMeta.project().empty() || bufferMeta.aliuid().size() > 16) {
             if (meta.mHandled == 1)
                 continue;
+            // If buffer is broken, aliuid may be too large. Normal aliuid size is 16.
+            if (readResult && bufferMeta.aliuid().size() > 16) {
+                LOG_ERROR(sLogger,
+                          ("send disk buffer fail",
+                           "abnormal aliuid size")("filename", filename)("size", bufferMeta.aliuid().size()));
+            }
             sendResult = true;
             discardCount++;
         }

--- a/core/plugin/flusher/sls/DiskBufferWriter.h
+++ b/core/plugin/flusher/sls/DiskBufferWriter.h
@@ -91,6 +91,7 @@ private:
     std::string GetBufferFileName();
     void SetBufferFileName(const std::string& filename);
     std::string GetBufferFileHeader();
+    bool CheckBufferMetaValidation(const std::string& filename, const sls_logs::LogtailBufferMeta& bufferMeta);
 
     SafeQueue<SenderQueueItem*> mQueue;
 

--- a/core/plugin/flusher/sls/DiskBufferWriter.h
+++ b/core/plugin/flusher/sls/DiskBufferWriter.h
@@ -57,6 +57,7 @@ public:
 
 private:
     static const int32_t BUFFER_META_BASE_SIZE;
+    static const size_t BUFFER_META_MAX_SIZE;
 
     struct EncryptionStateMeta {
         int32_t mLogDataSize;


### PR DESCRIPTION
## 问题
disk buffer反序列化出来的数据存在问题，导致aliuid变量异常大，导致获取ak失败，并且不断重试，导致内存升高。
触发条件是几个的组合：
1. 进程优雅重启，触发disk buffer write。而流水线中存在大量阻塞流水线和数据，导致写入disk buffer时超时5秒，导致强制停止
2. 对于unauthorized的请求，会重试6个小时
3. disk buffer在发送的时候还会写数据回到disk buffer文件中，可能写坏掉

## 解决方法
临时解决方案：判断aliuid大小，如果超出正常长度就跳过
最终解决方案：通过磁盘队列持久化阻塞数据
