### PR TITLE
Fixed the issue that the Golang Stdout plugin missed collecting the end of the log file when the container was stopped.

### DIFF
--- a/pkg/helper/log_file_reader_test.go
+++ b/pkg/helper/log_file_reader_test.go
@@ -1,0 +1,119 @@
+package helper
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testFilePath    = "./test.log"
+	newTestFilePath = "./new_test.log"
+)
+
+var testFileStat StateOS
+
+func setup() error {
+	fmt.Println("Setting up for tests...")
+
+	os.Create(testFilePath)
+	fileInfo, err := os.Stat(testFilePath)
+	if err != nil {
+		return err
+	}
+	testFileStat = GetOSState(fileInfo)
+	return nil
+}
+
+func teardown() error {
+	fmt.Println("Tearing down after tests...")
+	err := os.Remove(testFilePath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getMockCheckpoint() LogFileReaderCheckPoint {
+	return LogFileReaderCheckPoint{
+		Path:   testFilePath,
+		Offset: 0,
+		State:  testFileStat,
+	}
+}
+
+func getMockLogReaderConfig() LogFileReaderConfig {
+	return LogFileReaderConfig{
+		CloseFileSec:     60,
+		MaxReadBlockSize: 1024,
+		ReadIntervalMs:   1000,
+		Tracker:          nil,
+	}
+}
+
+func writeContent(filePath string) error {
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	writer := bufio.NewWriter(file)
+	_, err = writer.WriteString("hello world" + "\n")
+	if err != nil {
+		return err
+	}
+	err = writer.Flush()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type MockLogFileProcessor struct {
+}
+
+func (m *MockLogFileProcessor) Process(fileBlock []byte, noChangeInterval time.Duration) int {
+	return 0
+}
+
+func getMockLogFileProcessor() *MockLogFileProcessor {
+	return &MockLogFileProcessor{}
+}
+
+func TestCheckFileChange(t *testing.T) {
+	reader, err := NewLogFileReader(context.Background(), getMockCheckpoint(), getMockLogReaderConfig(), getMockLogFileProcessor())
+	assert.Nil(t, err)
+	change := reader.CheckFileChange()
+	assert.Equal(t, false, change)
+
+	// write to file
+	writeContent(testFilePath)
+	change = reader.CheckFileChange()
+	assert.Equal(t, true, change)
+	reader.ReadAndProcess(false)
+
+	// write to file and rename, mock the file path in logfilereader unreachable
+	writeContent(testFilePath)
+	os.Rename(testFilePath, newTestFilePath)
+	change = reader.CheckFileChange()
+	assert.Equal(t, true, change)
+}
+
+func TestMain(m *testing.M) {
+	err := setup()
+	if err != nil {
+		fmt.Println("Setup failed:", err)
+		os.Exit(1)
+	}
+	exitCode := m.Run()
+	err = teardown()
+	if err != nil {
+		fmt.Println("Teardown failed:", err)
+		os.Exit(1)
+	}
+	os.Exit(exitCode)
+}

--- a/pkg/helper/log_file_reader_test.go
+++ b/pkg/helper/log_file_reader_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	testFilePath    = "./test.log"
-	newTestFilePath = "./new_test.log"
+	testFilePath = "./test.log"
 )
 
 var testFileStat StateOS
@@ -32,6 +31,9 @@ func setup() error {
 
 func teardown() error {
 	fmt.Println("Tearing down after tests...")
+	if _, err := os.Stat(testFilePath); os.IsNotExist(err) {
+		return nil
+	}
 	err := os.Remove(testFilePath)
 	if err != nil {
 		return err
@@ -96,11 +98,13 @@ func TestCheckFileChange(t *testing.T) {
 	assert.Equal(t, true, change)
 	reader.ReadAndProcess(false)
 
-	// write to file and rename, mock the file path in logfilereader unreachable
+	// write to file and remove, mock the file path in logfilereader unreachable
 	writeContent(testFilePath)
-	os.Rename(testFilePath, newTestFilePath)
+	os.Remove(testFilePath)
 	change = reader.CheckFileChange()
 	assert.Equal(t, true, change)
+
+	reader.CloseFile("finish test")
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
问题现象：客户反馈Golang标准输出采集插件在容器停止的时候，末尾的一些数据采集不到
问题原因：容器停止之后，容器标准输出的文件路径就访问不到了，而LogFileReader判断文件是否有变化的时候，依赖文件路径的可访问，因此容器停止之后，未采集的数据就不会继续采集了。
修复方案： LogFileReader判断文件是否有变化的时候，依据当前持有的文件句柄继续判断文件内容，保证继续采集完。（目前会持有60s）

修复前：可以看到最后的数据并没有采集上来
![image](https://github.com/user-attachments/assets/870b8b1c-f7ea-4965-9ba6-3460ef1a3784)
![image](https://github.com/user-attachments/assets/dd3d8b83-9568-4d26-8fb0-068e0ad393cd)
![image](https://github.com/user-attachments/assets/3da95ffa-0789-4676-a20d-9da0353994b4)

修复后：可以看到最后一行数据采集上来了
![image](https://github.com/user-attachments/assets/ddf1ef4b-1fed-4fd2-9f63-2541ab5b507d)
![image](https://github.com/user-attachments/assets/148b2540-85ba-4456-b131-a453aa467656)
![image](https://github.com/user-attachments/assets/0f906e29-29f3-4173-9b5b-be806301395f)
