### PR TITLE
Fix the crash caused by interface null value judgment error in golang.

### DIFF
--- a/pkg/helper/containercenter/container_center.go
+++ b/pkg/helper/containercenter/container_center.go
@@ -1188,6 +1188,7 @@ func (dc *ContainerCenter) initClient() error {
 	// do not CreateDockerClient multi times
 	if dc.client == nil {
 		if dc.client, err = CreateDockerClient(); err != nil {
+			dc.client = nil
 			dc.setLastError(err, "init docker client from env error")
 			return err
 		}

--- a/pkg/helper/containercenter/container_center_test.go
+++ b/pkg/helper/containercenter/container_center_test.go
@@ -576,3 +576,13 @@ func TestContainerCenterFetchAllAndOne(t *testing.T) {
 		assert.Equal(t, true, container.deleteFlag)
 	}
 }
+
+func TestInitClientMutiTime(t *testing.T) {
+	containerCenterInstance = &ContainerCenter{}
+	err := containerCenterInstance.initClient()
+	assert.NotNil(t, err)
+	assert.Nil(t, containerCenterInstance.client)
+	err = containerCenterInstance.initClient()
+	assert.NotNil(t, err)
+	assert.Nil(t, containerCenterInstance.client)
+}

--- a/pkg/helper/containercenter/container_center_test.go
+++ b/pkg/helper/containercenter/container_center_test.go
@@ -579,10 +579,9 @@ func TestContainerCenterFetchAllAndOne(t *testing.T) {
 
 func TestInitClientMutiTime(t *testing.T) {
 	containerCenterInstance = &ContainerCenter{}
-	err := containerCenterInstance.initClient()
-	assert.NotNil(t, err)
-	assert.Nil(t, containerCenterInstance.client)
-	err = containerCenterInstance.initClient()
-	assert.NotNil(t, err)
-	assert.Nil(t, containerCenterInstance.client)
+	for i := 0; i < 100; i++ {
+		err := containerCenterInstance.initClient()
+		assert.NotNil(t, err)
+		assert.Nil(t, containerCenterInstance.client)
+	}
 }


### PR DESCRIPTION
问题现象：
非容器场景，但是配置了容器的采集配置，golang模块会持续crash在docker client处

问题原因：
docker client为Interface类型，Go 语言规范规定：
- 接口变量仅当类型和值都为 nil 时才等于 nil
- 当接口持有具体类型的 nil 值时，接口本身不是 nil

修复方案：
initClient失败的时候，强制dc.client = nil，这样保证类型和值都为nil