### PR TITLE
feat: add containerd event listener for real-time container lifecycle

### DIFF
--- a/pkg/helper/containercenter/container_discover_controller.go
+++ b/pkg/helper/containercenter/container_discover_controller.go
@@ -128,7 +128,11 @@ func (c *ContainerDiscoverManager) fetchCRI() error {
 func (c *ContainerDiscoverManager) StartSyncContainers() {
 	if c.enableCRIDiscover {
 		logger.Debug(context.Background(), "discover manager start sync containers goroutine", "cri")
-		go criRuntimeWrapper.loopSyncContainers()
+		if criRuntimeWrapper.nativeClient != nil {
+			go criRuntimeWrapper.containerdEventListener()
+		} else {
+			go criRuntimeWrapper.loopSyncContainers()
+		}
 	}
 	if c.enableStaticDiscover {
 		logger.Debug(context.Background(), "discover manager start sync containers goroutine", "static")


### PR DESCRIPTION
目前在 cri_adapter.go 中，containerd类型容器状态的更新主要依赖于定时轮询（如 syncContainers）。为了提高状态感知的实时性和性能，实现基于containerd容器生命周期事件的监听与处理。