### PR TITLE
add actions-timeline

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -217,3 +217,11 @@ jobs:
       
       - name: Push benchmark result
         run: git push 'https://${{ github.repository_owner }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository_owner }}/LoongCollector.git' gh-pages:gh-pages
+
+  actions-timeline:
+    needs: [result]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@v2

--- a/.github/workflows/build-core-ut.yaml
+++ b/.github/workflows/build-core-ut.yaml
@@ -129,3 +129,11 @@ jobs:
     steps:
       - name: Build Result
         run: echo "Just to make the GitHub merge button green"
+
+  actions-timeline:
+    needs: [result]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@v2

--- a/.github/workflows/build-core.yaml
+++ b/.github/workflows/build-core.yaml
@@ -117,3 +117,11 @@ jobs:
     steps:
       - name: Build Result
         run: echo "Just to make the GitHub merge button green"
+
+  actions-timeline:
+    needs: [result]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@v2

--- a/.github/workflows/build-pure-plugin.yaml
+++ b/.github/workflows/build-pure-plugin.yaml
@@ -105,3 +105,11 @@ jobs:
     steps:
       - name: Build Result
         run: echo "Just to make the GitHub merge button green"
+  
+  actions-timeline:
+    needs: [result]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,3 +111,11 @@ jobs:
     steps:
       - name: Build Result
         run: echo "Just to make the GitHub merge button green"
+
+  actions-timeline:
+    needs: [result]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@v2

--- a/.github/workflows/e2e-framework.yaml
+++ b/.github/workflows/e2e-framework.yaml
@@ -93,3 +93,11 @@ jobs:
     steps:
       - name: Build Result
         run: echo "Just to make the GitHub merge button green"
+
+  actions-timeline:
+    needs: [result]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@v2

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -95,3 +95,11 @@ jobs:
     steps:
       - name: Build Result
         run: echo "Just to make the GitHub merge button green"
+
+  actions-timeline:
+    needs: [result]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@v2

--- a/.github/workflows/static-check.yaml
+++ b/.github/workflows/static-check.yaml
@@ -109,3 +109,11 @@ jobs:
     steps:
       - name: Build Result
         run: echo "Just to make the GitHub merge button green"
+
+  actions-timeline:
+    needs: [result]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@v2


### PR DESCRIPTION
## 做了什么

添加了actions-timeline这个步骤，可以把每一步的耗时详细展示出来，便于分析、合并、优化现有的多个workflow

## 每个 workflow的分析

### Build（在self-hosted runner上跑）

可以看到准备 ubuntu 环境耗时比较久，其次就是 “Build Binary” 和 “Build Docker”，这两步是为了验证能否编译通过，而其他workflow里会重复编译一个结果做测试，所以可以合并起来。result这一步没有用，反而还有额外的等待runner分配的时间。

![image](https://github.com/user-attachments/assets/a96be291-c69a-4353-8f15-116212a8050a)

### Build Core（在self-hosted runner上跑）

这个CI由于网络环境问题，“Set up Go”，“Check out code”和“Set custom submodule URL and fetch”都比较久，而且能看到有一次跟 Build 重复的 “Build Binary”，都是可以优化的。

![image](https://github.com/user-attachments/assets/dc9785af-2e0b-4a2e-8c00-c5e61c8c9b59)

### Build Core Unit Test（在self-hosted runner上跑）

跟Build Core一样的问题。

![image](https://github.com/user-attachments/assets/323f36d6-c8ff-4e75-89ee-04bb339314ad)


### Build Pure Plugin（在self-hosted runner上跑）

这个很快，暂时不用优化

![image](https://github.com/user-attachments/assets/a996fff0-4c01-4a07-b51f-80e94971bba7)


### E2E Core Test（在Github runner上跑）

可以看到E2E Plugin Framework Test 占用了非常长的时间，实际上它并没有测试用例，就是用github runner编译完了结束，这个是可以优化的。

![image](https://github.com/user-attachments/assets/ff9ae70a-041c-4cc8-a823-712c343cae9f)


### E2E Test（在Github runner上跑）

E2E Behavior Test的时间非常长，其中前半部分是在编译（这个是可以跟其他流程合并的，self-hosted-runner的编译效率高），剩下的 914.39s（15min左右）在串行跑测试，每个测试都需要用docker-compose重复拉镜像、测试、销毁容器的过程，会随着用例的变多，时间越来越长（每个用例在半分钟左右），这里需要改成并行（benchmark已经改好了，不过调研发现并行跑go的测试还有更优的方法，会一并优化掉）

![image](https://github.com/user-attachments/assets/16ba7526-b8d4-4e61-929a-f24580868d50)


### Static Check（在Github runner上跑）

这里的C++ Core Lint、Go Plugin Lint、UnitTest（Go）和UnitTest PluginManager都是可以并行的，改为并行后时间应该在10min内。

![image](https://github.com/user-attachments/assets/54d21728-d8a7-4885-bb6f-4be2bfb2deb3)

## 后续优化方向

该优化方向是基于上文对每个 workflow 时间分析的总结，只是一个优化方案的设计，还没有开始实操。

* 环境方面的改进：
  * 每个self-hosted runner规格调大，只用于编译，争取把带ut的编译速度压缩到10min。
  * 多使用Github或自建集群缓存一些常用的东西，比如go 1.19的安装、开发镜像（编译ut的时候，光是拉开发镜像就用了6min）
  * 根据runner配置不同的资源地址，加快下载速度
* 流程方面的改进
  * 合并workflow。下面的Job按路线执行，没有先后顺序的可以并行，修改后的整体时间预期会达到20min左右，资源开销会小很多（Github runner 45min，self-hosted 15min，对比现在Github runner 70min，self-hosted 60min），且完全覆盖之前的测试能力
    ```text
    C++ Core Lint
    （Github，4min）

    Go lint
    （Github，7min）

    Go UnitTest
    （Github，6min）

    UnitTest PluginManager                        │-->并行执行e2e core 等其他测试
    （Github，7min）                              │  （Github，2~5min）
                                                  │
    编译C++部分--------------->生成 release 镜像 ------- > 并行执行e2e测试
    （self-hosted，5min） │    （Github，1min）    │      （Github，2min）
                         │                        │
    编译Go部分------------│                        │-->校验可靠性
    （Github，3min）      │                             （Github，5min）
                         │
    编译C++ UT部分----------->生成测试镜像 ------------ >执行C++ UT
    （self-hosted，10min）    （Github，1min）      │      （Github，8min）
                                                   │
                                                   │-->测试覆盖率
                                                    （Github，3min）
    ```

