### PR TITLE
fix: k8s resource nil point

### DIFF
--- a/pkg/helper/k8smeta/k8s_meta_manager.go
+++ b/pkg/helper/k8smeta/k8s_meta_manager.go
@@ -132,6 +132,7 @@ func (m *MetaManager) IsReady() bool {
 func (m *MetaManager) RegisterSendFunc(projectName, configName, resourceType string, sendFunc SendFunc, interval int) {
 	if cache, ok := m.cacheMap[resourceType]; ok {
 		cache.RegisterSendFunc(configName, func(events []*K8sMetaEvent) {
+			defer panicRecover()
 			sendFunc(events)
 			m.registerLock.RLock()
 			for _, linkType := range m.linkRegisterMap[configName] {

--- a/pkg/helper/k8smeta/k8s_meta_store_interface.go
+++ b/pkg/helper/k8smeta/k8s_meta_store_interface.go
@@ -30,6 +30,6 @@ func panicRecover() {
 	if err := recover(); err != nil {
 		trace := make([]byte, 2048)
 		runtime.Stack(trace, true)
-		logger.Error(context.Background(), "PLUGIN_RUNTIME_ALARM", "skywalking v2 runtime panic error", err, "stack", string(trace))
+		logger.Error(context.Background(), "PLUGIN_RUNTIME_ALARM", "k8s meta panic error", err, "stack", string(trace))
 	}
 }

--- a/plugins/input/kubernetesmetav2/meta_collector.go
+++ b/plugins/input/kubernetesmetav2/meta_collector.go
@@ -464,3 +464,17 @@ func convertPipelineEvent2Log(event models.PipelineEvent) *protocol.Log {
 func isEntity(resourceType string) bool {
 	return !strings.Contains(resourceType, k8smeta.LINK_SPLIT_CHARACTER)
 }
+
+func safeGetInt32String(pointer *int32) string {
+	if pointer == nil {
+		return ""
+	}
+	return strconv.FormatInt(int64(*pointer), 10)
+}
+
+func safeGetBoolString(pointer *bool) string {
+	if pointer == nil {
+		return ""
+	}
+	return strconv.FormatBool(*pointer)
+}

--- a/plugins/input/kubernetesmetav2/meta_collector_app.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_app.go
@@ -23,7 +23,11 @@ func (m *metaCollector) processDeploymentEntity(data *k8smeta.ObjectWrapper, met
 		log.Contents.Add("labels", m.processEntityJSONObject(obj.Labels))
 		log.Contents.Add("annotations", m.processEntityJSONObject(obj.Annotations))
 		log.Contents.Add("match_labels", m.processEntityJSONObject(obj.Spec.Selector.MatchLabels))
-		log.Contents.Add("replicas", strconv.FormatInt(int64(*obj.Spec.Replicas), 10))
+		if obj.Spec.Replicas != nil {
+			log.Contents.Add("replicas", strconv.FormatInt(int64(*obj.Spec.Replicas), 10))
+		} else {
+			log.Contents.Add("replicas", "")
+		}
 		log.Contents.Add("ready_replicas", strconv.FormatInt(int64(obj.Status.ReadyReplicas), 10))
 		containerInfos := []map[string]string{}
 		for _, container := range obj.Spec.Template.Spec.Containers {
@@ -80,7 +84,11 @@ func (m *metaCollector) processStatefulSetEntity(data *k8smeta.ObjectWrapper, me
 		log.Contents.Add("labels", m.processEntityJSONObject(obj.Labels))
 		log.Contents.Add("annotations", m.processEntityJSONObject(obj.Annotations))
 		log.Contents.Add("match_labels", m.processEntityJSONObject(obj.Spec.Selector.MatchLabels))
-		log.Contents.Add("replicas", strconv.FormatInt(int64(*obj.Spec.Replicas), 10))
+		if obj.Spec.Replicas != nil {
+			log.Contents.Add("replicas", strconv.FormatInt(int64(*obj.Spec.Replicas), 10))
+		} else {
+			log.Contents.Add("replicas", "")
+		}
 		containerInfos := []map[string]string{}
 		for _, container := range obj.Spec.Template.Spec.Containers {
 			containerInfo := map[string]string{
@@ -108,7 +116,11 @@ func (m *metaCollector) processReplicaSetEntity(data *k8smeta.ObjectWrapper, met
 		log.Contents.Add("labels", m.processEntityJSONObject(obj.Labels))
 		log.Contents.Add("annotations", m.processEntityJSONObject(obj.Annotations))
 		log.Contents.Add("match_labels", m.processEntityJSONObject(obj.Spec.Selector.MatchLabels))
-		log.Contents.Add("replicas", strconv.FormatInt(int64(*obj.Spec.Replicas), 10))
+		if obj.Spec.Replicas != nil {
+			log.Contents.Add("replicas", strconv.FormatInt(int64(*obj.Spec.Replicas), 10))
+		} else {
+			log.Contents.Add("replicas", "")
+		}
 		containerInfos := []map[string]string{}
 		for _, container := range obj.Spec.Template.Spec.Containers {
 			containerInfo := map[string]string{

--- a/plugins/input/kubernetesmetav2/meta_collector_app.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_app.go
@@ -23,11 +23,7 @@ func (m *metaCollector) processDeploymentEntity(data *k8smeta.ObjectWrapper, met
 		log.Contents.Add("labels", m.processEntityJSONObject(obj.Labels))
 		log.Contents.Add("annotations", m.processEntityJSONObject(obj.Annotations))
 		log.Contents.Add("match_labels", m.processEntityJSONObject(obj.Spec.Selector.MatchLabels))
-		if obj.Spec.Replicas != nil {
-			log.Contents.Add("replicas", strconv.FormatInt(int64(*obj.Spec.Replicas), 10))
-		} else {
-			log.Contents.Add("replicas", "")
-		}
+		log.Contents.Add("replicas", safeGetInt32String(obj.Spec.Replicas))
 		log.Contents.Add("ready_replicas", strconv.FormatInt(int64(obj.Status.ReadyReplicas), 10))
 		containerInfos := []map[string]string{}
 		for _, container := range obj.Spec.Template.Spec.Containers {
@@ -84,11 +80,7 @@ func (m *metaCollector) processStatefulSetEntity(data *k8smeta.ObjectWrapper, me
 		log.Contents.Add("labels", m.processEntityJSONObject(obj.Labels))
 		log.Contents.Add("annotations", m.processEntityJSONObject(obj.Annotations))
 		log.Contents.Add("match_labels", m.processEntityJSONObject(obj.Spec.Selector.MatchLabels))
-		if obj.Spec.Replicas != nil {
-			log.Contents.Add("replicas", strconv.FormatInt(int64(*obj.Spec.Replicas), 10))
-		} else {
-			log.Contents.Add("replicas", "")
-		}
+		log.Contents.Add("replicas", safeGetInt32String(obj.Spec.Replicas))
 		containerInfos := []map[string]string{}
 		for _, container := range obj.Spec.Template.Spec.Containers {
 			containerInfo := map[string]string{
@@ -116,11 +108,7 @@ func (m *metaCollector) processReplicaSetEntity(data *k8smeta.ObjectWrapper, met
 		log.Contents.Add("labels", m.processEntityJSONObject(obj.Labels))
 		log.Contents.Add("annotations", m.processEntityJSONObject(obj.Annotations))
 		log.Contents.Add("match_labels", m.processEntityJSONObject(obj.Spec.Selector.MatchLabels))
-		if obj.Spec.Replicas != nil {
-			log.Contents.Add("replicas", strconv.FormatInt(int64(*obj.Spec.Replicas), 10))
-		} else {
-			log.Contents.Add("replicas", "")
-		}
+		log.Contents.Add("replicas", safeGetInt32String(obj.Spec.Replicas))
 		containerInfos := []map[string]string{}
 		for _, container := range obj.Spec.Template.Spec.Containers {
 			containerInfo := map[string]string{

--- a/plugins/input/kubernetesmetav2/meta_collector_batch.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_batch.go
@@ -32,9 +32,21 @@ func (m *metaCollector) processJobEntity(data *k8smeta.ObjectWrapper, method str
 			containerInfos = append(containerInfos, containerInfo)
 		}
 		log.Contents.Add("containers", m.processEntityJSONArray(containerInfos))
-		log.Contents.Add("suspend", strconv.FormatBool(*obj.Spec.Suspend))
-		log.Contents.Add("backoff_limit", strconv.FormatInt(int64(*obj.Spec.BackoffLimit), 10))
-		log.Contents.Add("completion", strconv.FormatInt(int64(*obj.Spec.Completions), 10))
+		if obj.Spec.Suspend != nil {
+			log.Contents.Add("suspend", strconv.FormatBool(*obj.Spec.Suspend))
+		} else {
+			log.Contents.Add("suspend", "")
+		}
+		if obj.Spec.BackoffLimit != nil {
+			log.Contents.Add("backoff_limit", strconv.FormatInt(int64(*obj.Spec.BackoffLimit), 10))
+		} else {
+			log.Contents.Add("backoff_limit", "")
+		}
+		if obj.Spec.Completions != nil {
+			log.Contents.Add("completion", strconv.FormatInt(int64(*obj.Spec.Completions), 10))
+		} else {
+			log.Contents.Add("completion", "")
+		}
 		return []models.PipelineEvent{log}
 	}
 	return nil
@@ -53,7 +65,11 @@ func (m *metaCollector) processCronJobEntity(data *k8smeta.ObjectWrapper, method
 		log.Contents.Add("labels", m.processEntityJSONObject(obj.Labels))
 		log.Contents.Add("annotations", m.processEntityJSONObject(obj.Annotations))
 		log.Contents.Add("schedule", obj.Spec.Schedule)
-		log.Contents.Add("suspend", strconv.FormatBool(*obj.Spec.Suspend))
+		if obj.Spec.Suspend != nil {
+			log.Contents.Add("suspend", strconv.FormatBool(*obj.Spec.Suspend))
+		} else {
+			log.Contents.Add("suspend", "")
+		}
 		return []models.PipelineEvent{log}
 	}
 	return nil

--- a/plugins/input/kubernetesmetav2/meta_collector_batch.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_batch.go
@@ -1,7 +1,6 @@
 package kubernetesmetav2
 
 import (
-	"strconv"
 	"time"
 
 	batch "k8s.io/api/batch/v1" //nolint:typecheck
@@ -32,21 +31,9 @@ func (m *metaCollector) processJobEntity(data *k8smeta.ObjectWrapper, method str
 			containerInfos = append(containerInfos, containerInfo)
 		}
 		log.Contents.Add("containers", m.processEntityJSONArray(containerInfos))
-		if obj.Spec.Suspend != nil {
-			log.Contents.Add("suspend", strconv.FormatBool(*obj.Spec.Suspend))
-		} else {
-			log.Contents.Add("suspend", "")
-		}
-		if obj.Spec.BackoffLimit != nil {
-			log.Contents.Add("backoff_limit", strconv.FormatInt(int64(*obj.Spec.BackoffLimit), 10))
-		} else {
-			log.Contents.Add("backoff_limit", "")
-		}
-		if obj.Spec.Completions != nil {
-			log.Contents.Add("completion", strconv.FormatInt(int64(*obj.Spec.Completions), 10))
-		} else {
-			log.Contents.Add("completion", "")
-		}
+		log.Contents.Add("suspend", safeGetBoolString(obj.Spec.Suspend))
+		log.Contents.Add("backoff_limit", safeGetInt32String(obj.Spec.BackoffLimit))
+		log.Contents.Add("completion", safeGetInt32String(obj.Spec.Completions))
 		return []models.PipelineEvent{log}
 	}
 	return nil
@@ -65,11 +52,7 @@ func (m *metaCollector) processCronJobEntity(data *k8smeta.ObjectWrapper, method
 		log.Contents.Add("labels", m.processEntityJSONObject(obj.Labels))
 		log.Contents.Add("annotations", m.processEntityJSONObject(obj.Annotations))
 		log.Contents.Add("schedule", obj.Spec.Schedule)
-		if obj.Spec.Suspend != nil {
-			log.Contents.Add("suspend", strconv.FormatBool(*obj.Spec.Suspend))
-		} else {
-			log.Contents.Add("suspend", "")
-		}
+		log.Contents.Add("suspend", safeGetBoolString(obj.Spec.Suspend))
 		return []models.PipelineEvent{log}
 	}
 	return nil

--- a/plugins/input/kubernetesmetav2/meta_collector_core.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_core.go
@@ -209,7 +209,11 @@ func (m *metaCollector) processPersistentVolumeEntity(data *k8smeta.ObjectWrappe
 		log.Contents.Add("status", string(obj.Status.Phase))
 		log.Contents.Add("storage_class_name", obj.Spec.StorageClassName)
 		log.Contents.Add("persistent_volume_reclaim_policy", string(obj.Spec.PersistentVolumeReclaimPolicy))
-		log.Contents.Add("volume_mode", string(*obj.Spec.VolumeMode))
+		if obj.Spec.VolumeMode != nil {
+			log.Contents.Add("volume_mode", string(*obj.Spec.VolumeMode))
+		} else {
+			log.Contents.Add("volume_mode", "")
+		}
 		log.Contents.Add("capacity", obj.Spec.Capacity.Storage().String())
 		log.Contents.Add("fsType", obj.Spec.CSI.FSType)
 		return []models.PipelineEvent{log}

--- a/plugins/input/kubernetesmetav2/meta_collector_storage.go
+++ b/plugins/input/kubernetesmetav2/meta_collector_storage.go
@@ -20,8 +20,16 @@ func (m *metaCollector) processStorageClassEntity(data *k8smeta.ObjectWrapper, m
 		log.Contents.Add("api_version", obj.APIVersion)
 		log.Contents.Add("labels", m.processEntityJSONObject(obj.Labels))
 		log.Contents.Add("annotations", m.processEntityJSONObject(obj.Annotations))
-		log.Contents.Add("reclaim_policy", string(*obj.ReclaimPolicy))
-		log.Contents.Add("volume_binding_mode", string(*obj.VolumeBindingMode))
+		if obj.ReclaimPolicy != nil {
+			log.Contents.Add("reclaim_policy", string(*obj.ReclaimPolicy))
+		} else {
+			log.Contents.Add("reclaim_policy", "")
+		}
+		if obj.VolumeBindingMode != nil {
+			log.Contents.Add("volume_binding_mode", string(*obj.VolumeBindingMode))
+		} else {
+			log.Contents.Add("volume_binding_mode", "")
+		}
 		return []models.PipelineEvent{log}
 	}
 	return nil


### PR DESCRIPTION
## 问题
![image](https://github.com/user-attachments/assets/775a7f73-c875-47a8-93bf-1ae0d4933561)
K8s资源中，这类虽然有默认值的指针，在通过client-go获取时仍然可能是空的。

## 解决方案
1. 检查是否是空指针
2. 添加panicRecover，保证至少不crash