### PR TITLE
Fixed the log writing deadlock problem caused by the logical loop of the Golang log module.

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -103,7 +103,6 @@ var (
 func InitLogger() {
 	once.Do(func() {
 		initNormalLogger()
-		catchStandardOutput()
 	})
 }
 
@@ -335,7 +334,6 @@ func generateDefaultConfig() string {
 
 // Close the logger and recover the stdout and stderr
 func Close() {
-	CloseCatchStdout()
 	logtailLogger.Close()
 }
 


### PR DESCRIPTION
主要改动：
1. 调试模式下，新增stack信息输出选项，用来输出当前程序堆栈信息
2. 去掉loongcollector logger模块捕获标准输出逻辑

问题原因：
1. seelog内部，在磁盘满的情况下，会使用fmt.Prrint输出日志
4. loongcollector logger模块，会捕获标准输出，然后重定向使用seelog输出
在磁盘满的情况下，loongcollector logger中，捕获标准输出逻辑会hang住，从而导致seelog内部锁一直不释放

关键堆栈信息：
1. seelog内部fmt输出卡住，这里卡住会导致seelog的锁一直被此协程持有，其他协程拿不到锁
![image](https://github.com/user-attachments/assets/affe753f-83ba-4394-8ae9-3f64c4505025)
2. 业务协程调用seelog卡住
![image](https://github.com/user-attachments/assets/ac32b7d3-fec8-466d-b7db-461628b42703)

