### PR TITLE
feat: add instance labels into host monitor metrics

### DIFF
--- a/core/host_monitor/Constants.cpp
+++ b/core/host_monitor/Constants.cpp
@@ -24,4 +24,11 @@ std::filesystem::path PROCESS_DIR = "/proc";
 const std::filesystem::path PROCESS_STAT = "stat";
 const int64_t SYSTEM_HERTZ = sysconf(_SC_CLK_TCK);
 
+#ifdef __ENTERPRISE__
+const std::string DEFAULT_INSTANCE_ID_LABEL = "instance_id";
+const std::string DEFAULT_USER_ID_LABEL = "user_id";
+#else
+const std::string DEFAULT_HOST_IP_LABEL = "host_ip";
+#endif
+
 } // namespace logtail

--- a/core/host_monitor/Constants.h
+++ b/core/host_monitor/Constants.h
@@ -24,4 +24,11 @@ extern std::filesystem::path PROCESS_DIR;
 const extern std::filesystem::path PROCESS_STAT;
 const extern int64_t SYSTEM_HERTZ;
 
+#ifdef __ENTERPRISE__
+const extern std::string DEFAULT_INSTANCE_ID_LABEL;
+const extern std::string DEFAULT_USER_ID_LABEL;
+#else
+const extern std::string DEFAULT_HOST_IP_LABEL;
+#endif
+
 } // namespace logtail

--- a/core/host_monitor/HostMonitorInputRunner.cpp
+++ b/core/host_monitor/HostMonitorInputRunner.cpp
@@ -28,12 +28,22 @@
 
 #include "collection_pipeline/queue/ProcessQueueManager.h"
 #include "common/Flags.h"
+#include "common/MachineInfoUtil.h"
+#include "common/StringView.h"
 #include "common/timer/Timer.h"
+#include "host_monitor/Constants.h"
 #include "host_monitor/HostMonitorTimerEvent.h"
 #include "host_monitor/collector/CPUCollector.h"
 #include "host_monitor/collector/ProcessEntityCollector.h"
 #include "logger/Logger.h"
+#include "models/MetricEvent.h"
+#include "models/PipelineEventGroup.h"
+#include "monitor/Monitor.h"
 #include "runner/ProcessorRunner.h"
+
+#ifdef __ENTERPRISE__
+#include "config/provider/EnterpriseConfigProvider.h"
+#endif
 
 DEFINE_FLAG_INT32(host_monitor_thread_pool_size, "host monitor thread pool size", 3);
 
@@ -170,6 +180,7 @@ void HostMonitorInputRunner::ScheduleOnce(const std::chrono::steady_clock::time_
                 sLogger,
                 ("host monitor", "collect data")("collector", config.mCollectorName)("size", group.GetEvents().size()));
             if (group.GetEvents().size() > 0) {
+                AddHostLabels(group);
                 bool result = ProcessorRunner::GetInstance()->PushQueue(
                     config.mProcessQueueKey, config.mInputIndex, std::move(group));
                 if (!result) {
@@ -195,6 +206,29 @@ void HostMonitorInputRunner::PushNextTimerEvent(const std::chrono::steady_clock:
     }
     auto event = std::make_unique<HostMonitorTimerEvent>(nextExecTime, config);
     Timer::GetInstance()->PushEvent(std::move(event));
+}
+
+void HostMonitorInputRunner::AddHostLabels(PipelineEventGroup& group) {
+#ifdef __ENTERPRISE__
+    auto userID = group.GetSourceBuffer()->CopyString(EnterpriseConfigProvider::GetInstance()->GetAliuidSet());
+#else
+    auto hostIP = group.GetSourceBuffer()->CopyString(LoongCollectorMonitor::mIpAddr);
+#endif
+    for (auto& e : group.MutableEvents()) {
+        if (!e.Is<MetricEvent>()) {
+            continue;
+        }
+        auto& metricEvent = e.Cast<MetricEvent>();
+#ifdef __ENTERPRISE__
+        const auto* entity = InstanceIdentity::Instance()->GetEntity();
+        if (entity != nullptr) {
+            metricEvent.SetTagNoCopy(DEFAULT_INSTANCE_ID_LABEL, entity->GetHostID());
+        }
+        metricEvent.SetTagNoCopy(DEFAULT_USER_ID_LABEL, StringView(userID.data, userID.size));
+#else
+        metricEvent.SetTagNoCopy(DEFAULT_HOST_IP_LABEL, StringView(hostIP.data, hostIP.size));
+#endif
+    }
 }
 
 } // namespace logtail

--- a/core/host_monitor/HostMonitorInputRunner.h
+++ b/core/host_monitor/HostMonitorInputRunner.h
@@ -95,6 +95,7 @@ private:
 
     void PushNextTimerEvent(const std::chrono::steady_clock::time_point& execTime,
                             const HostMonitorTimerEvent::CollectConfig& config);
+    void AddHostLabels(PipelineEventGroup& group);
 
     std::atomic_bool mIsStarted = false;
     std::unique_ptr<ThreadPool> mThreadPool;


### PR DESCRIPTION
商业版主机监控指标默认添加 instance_id 和 user_id 两个标签。
开源版主机监控指标默认添加 host_ip 标签。

## TODO
对于Label的处理，后续Loongcollector SPL支持处理Metric后，可以通过SPL进行删除和重命名