### PR TITLE
fix: processor released before serialized when pipeline update

### DIFF
--- a/core/collection_pipeline/CollectionPipeline.cpp
+++ b/core/collection_pipeline/CollectionPipeline.cpp
@@ -392,8 +392,10 @@ void CollectionPipeline::Process(vector<PipelineEventGroup>& logGroupList, size_
     ADD_COUNTER(mProcessorsInGroupsTotal, logGroupList.size())
 
     auto before = chrono::system_clock::now();
-    for (auto& p : mInputs[inputIndex]->GetInnerProcessors()) {
-        p->Process(logGroupList);
+    if (inputIndex < mInputs.size()) {
+        for (auto& p : mInputs[inputIndex]->GetInnerProcessors()) {
+            p->Process(logGroupList);
+        }
     }
     for (auto& p : mPipelineInnerProcessorLine) {
         p->Process(logGroupList);

--- a/core/collection_pipeline/CollectionPipeline.cpp
+++ b/core/collection_pipeline/CollectionPipeline.cpp
@@ -24,7 +24,6 @@
 
 #include "json/value.h"
 
-#include "Logger.h"
 #include "app_config/AppConfig.h"
 #include "collection_pipeline/batch/TimeoutFlushManager.h"
 #include "collection_pipeline/plugin/PluginRegistry.h"
@@ -34,6 +33,7 @@
 #include "common/Flags.h"
 #include "common/ParamExtractor.h"
 #include "go_pipeline/LogtailPlugin.h"
+#include "logger/Logger.h"
 #include "plugin/flusher/sls/FlusherSLS.h"
 #include "plugin/input/InputFeedbackInterfaceRegistry.h"
 #include "plugin/processor/ProcessorParseApsaraNative.h"

--- a/core/collection_pipeline/queue/BoundedProcessQueue.cpp
+++ b/core/collection_pipeline/queue/BoundedProcessQueue.cpp
@@ -72,14 +72,6 @@ bool BoundedProcessQueue::Pop(unique_ptr<ProcessQueueItem>& item) {
     return true;
 }
 
-void BoundedProcessQueue::SetPipelineForItems(const std::shared_ptr<CollectionPipeline>& p) const {
-    for (auto& item : mQueue) {
-        if (!item->mPipeline) {
-            item->mPipeline = p;
-        }
-    }
-}
-
 void BoundedProcessQueue::SetUpStreamFeedbacks(vector<FeedbackInterface*>&& feedbacks) {
     mUpStreamFeedbacks.clear();
     for (auto& item : feedbacks) {

--- a/core/collection_pipeline/queue/BoundedProcessQueue.h
+++ b/core/collection_pipeline/queue/BoundedProcessQueue.h
@@ -37,7 +37,6 @@ public:
 
     bool Push(std::unique_ptr<ProcessQueueItem>&& item) override;
     bool Pop(std::unique_ptr<ProcessQueueItem>& item) override;
-    void SetPipelineForItems(const std::shared_ptr<CollectionPipeline>& p) const override;
 
     void SetUpStreamFeedbacks(std::vector<FeedbackInterface*>&& feedbacks);
 

--- a/core/collection_pipeline/queue/CircularProcessQueue.cpp
+++ b/core/collection_pipeline/queue/CircularProcessQueue.cpp
@@ -79,14 +79,6 @@ bool CircularProcessQueue::Pop(unique_ptr<ProcessQueueItem>& item) {
     return true;
 }
 
-void CircularProcessQueue::SetPipelineForItems(const std::shared_ptr<CollectionPipeline>& p) const {
-    for (auto& item : mQueue) {
-        if (!item->mPipeline) {
-            item->mPipeline = p;
-        }
-    }
-}
-
 void CircularProcessQueue::Reset(size_t cap) {
     // it seems more reasonable to retain extra items and process them immediately, however this contray to current
     // framework design so we simply discard extra items, considering that it is a rare case to change capacity

--- a/core/collection_pipeline/queue/CircularProcessQueue.h
+++ b/core/collection_pipeline/queue/CircularProcessQueue.h
@@ -34,7 +34,6 @@ public:
 
     bool Push(std::unique_ptr<ProcessQueueItem>&& item) override;
     bool Pop(std::unique_ptr<ProcessQueueItem>& item) override;
-    void SetPipelineForItems(const std::shared_ptr<CollectionPipeline>& p) const override;
 
     void Reset(size_t cap);
 

--- a/core/collection_pipeline/queue/ExactlyOnceQueueManager.cpp
+++ b/core/collection_pipeline/queue/ExactlyOnceQueueManager.cpp
@@ -153,12 +153,6 @@ void ExactlyOnceQueueManager::DisablePopProcessQueue(const string& configName, b
     for (auto& iter : mProcessQueues) {
         if (iter.second->GetConfigName() == configName) {
             iter.second->DisablePop();
-            if (!isPipelineRemoving) {
-                const auto& p = CollectionPipelineManager::GetInstance()->FindConfigByName(configName);
-                if (p) {
-                    iter.second->SetPipelineForItems(p);
-                }
-            }
         }
     }
 }

--- a/core/collection_pipeline/queue/ProcessQueueInterface.h
+++ b/core/collection_pipeline/queue/ProcessQueueInterface.h
@@ -46,8 +46,6 @@ public:
     void DisablePop() { mValidToPop = false; }
     void EnablePop() { mValidToPop = true; }
 
-    virtual void SetPipelineForItems(const std::shared_ptr<CollectionPipeline>& p) const = 0;
-
     void Reset() { mDownStreamQueues.clear(); }
 
 protected:

--- a/core/collection_pipeline/queue/ProcessQueueItem.h
+++ b/core/collection_pipeline/queue/ProcessQueueItem.h
@@ -28,7 +28,6 @@ class CollectionPipeline;
 
 struct ProcessQueueItem {
     PipelineEventGroup mEventGroup;
-    std::shared_ptr<CollectionPipeline> mPipeline; // not null only during pipeline update
     size_t mInputIndex = 0; // index of the input in the pipeline
     std::chrono::system_clock::time_point mEnqueTime;
 

--- a/core/collection_pipeline/queue/ProcessQueueManager.cpp
+++ b/core/collection_pipeline/queue/ProcessQueueManager.cpp
@@ -238,12 +238,6 @@ void ProcessQueueManager::DisablePop(const string& configName, bool isPipelineRe
         auto iter = mQueues.find(key);
         if (iter != mQueues.end()) {
             (*iter->second.first)->DisablePop();
-            if (!isPipelineRemoving) {
-                const auto& p = CollectionPipelineManager::GetInstance()->FindConfigByName(configName);
-                if (p) {
-                    (*iter->second.first)->SetPipelineForItems(p);
-                }
-            }
         }
     } else {
         ExactlyOnceQueueManager::GetInstance()->DisablePopProcessQueue(configName, isPipelineRemoving);

--- a/core/runner/ProcessorRunner.cpp
+++ b/core/runner/ProcessorRunner.cpp
@@ -137,6 +137,8 @@ void ProcessorRunner::Run(uint32_t threadNo) {
 
         vector<PipelineEventGroup> eventGroupList;
         eventGroupList.emplace_back(std::move(item->mEventGroup));
+        // TODO: use old pipeline input index to find inner processor in new pipeline, maybe cause some issues when
+        // there are multiple inputs
         pipeline->Process(eventGroupList, item->mInputIndex);
 
         if (pipeline->IsFlushingThroughGoPipeline()) {

--- a/core/runner/ProcessorRunner.cpp
+++ b/core/runner/ProcessorRunner.cpp
@@ -124,7 +124,7 @@ void ProcessorRunner::Run(uint32_t threadNo) {
         ADD_COUNTER(sInGroupsCnt, 1);
         ADD_COUNTER(sInGroupDataSizeBytes, item->mEventGroup.DataSize());
 
-        shared_ptr<CollectionPipeline>& pipeline = item->mPipeline;
+        shared_ptr<CollectionPipeline> pipeline = item->mPipeline;
         bool hasOldPipeline = pipeline != nullptr;
         if (!hasOldPipeline) {
             pipeline = CollectionPipelineManager::GetInstance()->FindConfigByName(configName);
@@ -141,7 +141,6 @@ void ProcessorRunner::Run(uint32_t threadNo) {
         vector<PipelineEventGroup> eventGroupList;
         eventGroupList.emplace_back(std::move(item->mEventGroup));
         pipeline->Process(eventGroupList, item->mInputIndex);
-        auto oldPipeline = pipeline; // keep the old pipeline pointer
         // if the pipeline is updated, the pointer will be released, so we need to update it to the new pipeline
         if (hasOldPipeline) {
             pipeline = CollectionPipelineManager::GetInstance()->FindConfigByName(configName); // update to new pipeline

--- a/core/runner/ProcessorRunner.cpp
+++ b/core/runner/ProcessorRunner.cpp
@@ -124,11 +124,8 @@ void ProcessorRunner::Run(uint32_t threadNo) {
         ADD_COUNTER(sInGroupsCnt, 1);
         ADD_COUNTER(sInGroupDataSizeBytes, item->mEventGroup.DataSize());
 
-        shared_ptr<CollectionPipeline> pipeline = item->mPipeline;
-        bool hasOldPipeline = pipeline != nullptr;
-        if (!hasOldPipeline) {
-            pipeline = CollectionPipelineManager::GetInstance()->FindConfigByName(configName);
-        }
+        const shared_ptr<CollectionPipeline>& pipeline
+            = CollectionPipelineManager::GetInstance()->FindConfigByName(configName);
         if (!pipeline) {
             LOG_INFO(sLogger,
                      ("pipeline not found during processing, perhaps due to config deletion",
@@ -141,16 +138,6 @@ void ProcessorRunner::Run(uint32_t threadNo) {
         vector<PipelineEventGroup> eventGroupList;
         eventGroupList.emplace_back(std::move(item->mEventGroup));
         pipeline->Process(eventGroupList, item->mInputIndex);
-        // if the pipeline is updated, the pointer will be released, so we need to update it to the new pipeline
-        if (hasOldPipeline) {
-            pipeline = CollectionPipelineManager::GetInstance()->FindConfigByName(configName); // update to new pipeline
-            if (!pipeline) {
-                LOG_INFO(sLogger,
-                         ("pipeline not found during processing, perhaps due to config deletion",
-                          "discard data")("config", configName));
-                continue;
-            }
-        }
 
         if (pipeline->IsFlushingThroughGoPipeline()) {
             // TODO:

--- a/core/runner/ProcessorRunner.cpp
+++ b/core/runner/ProcessorRunner.cpp
@@ -141,6 +141,7 @@ void ProcessorRunner::Run(uint32_t threadNo) {
         vector<PipelineEventGroup> eventGroupList;
         eventGroupList.emplace_back(std::move(item->mEventGroup));
         pipeline->Process(eventGroupList, item->mInputIndex);
+        auto oldPipeline = pipeline; // keep the old pipeline pointer
         // if the pipeline is updated, the pointer will be released, so we need to update it to the new pipeline
         if (hasOldPipeline) {
             pipeline = CollectionPipelineManager::GetInstance()->FindConfigByName(configName); // update to new pipeline

--- a/core/unittest/pipeline/PipelineUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUnittest.cpp
@@ -72,7 +72,6 @@ protected:
     unique_ptr<ProcessQueueItem> GenerateProcessItem(shared_ptr<CollectionPipeline> pipeline) const {
         PipelineEventGroup eventGroup(make_shared<SourceBuffer>());
         auto item = make_unique<ProcessQueueItem>(std::move(eventGroup), 0);
-        item->mPipeline = pipeline;
         return item;
     }
 

--- a/core/unittest/pipeline/PipelineUpdateUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUpdateUnittest.cpp
@@ -270,9 +270,6 @@ private:
             while ((i < to + 1) && j < requests.size()) {
                 auto content = requests[j].mData;
                 auto actualLogstore = static_cast<FlusherSLS*>(requests[j].mFlusher)->mLogstore;
-                LOG_INFO(sLogger,
-                         ("verify data", "checking request")("i", i)("j", j)("content", content)("logstore", logstore)(
-                             "actual logstore", actualLogstore));
                 if (actualLogstore != logstore) {
                     ++j;
                     continue;

--- a/core/unittest/pipeline/PipelineUpdateUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUpdateUnittest.cpp
@@ -63,6 +63,21 @@ class FlusherSLSMock : public FlusherSLS {
 public:
     static const std::string sName;
 
+    bool Init(const Json::Value& config, Json::Value& optionalGoPipeline) override {
+        string errorMsg;
+        uint32_t delay = 0;
+        GetOptionalUIntParam(config, "SendDelay", delay, errorMsg);
+        mSendDelay = std::chrono::milliseconds(delay);
+        return FlusherSLS::Init(config, optionalGoPipeline);
+    }
+
+    bool Send(PipelineEventGroup&& g) override {
+        if (mSendDelay > std::chrono::milliseconds(0)) {
+            std::this_thread::sleep_for(mSendDelay);
+        }
+        return FlusherSLS::Send(std::move(g));
+    }
+
     bool BuildRequest(SenderQueueItem* item,
                       std::unique_ptr<HttpSinkRequest>& req,
                       bool* keepItem,
@@ -73,6 +88,9 @@ public:
             "POST", false, "test-host", 80, "/test-operation", "", header, data->mData, item);
         return true;
     }
+
+private:
+    std::chrono::milliseconds mSendDelay = std::chrono::milliseconds(0);
 };
 
 const std::string FlusherSLSMock::sName = "flusher_sls_mock";
@@ -122,6 +140,7 @@ public:
     void TestPipelineUpdateManyCase8() const;
     void TestPipelineUpdateManyCase9() const;
     void TestPipelineUpdateManyCase10() const;
+    void TestPipelineRelease() const;
 
 protected:
     static void SetUpTestCase() {
@@ -240,7 +259,7 @@ private:
         processor->Unblock();
     }
 
-    void VerifyData(std::string logstore, size_t from, size_t to) const {
+    void VerifyData(std::string logstore, size_t from, size_t to, bool checkProcessorLocalData = false) const {
         size_t i = from;
         size_t j = 0;
         size_t retryTimes = 15;
@@ -251,11 +270,20 @@ private:
             while ((i < to + 1) && j < requests.size()) {
                 auto content = requests[j].mData;
                 auto actualLogstore = static_cast<FlusherSLS*>(requests[j].mFlusher)->mLogstore;
+                LOG_INFO(sLogger,
+                         ("verify data", "checking request")("i", i)("j", j)("content", content)("logstore", logstore)(
+                             "actual logstore", actualLogstore));
                 if (actualLogstore != logstore) {
                     ++j;
                     continue;
                 }
-                if (content.find("test-data-" + to_string(i)) != string::npos) {
+                bool correctData = true;
+                correctData &= content.find("test-data-" + to_string(i)) != string::npos;
+                if (checkProcessorLocalData) {
+                    correctData &= content.find(PROCESSOR_MOCK_LOCAL_CONTENT_KEY) != string::npos;
+                    correctData &= content.find(PROCESSOR_MOCK_LOCAL_CONTENT_VALUE) != string::npos;
+                }
+                if (correctData) {
                     ++i;
                     continue;
                 }
@@ -325,6 +353,15 @@ private:
             "Logstore": "test_logstore_2",
             "Region": "test_region",
             "Endpoint": "test_endpoint"
+        })";
+    string slowFlusherConfig = R"(
+        {
+            "Type": "flusher_sls_mock",
+            "Project": "test_project",
+            "Logstore": "test_logstore_2",
+            "Region": "test_region",
+            "Endpoint": "test_endpoint",
+            "SendDelay": 1000
         })";
     string nativeFlusherConfig3 = R"(
         {
@@ -1708,12 +1745,13 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase1() const {
     diffUpdate3.mModified.push_back(std::move(pipelineConfigObjUpdate3));
     auto result = async(launch::async, [&]() {
         this_thread::sleep_for(chrono::milliseconds(1000));
-        auto processor1
-            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline1->mProcessorLine[0].get()->mPlugin.get()));
-        processor1->Unblock();
+        auto processor2
+            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
+        processor2->Unblock();
     });
     pipelineManager->UpdatePipelines(diffUpdate3);
     result.get();
+    BlockProcessor(configName);
     APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
 
     AddDataToProcessQueue(configName, "test-data-11");
@@ -1722,13 +1760,10 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase1() const {
 
     HttpSink::GetInstance()->Init();
     FlusherRunner::GetInstance()->Init();
-    auto processor2
-        = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
-    processor2->Unblock();
     UnBlockProcessor(configName);
     VerifyData("test_logstore_1", 1, 3);
-    VerifyData("test_logstore_2", 4, 4);
-    VerifyData("test_logstore_3", 5, 13);
+    VerifyData("test_logstore_2", 4, 4, true);
+    VerifyData("test_logstore_3", 5, 13, true);
 }
 
 void PipelineUpdateUnittest::TestPipelineUpdateManyCase2() const {
@@ -1786,11 +1821,12 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase2() const {
     diffUpdate3.mModified.push_back(std::move(pipelineConfigObjUpdate3));
     auto result = async(launch::async, [&]() {
         this_thread::sleep_for(chrono::milliseconds(1000));
-        auto processor1
-            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline1->mProcessorLine[0].get()->mPlugin.get()));
-        processor1->Unblock();
+        auto processor2
+            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
+        processor2->Unblock();
     });
     pipelineManager->UpdatePipelines(diffUpdate3);
+    BlockProcessor(configName);
     result.get();
     APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
 
@@ -1800,13 +1836,10 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase2() const {
 
     HttpSink::GetInstance()->Init();
     FlusherRunner::GetInstance()->Init();
-    auto processor2
-        = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
-    processor2->Unblock();
     UnBlockProcessor(configName);
     VerifyData("test_logstore_1", 1, 3);
-    VerifyData("test_logstore_2", 4, 4);
-    VerifyData("test_logstore_3", 5, 10);
+    VerifyData("test_logstore_2", 4, 4, true);
+    VerifyData("test_logstore_3", 5, 10, true);
 }
 
 void PipelineUpdateUnittest::TestPipelineUpdateManyCase3() const {
@@ -1864,11 +1897,12 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase3() const {
     diffUpdate3.mModified.push_back(std::move(pipelineConfigObjUpdate3));
     auto result = async(launch::async, [&]() {
         this_thread::sleep_for(chrono::milliseconds(1000));
-        auto processor1
-            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline1->mProcessorLine[0].get()->mPlugin.get()));
-        processor1->Unblock();
+        auto processor2
+            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
+        processor2->Unblock();
     });
     pipelineManager->UpdatePipelines(diffUpdate3);
+    BlockProcessor(configName);
     result.get();
     APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
 
@@ -1878,13 +1912,10 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase3() const {
 
     HttpSink::GetInstance()->Init();
     FlusherRunner::GetInstance()->Init();
-    auto processor2
-        = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
-    processor2->Unblock();
     UnBlockProcessor(configName);
     VerifyData("test_logstore_1", 1, 3);
-    VerifyData("test_logstore_2", 4, 4);
-    VerifyData("test_logstore_3", 5, 10);
+    VerifyData("test_logstore_2", 4, 4, true);
+    VerifyData("test_logstore_3", 5, 10, true);
 }
 
 void PipelineUpdateUnittest::TestPipelineUpdateManyCase4() const {
@@ -1939,11 +1970,12 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase4() const {
     diffUpdate3.mModified.push_back(std::move(pipelineConfigObjUpdate3));
     auto result = async(launch::async, [&]() {
         this_thread::sleep_for(chrono::milliseconds(1000));
-        auto processor1
-            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline1->mProcessorLine[0].get()->mPlugin.get()));
-        processor1->Unblock();
+        auto processor2
+            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
+        processor2->Unblock();
     });
     pipelineManager->UpdatePipelines(diffUpdate3);
+    BlockProcessor(configName);
     result.get();
     APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
 
@@ -1953,13 +1985,10 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase4() const {
 
     HttpSink::GetInstance()->Init();
     FlusherRunner::GetInstance()->Init();
-    auto processor2
-        = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
-    processor2->Unblock();
     UnBlockProcessor(configName);
     VerifyData("test_logstore_1", 1, 3);
-    VerifyData("test_logstore_2", 4, 4);
-    VerifyData("test_logstore_3", 5, 7);
+    VerifyData("test_logstore_2", 4, 4, true);
+    VerifyData("test_logstore_3", 5, 7, true);
 }
 
 void PipelineUpdateUnittest::TestPipelineUpdateManyCase5() const {
@@ -2015,11 +2044,12 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase5() const {
     diffUpdate3.mModified.push_back(std::move(pipelineConfigObjUpdate3));
     auto result = async(launch::async, [&]() {
         this_thread::sleep_for(chrono::milliseconds(1000));
-        auto processor1
-            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline1->mProcessorLine[0].get()->mPlugin.get()));
-        processor1->Unblock();
+        auto processor2
+            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
+        processor2->Unblock();
     });
     pipelineManager->UpdatePipelines(diffUpdate3);
+    BlockProcessor(configName);
     result.get();
     APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
 
@@ -2029,12 +2059,9 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase5() const {
 
     HttpSink::GetInstance()->Init();
     FlusherRunner::GetInstance()->Init();
-    auto processor2
-        = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
-    processor2->Unblock();
     UnBlockProcessor(configName);
-    VerifyData("test_logstore_2", 1, 1);
-    VerifyData("test_logstore_3", 2, 10);
+    VerifyData("test_logstore_2", 1, 1, true);
+    VerifyData("test_logstore_3", 2, 10, true);
 }
 
 void PipelineUpdateUnittest::TestPipelineUpdateManyCase6() const {
@@ -2087,11 +2114,12 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase6() const {
     diffUpdate3.mModified.push_back(std::move(pipelineConfigObjUpdate3));
     auto result = async(launch::async, [&]() {
         this_thread::sleep_for(chrono::milliseconds(1000));
-        auto processor1
-            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline1->mProcessorLine[0].get()->mPlugin.get()));
-        processor1->Unblock();
+        auto processor2
+            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
+        processor2->Unblock();
     });
     pipelineManager->UpdatePipelines(diffUpdate3);
+    BlockProcessor(configName);
     result.get();
     APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
 
@@ -2101,12 +2129,9 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase6() const {
 
     HttpSink::GetInstance()->Init();
     FlusherRunner::GetInstance()->Init();
-    auto processor2
-        = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
-    processor2->Unblock();
     UnBlockProcessor(configName);
-    VerifyData("test_logstore_2", 1, 1);
-    VerifyData("test_logstore_3", 2, 7);
+    VerifyData("test_logstore_2", 1, 1, true);
+    VerifyData("test_logstore_3", 2, 7, true);
 }
 
 void PipelineUpdateUnittest::TestPipelineUpdateManyCase7() const {
@@ -2159,11 +2184,12 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase7() const {
     diffUpdate3.mModified.push_back(std::move(pipelineConfigObjUpdate3));
     auto result = async(launch::async, [&]() {
         this_thread::sleep_for(chrono::milliseconds(1000));
-        auto processor1
-            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline1->mProcessorLine[0].get()->mPlugin.get()));
-        processor1->Unblock();
+        auto processor2
+            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
+        processor2->Unblock();
     });
     pipelineManager->UpdatePipelines(diffUpdate3);
+    BlockProcessor(configName);
     result.get();
     APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
 
@@ -2173,12 +2199,9 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase7() const {
 
     HttpSink::GetInstance()->Init();
     FlusherRunner::GetInstance()->Init();
-    auto processor2
-        = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
-    processor2->Unblock();
     UnBlockProcessor(configName);
-    VerifyData("test_logstore_2", 1, 1);
-    VerifyData("test_logstore_3", 2, 7);
+    VerifyData("test_logstore_2", 1, 1, true);
+    VerifyData("test_logstore_3", 2, 7, true);
 }
 
 void PipelineUpdateUnittest::TestPipelineUpdateManyCase8() const {
@@ -2228,11 +2251,12 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase8() const {
     diffUpdate3.mModified.push_back(std::move(pipelineConfigObjUpdate3));
     auto result = async(launch::async, [&]() {
         this_thread::sleep_for(chrono::milliseconds(1000));
-        auto processor1
-            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline1->mProcessorLine[0].get()->mPlugin.get()));
-        processor1->Unblock();
+        auto processor2
+            = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
+        processor2->Unblock();
     });
     pipelineManager->UpdatePipelines(diffUpdate3);
+    BlockProcessor(configName);
     result.get();
     APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
 
@@ -2242,12 +2266,9 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase8() const {
 
     HttpSink::GetInstance()->Init();
     FlusherRunner::GetInstance()->Init();
-    auto processor2
-        = static_cast<ProcessorMock*>(const_cast<Processor*>(pipeline2->mProcessorLine[0].get()->mPlugin.get()));
-    processor2->Unblock();
     UnBlockProcessor(configName);
-    VerifyData("test_logstore_2", 1, 1);
-    VerifyData("test_logstore_3", 2, 4);
+    VerifyData("test_logstore_2", 1, 1, true);
+    VerifyData("test_logstore_3", 2, 4, true);
 }
 
 void PipelineUpdateUnittest::TestPipelineUpdateManyCase9() const {
@@ -2314,7 +2335,7 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase9() const {
     UnBlockProcessor(configName);
     VerifyData("test_logstore_1", 1, 3);
     VerifyData("test_logstore_2", 4, 6);
-    VerifyData("test_logstore_3", 7, 9);
+    VerifyData("test_logstore_3", 7, 9, true);
 }
 
 void PipelineUpdateUnittest::TestPipelineUpdateManyCase10() const {
@@ -2377,6 +2398,43 @@ void PipelineUpdateUnittest::TestPipelineUpdateManyCase10() const {
     VerifyData("test_logstore_3", 4, 6);
 }
 
+void PipelineUpdateUnittest::TestPipelineRelease() const {
+    const std::string configName = "test1";
+    ProcessorRunner::GetInstance()->Stop();
+    // load old pipeline
+    Json::Value pipelineConfigJson
+        = GeneratePipelineConfigJson(nativeInputConfig, nativeProcessorConfig, nativeFlusherConfig);
+    auto pipelineManager = CollectionPipelineManager::GetInstance();
+    CollectionConfigDiff diff;
+    CollectionConfig pipelineConfigObj = CollectionConfig(configName, make_unique<Json::Value>(pipelineConfigJson));
+    pipelineConfigObj.Parse();
+    diff.mAdded.push_back(std::move(pipelineConfigObj));
+    pipelineManager->UpdatePipelines(diff);
+    APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
+
+    // Add data without trigger
+    AddDataToProcessQueue(configName, "test-data-1");
+    AddDataToProcessQueue(configName, "test-data-2");
+    AddDataToProcessQueue(configName, "test-data-3");
+
+    // load new pipeline
+    Json::Value pipelineConfigJsonUpdate2
+        = GeneratePipelineConfigJson(nativeInputConfig2, nativeProcessorConfig2, slowFlusherConfig);
+    CollectionConfigDiff diffUpdate2;
+    CollectionConfig pipelineConfigObjUpdate2
+        = CollectionConfig(configName, make_unique<Json::Value>(pipelineConfigJsonUpdate2));
+    pipelineConfigObjUpdate2.Parse();
+    diffUpdate2.mModified.push_back(std::move(pipelineConfigObjUpdate2));
+    pipelineManager->UpdatePipelines(diffUpdate2);
+    APSARA_TEST_EQUAL_FATAL(1U, pipelineManager->GetAllPipelines().size());
+
+    ProcessorRunner::GetInstance()->Init();
+    HttpSink::GetInstance()->Init();
+    FlusherRunner::GetInstance()->Init();
+    VerifyData("test_logstore_2", 1, 3, true);
+    LOG_INFO(sLogger, ("test", "end"));
+}
+
 UNIT_TEST_CASE(PipelineUpdateUnittest, TestFileServerStart)
 UNIT_TEST_CASE(PipelineUpdateUnittest, TestPipelineParamUpdateCase1)
 UNIT_TEST_CASE(PipelineUpdateUnittest, TestPipelineParamUpdateCase2)
@@ -2413,6 +2471,7 @@ UNIT_TEST_CASE(PipelineUpdateUnittest, TestPipelineUpdateManyCase7)
 UNIT_TEST_CASE(PipelineUpdateUnittest, TestPipelineUpdateManyCase8)
 UNIT_TEST_CASE(PipelineUpdateUnittest, TestPipelineUpdateManyCase9)
 UNIT_TEST_CASE(PipelineUpdateUnittest, TestPipelineUpdateManyCase10)
+UNIT_TEST_CASE(PipelineUpdateUnittest, TestPipelineRelease)
 
 } // namespace logtail
 

--- a/core/unittest/plugin/PluginMock.h
+++ b/core/unittest/plugin/PluginMock.h
@@ -29,6 +29,7 @@
 #include "collection_pipeline/plugin/interface/Processor.h"
 #include "collection_pipeline/queue/SLSSenderQueueItem.h"
 #include "collection_pipeline/queue/SenderQueueManager.h"
+#include "common/StringView.h"
 #include "plugin/flusher/sls/FlusherSLS.h"
 #include "task_pipeline/Task.h"
 #include "task_pipeline/TaskRegistry.h"
@@ -86,13 +87,27 @@ private:
 
 const std::string InputMock::sName = "input_mock";
 
+const std::string PROCESSOR_MOCK_LOCAL_CONTENT_KEY = "processor_mock_local_content_key";
+const std::string PROCESSOR_MOCK_LOCAL_CONTENT_VALUE = "processor_mock_local_content_value";
+
 class ProcessorMock : public Processor {
 public:
     static const std::string sName;
 
     const std::string& Name() const override { return sName; }
-    bool Init(const Json::Value& config) override { return true; }
+    bool Init(const Json::Value& config) override {
+        mLocalContentKey = PROCESSOR_MOCK_LOCAL_CONTENT_KEY;
+        mLocalContentValue = PROCESSOR_MOCK_LOCAL_CONTENT_VALUE;
+        return true;
+    }
     void Process(PipelineEventGroup& logGroup) override {
+        for (auto& e : logGroup.MutableEvents()) {
+            if (e.Is<LogEvent>()) {
+                auto& logEvent = e.Cast<LogEvent>();
+                logEvent.SetContentNoCopy(StringView(mLocalContentKey.data(), mLocalContentKey.size()),
+                                          StringView(mLocalContentValue.data(), mLocalContentValue.size()));
+            }
+        }
         while (mBlockFlag) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
@@ -108,6 +123,8 @@ protected:
     bool IsSupportedEvent(const PipelineEventPtr& e) const override { return true; };
 
     std::atomic_bool mBlockFlag = false;
+    std::string mLocalContentKey;
+    std::string mLocalContentValue;
 };
 
 const std::string ProcessorMock::sName = "processor_mock";

--- a/core/unittest/queue/BoundedProcessQueueUnittest.cpp
+++ b/core/unittest/queue/BoundedProcessQueueUnittest.cpp
@@ -31,7 +31,6 @@ public:
     void TestPush();
     void TestPop();
     void TestMetric();
-    void TestSetPipeline();
 
 protected:
     static void SetUpTestCase() { sCtx.SetConfigName("test_config"); }
@@ -144,31 +143,9 @@ void BoundedProcessQueueUnittest::TestMetric() {
     APSARA_TEST_EQUAL(1U, mQueue->mValidToPushFlag->GetValue());
 }
 
-void BoundedProcessQueueUnittest::TestSetPipeline() {
-    auto pipeline = make_shared<CollectionPipeline>();
-    CollectionPipelineManager::GetInstance()->mPipelineNameEntityMap["test_config"] = pipeline;
-
-    auto item1 = GenerateItem();
-    auto p1 = item1.get();
-    auto pipelineTmp = make_shared<CollectionPipeline>();
-    item1->mPipeline = pipelineTmp;
-
-    auto item2 = GenerateItem();
-    auto p2 = item2.get();
-
-    mQueue->Push(std::move(item1));
-    mQueue->Push(std::move(item2));
-    auto p = CollectionPipelineManager::GetInstance()->FindConfigByName("test_config");
-    mQueue->SetPipelineForItems(p);
-
-    APSARA_TEST_EQUAL(pipelineTmp, p1->mPipeline);
-    APSARA_TEST_EQUAL(pipeline, p2->mPipeline);
-}
-
 UNIT_TEST_CASE(BoundedProcessQueueUnittest, TestPush)
 UNIT_TEST_CASE(BoundedProcessQueueUnittest, TestPop)
 UNIT_TEST_CASE(BoundedProcessQueueUnittest, TestMetric)
-UNIT_TEST_CASE(BoundedProcessQueueUnittest, TestSetPipeline)
 
 } // namespace logtail
 

--- a/core/unittest/queue/CircularProcessQueueUnittest.cpp
+++ b/core/unittest/queue/CircularProcessQueueUnittest.cpp
@@ -29,7 +29,6 @@ public:
     void TestPop();
     void TestReset();
     void TestMetric();
-    void TestSetPipeline();
 
 protected:
     static void SetUpTestCase() { sCtx.SetConfigName("test_config"); }
@@ -181,32 +180,10 @@ void CircularProcessQueueUnittest::TestMetric() {
     APSARA_TEST_EQUAL(0U, mQueue->mQueueDataSizeByte->GetValue());
 }
 
-void CircularProcessQueueUnittest::TestSetPipeline() {
-    auto pipeline = make_shared<CollectionPipeline>();
-    CollectionPipelineManager::GetInstance()->mPipelineNameEntityMap["test_config"] = pipeline;
-
-    auto item1 = GenerateItem(1);
-    auto p1 = item1.get();
-    auto pipelineTmp = make_shared<CollectionPipeline>();
-    item1->mPipeline = pipelineTmp;
-
-    auto item2 = GenerateItem(1);
-    auto p2 = item2.get();
-
-    mQueue->Push(std::move(item1));
-    mQueue->Push(std::move(item2));
-    auto p = CollectionPipelineManager::GetInstance()->FindConfigByName("test_config");
-    mQueue->SetPipelineForItems(p);
-
-    APSARA_TEST_EQUAL(pipelineTmp, p1->mPipeline);
-    APSARA_TEST_EQUAL(pipeline, p2->mPipeline);
-}
-
 UNIT_TEST_CASE(CircularProcessQueueUnittest, TestPush)
 UNIT_TEST_CASE(CircularProcessQueueUnittest, TestPop)
 UNIT_TEST_CASE(CircularProcessQueueUnittest, TestReset)
 UNIT_TEST_CASE(CircularProcessQueueUnittest, TestMetric)
-UNIT_TEST_CASE(CircularProcessQueueUnittest, TestSetPipeline)
 
 } // namespace logtail
 

--- a/core/unittest/queue/ExactlyOnceQueueManagerUnittest.cpp
+++ b/core/unittest/queue/ExactlyOnceQueueManagerUnittest.cpp
@@ -297,8 +297,6 @@ void ExactlyOnceQueueManagerUnittest::OnPipelineUpdate() {
     sManager->DisablePopProcessQueue("test_config", false);
     APSARA_TEST_FALSE(ExactlyOnceQueueManager::GetInstance()->mProcessQueues[1]->mValidToPop);
     APSARA_TEST_FALSE(ExactlyOnceQueueManager::GetInstance()->mProcessQueues[2]->mValidToPop);
-    APSARA_TEST_EQUAL(pipeline1, p1->mPipeline);
-    APSARA_TEST_EQUAL(pipeline1, p2->mPipeline);
 
     auto item3 = GenerateProcessItem();
     auto p3 = item3.get();
@@ -314,10 +312,6 @@ void ExactlyOnceQueueManagerUnittest::OnPipelineUpdate() {
     sManager->DisablePopProcessQueue("test_config", false);
     APSARA_TEST_FALSE(sManager->mProcessQueues[1]->mValidToPop);
     APSARA_TEST_FALSE(sManager->mProcessQueues[2]->mValidToPop);
-    APSARA_TEST_EQUAL(pipeline1, p1->mPipeline);
-    APSARA_TEST_EQUAL(pipeline1, p2->mPipeline);
-    APSARA_TEST_EQUAL(pipeline2, p3->mPipeline);
-    APSARA_TEST_EQUAL(pipeline2, p4->mPipeline);
 
     auto item5 = GenerateProcessItem();
     auto p5 = item5.get();
@@ -330,12 +324,6 @@ void ExactlyOnceQueueManagerUnittest::OnPipelineUpdate() {
     sManager->DisablePopProcessQueue("test_config", true);
     APSARA_TEST_FALSE(sManager->mProcessQueues[1]->mValidToPop);
     APSARA_TEST_FALSE(sManager->mProcessQueues[2]->mValidToPop);
-    APSARA_TEST_EQUAL(pipeline1, p1->mPipeline);
-    APSARA_TEST_EQUAL(pipeline1, p2->mPipeline);
-    APSARA_TEST_EQUAL(pipeline2, p3->mPipeline);
-    APSARA_TEST_EQUAL(pipeline2, p4->mPipeline);
-    APSARA_TEST_EQUAL(nullptr, p5->mPipeline);
-    APSARA_TEST_EQUAL(nullptr, p6->mPipeline);
 
     sManager->EnablePopProcessQueue("test_config");
     APSARA_TEST_TRUE(sManager->mProcessQueues[1]->mValidToPop);

--- a/core/unittest/queue/ProcessQueueManagerUnittest.cpp
+++ b/core/unittest/queue/ProcessQueueManagerUnittest.cpp
@@ -384,7 +384,6 @@ void ProcessQueueManagerUnittest::OnPipelineUpdate() {
 
         sProcessQueueManager->DisablePop("test_config_1", false);
         APSARA_TEST_FALSE((*sProcessQueueManager->mQueues[key].first)->mValidToPop);
-        APSARA_TEST_EQUAL(pipeline1, p1->mPipeline);
 
         auto item2 = GenerateItem();
         auto p2 = item2.get();
@@ -395,8 +394,6 @@ void ProcessQueueManagerUnittest::OnPipelineUpdate() {
 
         sProcessQueueManager->DisablePop("test_config_1", false);
         APSARA_TEST_FALSE((*sProcessQueueManager->mQueues[key].first)->mValidToPop);
-        APSARA_TEST_EQUAL(pipeline1, p1->mPipeline);
-        APSARA_TEST_EQUAL(pipeline3, p2->mPipeline);
 
         auto item3 = GenerateItem();
         auto p3 = item3.get();
@@ -404,9 +401,6 @@ void ProcessQueueManagerUnittest::OnPipelineUpdate() {
 
         sProcessQueueManager->DisablePop("test_config_1", true);
         APSARA_TEST_FALSE((*sProcessQueueManager->mQueues[key].first)->mValidToPop);
-        APSARA_TEST_EQUAL(pipeline1, p1->mPipeline);
-        APSARA_TEST_EQUAL(pipeline3, p2->mPipeline);
-        APSARA_TEST_EQUAL(nullptr, p3->mPipeline);
 
         sProcessQueueManager->EnablePop("test_config_1");
         APSARA_TEST_TRUE((*sProcessQueueManager->mQueues[key].first)->mValidToPop);
@@ -423,8 +417,6 @@ void ProcessQueueManagerUnittest::OnPipelineUpdate() {
         sProcessQueueManager->DisablePop("test_config_2", false);
         APSARA_TEST_FALSE(ExactlyOnceQueueManager::GetInstance()->mProcessQueues[1]->mValidToPop);
         APSARA_TEST_FALSE(ExactlyOnceQueueManager::GetInstance()->mProcessQueues[2]->mValidToPop);
-        APSARA_TEST_EQUAL(pipeline2, p1->mPipeline);
-        APSARA_TEST_EQUAL(pipeline2, p2->mPipeline);
 
         auto item3 = GenerateItem();
         auto p3 = item3.get();
@@ -440,10 +432,6 @@ void ProcessQueueManagerUnittest::OnPipelineUpdate() {
         sProcessQueueManager->DisablePop("test_config_2", false);
         APSARA_TEST_FALSE(ExactlyOnceQueueManager::GetInstance()->mProcessQueues[1]->mValidToPop);
         APSARA_TEST_FALSE(ExactlyOnceQueueManager::GetInstance()->mProcessQueues[2]->mValidToPop);
-        APSARA_TEST_EQUAL(pipeline2, p1->mPipeline);
-        APSARA_TEST_EQUAL(pipeline2, p2->mPipeline);
-        APSARA_TEST_EQUAL(pipeline3, p3->mPipeline);
-        APSARA_TEST_EQUAL(pipeline3, p4->mPipeline);
 
         auto item5 = GenerateItem();
         auto p5 = item5.get();
@@ -456,12 +444,6 @@ void ProcessQueueManagerUnittest::OnPipelineUpdate() {
         sProcessQueueManager->DisablePop("test_config_2", true);
         APSARA_TEST_FALSE(ExactlyOnceQueueManager::GetInstance()->mProcessQueues[1]->mValidToPop);
         APSARA_TEST_FALSE(ExactlyOnceQueueManager::GetInstance()->mProcessQueues[2]->mValidToPop);
-        APSARA_TEST_EQUAL(pipeline2, p1->mPipeline);
-        APSARA_TEST_EQUAL(pipeline2, p2->mPipeline);
-        APSARA_TEST_EQUAL(pipeline3, p3->mPipeline);
-        APSARA_TEST_EQUAL(pipeline3, p4->mPipeline);
-        APSARA_TEST_EQUAL(nullptr, p5->mPipeline);
-        APSARA_TEST_EQUAL(nullptr, p6->mPipeline);
 
         sProcessQueueManager->EnablePop("test_config_2");
         APSARA_TEST_TRUE(ExactlyOnceQueueManager::GetInstance()->mProcessQueues[1]->mValidToPop);


### PR DESCRIPTION
配置更新时，残留在处理队列中的旧流水线数据，使用新流水线的处理插件处理。但是由于Input可能发生变化，所以退而求其次，使用旧流水线的inputIndex在新流水线找内置处理插件。如果找不到，则跳过内置处理插件。
之前代码在UT中会有非法访问的报错
![image](https://github.com/user-attachments/assets/017ccad1-7bec-4c91-a65d-9405be536538)
