### PR TITLE
compile: use GOMODCACHE instead of GOPATH

### DIFF
--- a/scripts/plugin_build.sh
+++ b/scripts/plugin_build.sh
@@ -72,7 +72,7 @@ if [[ $MOD = "vendor" ]]; then
   cd vendor/github.com/valyala/gozstd
 else
   "$CURRDIR/import_plugins.sh" "$PLUGINS_CONFIG_FILE" "$GO_MOD_FILE"
-  cd $(go env GOPATH)/pkg/mod/github.com/valyala/gozstd@*
+  cd $(go env GOMODCACHE)/github.com/valyala/gozstd@*
 fi
 # if libzstd.a is available in the image, copy instead of rebuild
 lib_name=libzstd_${GOOS}_${GOARCH}.a


### PR DESCRIPTION
Fix compile error when custom GOMODCACHE is set to dir other than $GOPATH/pkg/mod

This pull request includes a small update to the `scripts/plugin_build.sh` file. The change updates the path used to navigate to the `gozstd` module directory, replacing `$(go env GOPATH)/pkg/mod` with `$(go env GOMODCACHE)` to align with modern Go module caching practices.