### PR TITLE
Update k8s meta with specific relation type

### DIFF
--- a/plugins/input/kubernetesmetav2/meta_collector.go
+++ b/plugins/input/kubernetesmetav2/meta_collector.go
@@ -202,20 +202,20 @@ func (m *metaCollector) Stop() error {
 	return nil
 }
 
-func canClusterLinkDirectly(resourceType string, serviceK8sMeta *ServiceK8sMeta) bool {
+func canClusterLinkDirectly(resourceType string, serviceK8sMeta *ServiceK8sMeta) (bool, string)  {
 	if strings.ToLower(resourceType) == "namespace" && serviceK8sMeta.Namespace && serviceK8sMeta.Cluster2Namespace != "" {
-		return true
+		return true, serviceK8sMeta.Cluster2Namespace
 	}
 	if strings.ToLower(resourceType) == "node" && serviceK8sMeta.Node && serviceK8sMeta.Cluster2Node != "" {
-		return true
+		return true, serviceK8sMeta.Cluster2Node
 	}
 	if strings.ToLower(resourceType) == "persistentvolume" && serviceK8sMeta.PersistentVolume && serviceK8sMeta.Cluster2PersistentVolume != "" {
-		return true
+		return true, serviceK8sMeta.Cluster2PersistentVolume
 	}
 	if strings.ToLower(resourceType) == "storageclass" && serviceK8sMeta.StorageClass && serviceK8sMeta.Cluster2StorageClass != "" {
-		return true
+		return true, serviceK8sMeta.Cluster2StorageClass
 	}
-	return false
+	return false, ""
 }
 
 func (m *metaCollector) handleEvent(event []*k8smeta.K8sMetaEvent) {
@@ -241,8 +241,9 @@ func (m *metaCollector) handleAddOrUpdate(event *k8smeta.K8sMetaEvent) {
 		logs := processor(event.Object, "Update")
 		for _, log := range logs {
 			m.send(log, isEntity(event.Object.ResourceType))
-			if isEntity(event.Object.ResourceType) && canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta) {
-				link := m.generateEntityClusterLink(log)
+			canClusterLinkDirectly, relationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta) 
+			if isEntity(event.Object.ResourceType) && canClusterLinkDirectly {
+				link := m.generateEntityClusterLink(log, relationType)
 				m.send(link, true)
 			}
 		}
@@ -254,8 +255,9 @@ func (m *metaCollector) handleDelete(event *k8smeta.K8sMetaEvent) {
 		logs := processor(event.Object, "Expire")
 		for _, log := range logs {
 			m.send(log, isEntity(event.Object.ResourceType))
-			if isEntity(event.Object.ResourceType) && canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta) {
-				link := m.generateEntityClusterLink(log)
+			canClusterLinkDirectly, relationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta) 
+			if isEntity(event.Object.ResourceType) && canClusterLinkDirectly {
+				link := m.generateEntityClusterLink(log, relationType)
 				m.send(link, true)
 			}
 		}
@@ -407,7 +409,7 @@ func (m *metaCollector) generateClusterEntity() models.PipelineEvent {
 	return log
 }
 
-func (m *metaCollector) generateEntityClusterLink(entityEvent models.PipelineEvent) models.PipelineEvent {
+func (m *metaCollector) generateEntityClusterLink(entityEvent models.PipelineEvent, relationType string) models.PipelineEvent {
 	content := entityEvent.(*models.Log).Contents
 	log := &models.Log{}
 	log.Contents = models.NewLogContents()
@@ -417,8 +419,11 @@ func (m *metaCollector) generateEntityClusterLink(entityEvent models.PipelineEve
 	log.Contents.Add(entityLinkDestDomainFieldName, m.serviceK8sMeta.domain)
 	log.Contents.Add(entityLinkDestEntityTypeFieldName, content.Get(entityTypeFieldName))
 	log.Contents.Add(entityLinkDestEntityIDFieldName, content.Get(entityIDFieldName))
-
-	log.Contents.Add(entityLinkRelationTypeFieldName, "runs")
+	if relationType!="" {
+		log.Contents.Add(entityLinkRelationTypeFieldName, relationType)
+	}else{
+		log.Contents.Add(entityLinkRelationTypeFieldName, "runs")
+	}
 	log.Contents.Add(entityMethodFieldName, content.Get(entityMethodFieldName))
 
 	log.Contents.Add(entityFirstObservedTimeFieldName, content.Get(entityFirstObservedTimeFieldName))

--- a/plugins/input/kubernetesmetav2/meta_collector.go
+++ b/plugins/input/kubernetesmetav2/meta_collector.go
@@ -241,9 +241,9 @@ func (m *metaCollector) handleAddOrUpdate(event *k8smeta.K8sMetaEvent) {
 		logs := processor(event.Object, "Update")
 		for _, log := range logs {
 			m.send(log, isEntity(event.Object.ResourceType))
-			canClusterLinkDirectly, relationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta)
-			if isEntity(event.Object.ResourceType) && canClusterLinkDirectly {
-				link := m.generateEntityClusterLink(log, relationType)
+			linkClusterDirectly, linkRelationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta)
+			if isEntity(event.Object.ResourceType) && linkClusterDirectly {
+				link := m.generateEntityClusterLink(log, linkRelationType)
 				m.send(link, true)
 			}
 		}
@@ -255,9 +255,9 @@ func (m *metaCollector) handleDelete(event *k8smeta.K8sMetaEvent) {
 		logs := processor(event.Object, "Expire")
 		for _, log := range logs {
 			m.send(log, isEntity(event.Object.ResourceType))
-			canClusterLinkDirectly, relationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta)
-			if isEntity(event.Object.ResourceType) && canClusterLinkDirectly {
-				link := m.generateEntityClusterLink(log, relationType)
+			linkClusterDirectly, linkRelationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta)
+			if isEntity(event.Object.ResourceType) && linkClusterDirectly {
+				link := m.generateEntityClusterLink(log, linkRelationType)
 				m.send(link, true)
 			}
 		}
@@ -409,7 +409,7 @@ func (m *metaCollector) generateClusterEntity() models.PipelineEvent {
 	return log
 }
 
-func (m *metaCollector) generateEntityClusterLink(entityEvent models.PipelineEvent, relationType string) models.PipelineEvent {
+func (m *metaCollector) generateEntityClusterLink(entityEvent models.PipelineEvent, linkRelationType string) models.PipelineEvent {
 	content := entityEvent.(*models.Log).Contents
 	log := &models.Log{}
 	log.Contents = models.NewLogContents()
@@ -419,11 +419,7 @@ func (m *metaCollector) generateEntityClusterLink(entityEvent models.PipelineEve
 	log.Contents.Add(entityLinkDestDomainFieldName, m.serviceK8sMeta.domain)
 	log.Contents.Add(entityLinkDestEntityTypeFieldName, content.Get(entityTypeFieldName))
 	log.Contents.Add(entityLinkDestEntityIDFieldName, content.Get(entityIDFieldName))
-	if relationType != "" {
-		log.Contents.Add(entityLinkRelationTypeFieldName, relationType)
-	} else {
-		log.Contents.Add(entityLinkRelationTypeFieldName, "runs")
-	}
+	log.Contents.Add(entityLinkRelationTypeFieldName, linkRelationType)
 	log.Contents.Add(entityMethodFieldName, content.Get(entityMethodFieldName))
 
 	log.Contents.Add(entityFirstObservedTimeFieldName, content.Get(entityFirstObservedTimeFieldName))

--- a/plugins/input/kubernetesmetav2/meta_collector.go
+++ b/plugins/input/kubernetesmetav2/meta_collector.go
@@ -202,7 +202,7 @@ func (m *metaCollector) Stop() error {
 	return nil
 }
 
-func canClusterLinkDirectly(resourceType string, serviceK8sMeta *ServiceK8sMeta) (bool, string)  {
+func canClusterLinkDirectly(resourceType string, serviceK8sMeta *ServiceK8sMeta) (bool, string) {
 	if strings.ToLower(resourceType) == "namespace" && serviceK8sMeta.Namespace && serviceK8sMeta.Cluster2Namespace != "" {
 		return true, serviceK8sMeta.Cluster2Namespace
 	}
@@ -241,7 +241,7 @@ func (m *metaCollector) handleAddOrUpdate(event *k8smeta.K8sMetaEvent) {
 		logs := processor(event.Object, "Update")
 		for _, log := range logs {
 			m.send(log, isEntity(event.Object.ResourceType))
-			canClusterLinkDirectly, relationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta) 
+			canClusterLinkDirectly, relationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta)
 			if isEntity(event.Object.ResourceType) && canClusterLinkDirectly {
 				link := m.generateEntityClusterLink(log, relationType)
 				m.send(link, true)
@@ -255,7 +255,7 @@ func (m *metaCollector) handleDelete(event *k8smeta.K8sMetaEvent) {
 		logs := processor(event.Object, "Expire")
 		for _, log := range logs {
 			m.send(log, isEntity(event.Object.ResourceType))
-			canClusterLinkDirectly, relationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta) 
+			canClusterLinkDirectly, relationType := canClusterLinkDirectly(event.Object.ResourceType, m.serviceK8sMeta)
 			if isEntity(event.Object.ResourceType) && canClusterLinkDirectly {
 				link := m.generateEntityClusterLink(log, relationType)
 				m.send(link, true)
@@ -419,9 +419,9 @@ func (m *metaCollector) generateEntityClusterLink(entityEvent models.PipelineEve
 	log.Contents.Add(entityLinkDestDomainFieldName, m.serviceK8sMeta.domain)
 	log.Contents.Add(entityLinkDestEntityTypeFieldName, content.Get(entityTypeFieldName))
 	log.Contents.Add(entityLinkDestEntityIDFieldName, content.Get(entityIDFieldName))
-	if relationType!="" {
+	if relationType != "" {
 		log.Contents.Add(entityLinkRelationTypeFieldName, relationType)
-	}else{
+	} else {
 		log.Contents.Add(entityLinkRelationTypeFieldName, "runs")
 	}
 	log.Contents.Add(entityMethodFieldName, content.Get(entityMethodFieldName))


### PR DESCRIPTION
Pass relationtype to cluster-entity link by entity type
原 ： 对于cluster到Namespace、Node的link的关系类型，默认runs，参数配置没有生效
现 :   基于具体的参数配置（Cluster2Namespace等） 进行关系类型设定