### PR TITLE
Update libbpf to resolve Unsupported BTF_KIND issue

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Set custom submodule URL and fetch
         run: |
           SUBMODULE_PATH="core/_thirdparty/coolbpf"
-          git config submodule.$SUBMODULE_PATH.url "https://github.com/iLogtail/coolbpf-mirror.git"
+          git config submodule.$SUBMODULE_PATH.url "https://github.com/aliyun/coolbpf.git"
           git submodule update --init
           cd $SUBMODULE_PATH
           echo "Current commit: $(git rev-parse HEAD)"

--- a/.github/workflows/build-core-ut.yaml
+++ b/.github/workflows/build-core-ut.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Set custom submodule URL and fetch
         run: |
           SUBMODULE_PATH="core/_thirdparty/coolbpf"
-          git config submodule.$SUBMODULE_PATH.url "https://github.com/iLogtail/coolbpf-mirror.git"
+          git config submodule.$SUBMODULE_PATH.url "https://github.com/aliyun/coolbpf.git"
           git submodule update --init
           cd $SUBMODULE_PATH
           echo "Current commit: $(git rev-parse HEAD)"

--- a/.github/workflows/build-core.yaml
+++ b/.github/workflows/build-core.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Set custom submodule URL and fetch
         run: |
           SUBMODULE_PATH="core/_thirdparty/coolbpf"
-          git config submodule.$SUBMODULE_PATH.url "https://github.com/iLogtail/coolbpf-mirror.git"
+          git config submodule.$SUBMODULE_PATH.url "https://github.com/aliyun/coolbpf.git"
           git submodule update --init
           cd $SUBMODULE_PATH
           echo "Current commit: $(git rev-parse HEAD)"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Set custom submodule URL and fetch
         run: |
           SUBMODULE_PATH="core/_thirdparty/coolbpf"
-          git config submodule.$SUBMODULE_PATH.url "https://github.com/iLogtail/coolbpf-mirror.git"
+          git config submodule.$SUBMODULE_PATH.url "https://github.com/aliyun/coolbpf.git"
           git submodule update --init
           cd $SUBMODULE_PATH
           echo "Current commit: $(git rev-parse HEAD)"

--- a/.github/workflows/e2e-framework.yaml
+++ b/.github/workflows/e2e-framework.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Set custom submodule URL and fetch
         run: |
           SUBMODULE_PATH="core/_thirdparty/coolbpf"
-          git config submodule.$SUBMODULE_PATH.url "https://github.com/iLogtail/coolbpf-mirror.git"
+          git config submodule.$SUBMODULE_PATH.url "https://github.com/aliyun/coolbpf.git"
           git submodule update --init
           cd $SUBMODULE_PATH
           echo "Current commit: $(git rev-parse HEAD)"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Set custom submodule URL and fetch
         run: |
           SUBMODULE_PATH="core/_thirdparty/coolbpf"
-          git config submodule.$SUBMODULE_PATH.url "https://github.com/iLogtail/coolbpf-mirror.git"
+          git config submodule.$SUBMODULE_PATH.url "https://github.com/aliyun/coolbpf.git"
           git submodule update --init
           cd $SUBMODULE_PATH
           echo "Current commit: $(git rev-parse HEAD)"

--- a/core/ebpf/driver/BPFWrapper.h
+++ b/core/ebpf/driver/BPFWrapper.h
@@ -351,13 +351,8 @@ public:
             return nullptr;
         }
 
-        struct perf_buffer_opts pbOpts = {};
-        pbOpts.sample_cb = dataCb;
-        pbOpts.ctx = ctx;
-        pbOpts.lost_cb = lossCb;
-
         struct perf_buffer* pb = NULL;
-        pb = perf_buffer__new(mapFd, pageCnt == 0 ? 128 : pageCnt, &pbOpts);
+        pb = perf_buffer__new(mapFd, pageCnt == 0 ? 128 : pageCnt, dataCb, lossCb, ctx, NULL);
         auto err = libbpf_get_error(pb);
         if (err) {
             ebpf_log(logtail::ebpf::eBPFLogType::NAMI_LOG_TYPE_WARN,


### PR DESCRIPTION
The current version of libbpf is too old to recognize new BTF Types in 6.x kernel versions, causing loading failures on newer systems. 
```
[2025-05-13 15:44:14.204906］［debug] ［1301190］/workspaces/loongcollector-enterprise/core/ebpf/EBPFAdapter.cpp: 142 moduLe:eBPFDriver msg:libbpf: Unsupported BTF_KIND:19
[2025-05-13 15:44:14.204914］［debug] ［1301190］/workspaces/loongcollector-enterprise/core/ebpf/EBPFAdapter.cpp: module:eBPFDriver   msg: libbpf: loading kernel BTF '/sys/kernel/btf/vmlinux'：-22
```
This update resolves the "Unsupported BTF_KIND" error and allows proper loading on recent kernels.