### PR TITLE
Fix: selfmonitor crash

### DIFF
--- a/core/collection_pipeline/CollectionPipeline.cpp
+++ b/core/collection_pipeline/CollectionPipeline.cpp
@@ -340,7 +340,7 @@ bool CollectionPipeline::Init(CollectionConfig&& config) {
         ProcessQueueManager::GetInstance()->SetDownStreamQueues(mContext.GetProcessQueueKey(), std::move(senderQueues));
     }
 
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(mMetricsRecordRef,
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(mMetricsRecordRef,
                                                          MetricCategory::METRIC_CATEGORY_PIPELINE,
                                                          {{METRIC_LABEL_KEY_PROJECT, mContext.GetProjectName()},
                                                           {METRIC_LABEL_KEY_PIPELINE_NAME, mName},
@@ -355,6 +355,7 @@ bool CollectionPipeline::Init(CollectionConfig&& config) {
     mFlushersInEventsTotal = mMetricsRecordRef.CreateCounter(METRIC_PIPELINE_FLUSHERS_IN_EVENTS_TOTAL);
     mFlushersInSizeBytes = mMetricsRecordRef.CreateCounter(METRIC_PIPELINE_FLUSHERS_IN_SIZE_BYTES);
     mFlushersTotalPackageTimeMs = mMetricsRecordRef.CreateTimeCounter(METRIC_PIPELINE_FLUSHERS_TOTAL_PACKAGE_TIME_MS);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 
     return true;
 }

--- a/core/collection_pipeline/batch/Batcher.h
+++ b/core/collection_pipeline/batch/Batcher.h
@@ -111,7 +111,7 @@ public:
         } else {
             labels.emplace_back(METRIC_LABEL_KEY_GROUP_BATCH_ENABLED, "false");
         }
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_COMPONENT, std::move(labels));
         mInEventsTotal = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_IN_EVENTS_TOTAL);
         mInGroupDataSizeBytes = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_IN_SIZE_BYTES);
@@ -122,6 +122,7 @@ public:
         mBufferedEventsTotal = mMetricsRecordRef.CreateIntGauge(METRIC_COMPONENT_BATCHER_BUFFERED_EVENTS_TOTAL);
         mBufferedDataSizeByte = mMetricsRecordRef.CreateIntGauge(METRIC_COMPONENT_BATCHER_BUFFERED_SIZE_BYTES);
         mTotalAddTimeMs = mMetricsRecordRef.CreateTimeCounter(METRIC_COMPONENT_BATCHER_TOTAL_ADD_TIME_MS);
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 
         return true;
     }

--- a/core/collection_pipeline/plugin/instance/FlusherInstance.cpp
+++ b/core/collection_pipeline/plugin/instance/FlusherInstance.cpp
@@ -27,7 +27,7 @@ bool FlusherInstance::Init(const Json::Value& config,
     mPlugin->SetContext(context);
     mPlugin->SetPluginID(PluginID());
     mPlugin->SetFlusherIndex(flusherIdx);
-    mPlugin->SetMetricsRecordRef(Name(), PluginID());
+    mPlugin->CreateMetricsRecordRef(Name(), PluginID());
     if (!mPlugin->Init(config, optionalGoPipeline)) {
         return false;
     }
@@ -36,6 +36,7 @@ bool FlusherInstance::Init(const Json::Value& config,
     mInEventsTotal = mPlugin->GetMetricsRecordRef().CreateCounter(METRIC_PLUGIN_IN_EVENTS_TOTAL);
     mInSizeBytes = mPlugin->GetMetricsRecordRef().CreateCounter(METRIC_PLUGIN_IN_SIZE_BYTES);
     mTotalPackageTimeMs = mPlugin->GetMetricsRecordRef().CreateTimeCounter(METRIC_PLUGIN_FLUSHER_TOTAL_PACKAGE_TIME_MS);
+    mPlugin->CommitMetricsRecordRef();
     return true;
 }
 

--- a/core/collection_pipeline/plugin/instance/InputInstance.cpp
+++ b/core/collection_pipeline/plugin/instance/InputInstance.cpp
@@ -20,11 +20,12 @@ bool InputInstance::Init(const Json::Value& config,
                          size_t inputIdx,
                          Json::Value& optionalGoPipeline) {
     mPlugin->SetContext(context);
-    mPlugin->SetMetricsRecordRef(Name(), PluginID());
+    mPlugin->CreateMetricsRecordRef(Name(), PluginID());
     mPlugin->SetInputIndex(inputIdx);
     if (!mPlugin->Init(config, optionalGoPipeline)) {
         return false;
     }
+    mPlugin->CommitMetricsRecordRef();
     return true;
 }
 

--- a/core/collection_pipeline/plugin/instance/ProcessorInstance.cpp
+++ b/core/collection_pipeline/plugin/instance/ProcessorInstance.cpp
@@ -28,7 +28,7 @@ namespace logtail {
 
 bool ProcessorInstance::Init(const Json::Value& config, CollectionPipelineContext& context) {
     mPlugin->SetContext(context);
-    mPlugin->SetMetricsRecordRef(Name(), PluginID());
+    mPlugin->CreateMetricsRecordRef(Name(), PluginID());
     if (!mPlugin->Init(config)) {
         return false;
     }
@@ -39,7 +39,7 @@ bool ProcessorInstance::Init(const Json::Value& config, CollectionPipelineContex
     mInSizeBytes = mPlugin->GetMetricsRecordRef().CreateCounter(METRIC_PLUGIN_IN_SIZE_BYTES);
     mOutSizeBytes = mPlugin->GetMetricsRecordRef().CreateCounter(METRIC_PLUGIN_OUT_SIZE_BYTES);
     mTotalProcessTimeMs = mPlugin->GetMetricsRecordRef().CreateTimeCounter(METRIC_PLUGIN_TOTAL_PROCESS_TIME_MS);
-
+    mPlugin->CommitMetricsRecordRef();
     return true;
 }
 

--- a/core/collection_pipeline/plugin/interface/Plugin.h
+++ b/core/collection_pipeline/plugin/interface/Plugin.h
@@ -36,8 +36,8 @@ public:
     bool HasContext() const { return mContext != nullptr; }
     void SetContext(CollectionPipelineContext& context) { mContext = &context; }
     MetricsRecordRef& GetMetricsRecordRef() const { return mMetricsRecordRef; }
-    void SetMetricsRecordRef(const std::string& name, const std::string& id) {
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    void CreateMetricsRecordRef(const std::string& name, const std::string& id) {
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             mMetricsRecordRef,
             MetricCategory::METRIC_CATEGORY_PLUGIN,
             {{METRIC_LABEL_KEY_PROJECT, mContext->GetProjectName()},
@@ -45,6 +45,10 @@ public:
              {METRIC_LABEL_KEY_LOGSTORE, mContext->GetLogstoreName()},
              {METRIC_LABEL_KEY_PLUGIN_TYPE, name},
              {METRIC_LABEL_KEY_PLUGIN_ID, id}});
+    }
+
+    void CommitMetricsRecordRef() {
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
     }
 
 protected:

--- a/core/collection_pipeline/route/Router.cpp
+++ b/core/collection_pipeline/route/Router.cpp
@@ -35,7 +35,7 @@ bool Router::Init(std::vector<pair<size_t, const Json::Value*>> configs, const C
         }
     }
 
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef,
         MetricCategory::METRIC_CATEGORY_COMPONENT,
         {{METRIC_LABEL_KEY_PROJECT, ctx.GetProjectName()},
@@ -43,6 +43,7 @@ bool Router::Init(std::vector<pair<size_t, const Json::Value*>> configs, const C
          {METRIC_LABEL_KEY_COMPONENT_NAME, METRIC_LABEL_VALUE_COMPONENT_NAME_ROUTER}});
     mInEventsTotal = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_IN_EVENTS_TOTAL);
     mInGroupDataSizeBytes = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_IN_SIZE_BYTES);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
     return true;
 }
 

--- a/core/collection_pipeline/serializer/Serializer.h
+++ b/core/collection_pipeline/serializer/Serializer.h
@@ -47,7 +47,7 @@ template <typename T>
 class Serializer {
 public:
     Serializer(Flusher* f) : mFlusher(f) {
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             mMetricsRecordRef,
             MetricCategory::METRIC_CATEGORY_COMPONENT,
             {{METRIC_LABEL_KEY_PROJECT, f->GetContext().GetProjectName()},
@@ -61,6 +61,7 @@ public:
         mTotalProcessMs = mMetricsRecordRef.CreateTimeCounter(METRIC_COMPONENT_TOTAL_PROCESS_TIME_MS);
         mDiscardedItemsTotal = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_DISCARDED_ITEMS_TOTAL);
         mDiscardedItemSizeBytes = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_DISCARDED_SIZE_BYTES);
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
     }
     virtual ~Serializer() = default;
 

--- a/core/common/compression/Compressor.cpp
+++ b/core/common/compression/Compressor.cpp
@@ -23,7 +23,7 @@ using namespace std;
 namespace logtail {
 
 void Compressor::SetMetricRecordRef(MetricLabels&& labels, DynamicMetricLabels&& dynamicLabels) {
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_COMPONENT, std::move(labels), std::move(dynamicLabels));
     mInItemsTotal = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_IN_ITEMS_TOTAL);
     mInItemSizeBytes = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_IN_SIZE_BYTES);
@@ -32,6 +32,7 @@ void Compressor::SetMetricRecordRef(MetricLabels&& labels, DynamicMetricLabels&&
     mTotalProcessMs = mMetricsRecordRef.CreateTimeCounter(METRIC_COMPONENT_TOTAL_PROCESS_TIME_MS);
     mDiscardedItemsTotal = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_DISCARDED_ITEMS_TOTAL);
     mDiscardedItemSizeBytes = mMetricsRecordRef.CreateCounter(METRIC_COMPONENT_DISCARDED_SIZE_BYTES);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 }
 
 bool Compressor::DoCompress(const string& input, string& output, string& errorMsg) {

--- a/core/ebpf/EBPFServer.cpp
+++ b/core/ebpf/EBPFServer.cpp
@@ -173,7 +173,7 @@ void EBPFServer::Init() {
     // mMonitorMgr = std::make_unique<eBPFSelfMonitorMgr>();
     DynamicMetricLabels dynamicLabels;
     dynamicLabels.emplace_back(METRIC_LABEL_KEY_PROJECT, [this]() -> std::string { return this->GetAllProjects(); });
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef,
         MetricCategory::METRIC_CATEGORY_RUNNER,
         {{METRIC_LABEL_KEY_RUNNER_NAME, METRIC_LABEL_VALUE_RUNNER_NAME_EBPF_SERVER}},
@@ -186,6 +186,7 @@ void EBPFServer::Init() {
     auto processDataMapSize = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_EBPF_PROCESS_DATA_MAP_SIZE);
     auto retryableEventCacheSize = mMetricsRecordRef.CreateIntGauge(
         METRIC_RUNNER_EBPF_RETRYABLE_EVENT_CACHE_SIZE); // TODO: shoud be shared across network connection retry
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 
     mEBPFAdapter->Init();
 

--- a/core/file_server/FileServer.cpp
+++ b/core/file_server/FileServer.cpp
@@ -33,7 +33,7 @@ using namespace std;
 namespace logtail {
 
 FileServer::FileServer() {
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef,
         MetricCategory::METRIC_CATEGORY_RUNNER,
         {{METRIC_LABEL_KEY_RUNNER_NAME, METRIC_LABEL_VALUE_RUNNER_NAME_FILE_SERVER}});
@@ -62,6 +62,7 @@ void FileServer::Start() {
         PollingDirFile::GetInstance()->Start();
     }
     LogInput::GetInstance()->Start();
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
     LOG_INFO(sLogger, ("file server", "started"));
 }
 

--- a/core/metadata/K8sMetadata.cpp
+++ b/core/metadata/K8sMetadata.cpp
@@ -117,7 +117,7 @@ K8sMetadata::K8sMetadata(size_t ipCacheSize, size_t cidCacheSize, size_t externa
 #endif
 
     // self monitor
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mRef,
         MetricCategory::METRIC_CATEGORY_RUNNER,
         {{METRIC_LABEL_KEY_RUNNER_NAME, METRIC_LABEL_VALUE_RUNNER_NAME_K8S_METADATA}});
@@ -127,6 +127,7 @@ K8sMetadata::K8sMetadata(size_t ipCacheSize, size_t cidCacheSize, size_t externa
     mExternalIpCacheSize = mRef.CreateIntGauge(METRIC_RUNNER_METADATA_EXTERNAL_IP_CACHE_SIZE);
     mRequestMetaServerTotal = mRef.CreateCounter(METRIC_RUNNER_METADATA_REQUEST_REMOTE_TOTAL);
     mRequestMetaServerFailedTotal = mRef.CreateCounter(METRIC_RUNNER_METADATA_REQUEST_REMOTE_FAILED_TOTAL);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mRef);
 
     // batch query metadata ...
     if (mEnable) {

--- a/core/monitor/MetricManager.cpp
+++ b/core/monitor/MetricManager.cpp
@@ -35,14 +35,6 @@ WriteMetrics::~WriteMetrics() {
     Clear();
 }
 
-void WriteMetrics::PrepareMetricsRecordRef(MetricsRecordRef& ref,
-                                           const std::string& category,
-                                           MetricLabels&& labels,
-                                           DynamicMetricLabels&& dynamicLabels) {
-    CreateMetricsRecordRef(ref, category, std::move(labels), std::move(dynamicLabels));
-    CommitMetricsRecordRef(ref);
-}
-
 void WriteMetrics::CreateMetricsRecordRef(MetricsRecordRef& ref,
                                           const std::string& category,
                                           MetricLabels&& labels,

--- a/core/monitor/MetricManager.h
+++ b/core/monitor/MetricManager.h
@@ -46,10 +46,11 @@ public:
         return ptr;
     }
 
-    void PrepareMetricsRecordRef(MetricsRecordRef& ref,
-                                 const std::string& category,
-                                 MetricLabels&& labels,
-                                 DynamicMetricLabels&& dynamicLabels = {});
+    // PrepareMetricsRecordRef is unsafe, use CreateMetricsRecordRef + CommitMetricsRecordRef instead
+    // void PrepareMetricsRecordRef(MetricsRecordRef& ref,
+    //                              const std::string& category,
+    //                              MetricLabels&& labels,
+    //                              DynamicMetricLabels&& dynamicLabels = {});
     void CreateMetricsRecordRef(MetricsRecordRef& ref,
                                 const std::string& category,
                                 MetricLabels&& labels,

--- a/core/monitor/Monitor.cpp
+++ b/core/monitor/Monitor.cpp
@@ -625,7 +625,7 @@ void LoongCollectorMonitor::Init() {
         return EnterpriseConfigProvider::GetInstance()->GetUserDefinedIdSet();
     });
 #endif
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_AGENT, std::move(labels), std::move(dynamicLabels));
     // init value
     mAgentCpu = mMetricsRecordRef.CreateDoubleGauge(METRIC_AGENT_CPU);
@@ -634,6 +634,7 @@ void LoongCollectorMonitor::Init() {
     mAgentGoRoutinesTotal = mMetricsRecordRef.CreateIntGauge(METRIC_AGENT_GO_ROUTINES_TOTAL);
     mAgentOpenFdTotal = mMetricsRecordRef.CreateIntGauge(METRIC_AGENT_OPEN_FD_TOTAL);
     mAgentConfigTotal = mMetricsRecordRef.CreateIntGauge(METRIC_AGENT_PIPELINE_CONFIG_TOTAL);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 }
 
 void LoongCollectorMonitor::Stop() {

--- a/core/monitor/metric_models/ReentrantMetricsRecord.cpp
+++ b/core/monitor/metric_models/ReentrantMetricsRecord.cpp
@@ -22,7 +22,7 @@ void ReentrantMetricsRecord::Init(const std::string& category,
                                   MetricLabels& labels,
                                   DynamicMetricLabels& dynamicLabels,
                                   std::unordered_map<std::string, MetricType>& metricKeys) {
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef, category, std::move(labels), std::move(dynamicLabels));
     for (auto metric : metricKeys) {
         switch (metric.second) {
@@ -42,6 +42,7 @@ void ReentrantMetricsRecord::Init(const std::string& category,
                 break;
         }
     }
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 }
 
 const MetricLabelsPtr& ReentrantMetricsRecord::GetLabels() const {

--- a/core/prometheus/PrometheusInputRunner.cpp
+++ b/core/prometheus/PrometheusInputRunner.cpp
@@ -58,12 +58,13 @@ PrometheusInputRunner::PrometheusInputRunner()
     DynamicMetricLabels dynamicLabels;
     dynamicLabels.emplace_back(METRIC_LABEL_KEY_PROJECT, [this]() -> std::string { return this->GetAllProjects(); });
 
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_RUNNER, std::move(labels), std::move(dynamicLabels));
 
     mPromRegisterState = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_CLIENT_REGISTER_STATE);
     mPromJobNum = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_JOBS_TOTAL);
     mPromRegisterRetryTotal = mMetricsRecordRef.CreateCounter(METRIC_RUNNER_CLIENT_REGISTER_RETRY_TOTAL);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 }
 
 /// @brief receive scrape jobs from input plugins and update scrape jobs

--- a/core/prometheus/schedulers/ScrapeScheduler.cpp
+++ b/core/prometheus/schedulers/ScrapeScheduler.cpp
@@ -235,10 +235,11 @@ void ScrapeScheduler::InitSelfMonitor(const MetricLabels& defaultLabels) {
 
     mSelfMonitor->InitMetricManager(sScrapeMetricKeys, labels);
 
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_PLUGIN_SOURCE, std::move(labels));
     mPromDelayTotal = mMetricsRecordRef.CreateCounter(METRIC_PLUGIN_PROM_SCRAPE_DELAY_TOTAL);
     mPluginTotalDelayMs = mMetricsRecordRef.CreateCounter(METRIC_PLUGIN_TOTAL_DELAY_MS);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 }
 
 } // namespace logtail

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
@@ -471,10 +471,11 @@ void TargetSubscriberScheduler::InitSelfMonitor(const MetricLabels& defaultLabel
     mSelfMonitor = std::make_shared<PromSelfMonitorUnsafe>();
     mSelfMonitor->InitMetricManager(sSubscriberMetricKeys, mDefaultLabels);
 
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_PLUGIN_SOURCE, std::move(mDefaultLabels));
     mPromSubscriberTargets = mMetricsRecordRef.CreateIntGauge(METRIC_PLUGIN_PROM_SUBSCRIBE_TARGETS);
     mTotalDelayMs = mMetricsRecordRef.CreateCounter(METRIC_PLUGIN_TOTAL_DELAY_MS);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 }
 
 } // namespace logtail

--- a/core/runner/FlusherRunner.cpp
+++ b/core/runner/FlusherRunner.cpp
@@ -41,7 +41,7 @@ bool FlusherRunner::Init() {
     mCallback = [this]() { return LoadModuleConfig(false); };
     AppConfig::GetInstance()->RegisterCallback("max_bytes_per_sec", &mCallback);
 
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef,
         MetricCategory::METRIC_CATEGORY_RUNNER,
         {{METRIC_LABEL_KEY_RUNNER_NAME, METRIC_LABEL_VALUE_RUNNER_NAME_FLUSHER}});
@@ -52,6 +52,7 @@ bool FlusherRunner::Init() {
     mLastRunTime = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_LAST_RUN_TIME);
     mInItemRawDataSizeBytes = mMetricsRecordRef.CreateCounter(METRIC_RUNNER_FLUSHER_IN_RAW_SIZE_BYTES);
     mWaitingItemsTotal = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_FLUSHER_WAITING_ITEMS_TOTAL);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 
     mThreadRes = async(launch::async, &FlusherRunner::Run, this);
     mLastCheckSendClientTime = time(nullptr);

--- a/core/runner/ProcessorRunner.cpp
+++ b/core/runner/ProcessorRunner.cpp
@@ -91,7 +91,7 @@ void ProcessorRunner::Run(uint32_t threadNo) {
 
     // thread local metrics should be initialized in each thread
     sThreadNo = threadNo;
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         sMetricsRecordRef,
         MetricCategory::METRIC_CATEGORY_RUNNER,
         {{METRIC_LABEL_KEY_RUNNER_NAME, METRIC_LABEL_VALUE_RUNNER_NAME_PROCESSOR},
@@ -100,6 +100,7 @@ void ProcessorRunner::Run(uint32_t threadNo) {
     sInEventsCnt = sMetricsRecordRef.CreateCounter(METRIC_RUNNER_IN_EVENTS_TOTAL);
     sInGroupDataSizeBytes = sMetricsRecordRef.CreateCounter(METRIC_RUNNER_IN_SIZE_BYTES);
     sLastRunTime = sMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_LAST_RUN_TIME);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(sMetricsRecordRef);
 
     static int32_t lastFlushBatchTime = 0;
     while (true) {

--- a/core/runner/sink/http/HttpSink.cpp
+++ b/core/runner/sink/http/HttpSink.cpp
@@ -52,7 +52,7 @@ bool HttpSink::Init() {
         return false;
     }
 
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         mMetricsRecordRef,
         MetricCategory::METRIC_CATEGORY_RUNNER,
         {{METRIC_LABEL_KEY_RUNNER_NAME, METRIC_LABEL_VALUE_RUNNER_NAME_HTTP_SINK}});
@@ -66,6 +66,7 @@ bool HttpSink::Init() {
         = mMetricsRecordRef.CreateTimeCounter(METRIC_RUNNER_SINK_FAILED_ITEM_TOTAL_RESPONSE_TIME_MS);
     mSendingItemsTotal = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_SINK_SENDING_ITEMS_TOTAL);
     mSendConcurrency = mMetricsRecordRef.CreateIntGauge(METRIC_RUNNER_SINK_SEND_CONCURRENCY);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
 
     // TODO: should be dynamic
     SET_GAUGE(mSendConcurrency, AppConfig::GetInstance()->GetSendRequestGlobalConcurrency());

--- a/core/unittest/batch/BatcherUnittest.cpp
+++ b/core/unittest/batch/BatcherUnittest.cpp
@@ -42,7 +42,7 @@ protected:
     void SetUp() override {
         mCtx.SetConfigName("test_config");
         sFlusher->SetContext(mCtx);
-        sFlusher->SetMetricsRecordRef(FlusherMock::sName, "1");
+        sFlusher->CreateMetricsRecordRef(FlusherMock::sName, "1");
         sFlusher->SetPluginID("1");
     }
 

--- a/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
+++ b/core/unittest/batch/TimeoutFlushManagerUnittest.cpp
@@ -31,7 +31,7 @@ protected:
         sFlusher = make_unique<FlusherMock>();
         sCtx.SetConfigName("test_config");
         sFlusher->SetContext(sCtx);
-        sFlusher->SetMetricsRecordRef(FlusherMock::sName, "1");
+        sFlusher->CreateMetricsRecordRef(FlusherMock::sName, "1");
     }
 
     void TearDown() override { TimeoutFlushManager::GetInstance()->mTimeoutRecords.clear(); }
@@ -80,7 +80,7 @@ void TimeoutFlushManagerUnittest::TestFlushTimeoutBatch() {
 void TimeoutFlushManagerUnittest::TestUnregisterFlushers() {
     auto flusher = new FlusherMock();
     flusher->SetContext(sCtx);
-    flusher->SetMetricsRecordRef(FlusherMock::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherMock::sName, "1");
     auto instance = unique_ptr<FlusherInstance>(new FlusherInstance(flusher, PluginInstance::PluginMeta("1")));
     vector<unique_ptr<FlusherInstance>> flushers;
     flushers.push_back(std::move(instance));

--- a/core/unittest/config/PipelineManagerMock.h
+++ b/core/unittest/config/PipelineManagerMock.h
@@ -22,11 +22,12 @@ class PipelineMock : public CollectionPipeline {
 public:
     bool Init(CollectionConfig&& config) {
         mConfig = std::move(config.mDetail);
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             mMetricsRecordRef,
             MetricCategory::METRIC_CATEGORY_PIPELINE,
             {{METRIC_LABEL_KEY_PROJECT, mContext.GetProjectName()}, {METRIC_LABEL_KEY_PIPELINE_NAME, mName}});
         mStartTime = mMetricsRecordRef.CreateIntGauge(METRIC_PIPELINE_START_TIME);
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
         mSingletonInput = config.mSingletonInput;
         mContext.SetCreateTime(config.mCreateTime);
         return (*mConfig)["valid"].asBool();

--- a/core/unittest/ebpf/EBPFServerUnittest.cpp
+++ b/core/unittest/ebpf/EBPFServerUnittest.cpp
@@ -142,7 +142,7 @@ void eBPFServerUnittest::TestNetworkObserver() {
     // observer_options.Init(ObserverType::NETWORK, configJson, &ctx, "test");
     std::shared_ptr<InputNetworkObserver> input(new InputNetworkObserver());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     auto initStatus = input->Init(configJson, optionalGoPipeline);
     EXPECT_TRUE(initStatus);
     EXPECT_TRUE(ebpf::EBPFServer::GetInstance()->mEnvMgr.AbleToLoadDyLib());
@@ -171,7 +171,7 @@ void eBPFServerUnittest::TestNetworkSecurity() {
     )";
     std::shared_ptr<InputNetworkSecurity> input(new InputNetworkSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
 
     std::string errorMsg;
     Json::Value configJson, optionalGoPipeline;
@@ -179,7 +179,7 @@ void eBPFServerUnittest::TestNetworkSecurity() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
 
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     auto initStatus = input->Init(configJson, optionalGoPipeline);
     APSARA_TEST_TRUE(initStatus);
 
@@ -223,7 +223,7 @@ void eBPFServerUnittest::TestNetworkSecurity() {
 //     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
 
 //     input->SetContext(ctx);
-//     input->SetMetricsRecordRef("test", "1");
+//     input->CreateMetricsRecordRef("test", "1");
 //     auto initStatus = input->Init(configJson, optionalGoPipeline);
 //     APSARA_TEST_TRUE(initStatus);
 
@@ -259,7 +259,7 @@ void eBPFServerUnittest::TestProcessSecurity() {
     security_options.Init(SecurityProbeType::PROCESS, configJson, &ctx, "test");
     std::shared_ptr<InputProcessSecurity> input(new InputProcessSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     auto initStatus = input->Init(configJson, optionalGoPipeline);
     APSARA_TEST_TRUE(initStatus);
 
@@ -301,7 +301,7 @@ void eBPFServerUnittest::TestProcessSecurity() {
 //     ctx.SetConfigName("test-pipeline-1");
 //     std::shared_ptr<InputFileSecurity> input(new InputFileSecurity());
 //     input->SetContext(ctx);
-//     input->SetMetricsRecordRef("test", "1");
+//     input->CreateMetricsRecordRef("test", "1");
 
 //     std::string errorMsg;
 //     Json::Value configJson, optionalGoPipeline;
@@ -329,7 +329,7 @@ void eBPFServerUnittest::TestProcessSecurity() {
 //         }
 //     )";
 //     input->SetContext(ctx);
-//     input->SetMetricsRecordRef("test", "2");
+//     input->CreateMetricsRecordRef("test", "2");
 //     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
 //     res = input->Init(configJson, optionalGoPipeline);
 //     EXPECT_TRUE(res);
@@ -360,7 +360,7 @@ void eBPFServerUnittest::TestUpdateNetworkSecurity() {
     std::shared_ptr<InputNetworkSecurity> input(new InputNetworkSecurity());
     ctx.SetConfigName("test-file-pipeline");
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
 
     std::string errorMsg;
     Json::Value configJson, optionalGoPipeline;
@@ -368,7 +368,7 @@ void eBPFServerUnittest::TestUpdateNetworkSecurity() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
 
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     auto initStatus = input->Init(configJson, optionalGoPipeline);
     APSARA_TEST_TRUE(initStatus);
 
@@ -400,7 +400,7 @@ void eBPFServerUnittest::TestUpdateNetworkSecurity() {
         }
     )";
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "2");
+    input->CreateMetricsRecordRef("test", "2");
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     res = input->Init(configJson, optionalGoPipeline);
     EXPECT_TRUE(res);

--- a/core/unittest/ebpf/ManagerUnittest.cpp
+++ b/core/unittest/ebpf/ManagerUnittest.cpp
@@ -40,7 +40,7 @@ protected:
         Timer::GetInstance()->Init();
         mEBPFAdapter = std::make_shared<EBPFAdapter>();
         DynamicMetricLabels dynamicLabels;
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             mRef,
             MetricCategory::METRIC_CATEGORY_RUNNER,
             {{METRIC_LABEL_KEY_RUNNER_NAME, METRIC_LABEL_VALUE_RUNNER_NAME_EBPF_SERVER}},
@@ -51,6 +51,7 @@ protected:
         auto processCacheSize = mRef.CreateIntGauge(METRIC_RUNNER_EBPF_PROCESS_CACHE_SIZE);
         auto processDataMapSize = mRef.CreateIntGauge(METRIC_RUNNER_EBPF_PROCESS_DATA_MAP_SIZE);
         auto retryableEventCacheSize = mRef.CreateIntGauge(METRIC_RUNNER_EBPF_RETRYABLE_EVENT_CACHE_SIZE);
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(mRef);
         mProcessCacheManager = std::make_shared<ProcessCacheManager>(mEBPFAdapter,
                                                                      "test_host",
                                                                      "/",

--- a/core/unittest/ebpf/NetworkObserverUnittest.cpp
+++ b/core/unittest/ebpf/NetworkObserverUnittest.cpp
@@ -54,7 +54,7 @@ protected:
         mEBPFAdapter = std::make_shared<EBPFAdapter>();
         mEBPFAdapter->Init();
         DynamicMetricLabels dynamicLabels;
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             mRef,
             MetricCategory::METRIC_CATEGORY_RUNNER,
             {{METRIC_LABEL_KEY_RUNNER_NAME, METRIC_LABEL_VALUE_RUNNER_NAME_EBPF_SERVER}},
@@ -65,6 +65,7 @@ protected:
         auto processCacheSize = mRef.CreateIntGauge(METRIC_RUNNER_EBPF_PROCESS_CACHE_SIZE);
         auto processDataMapSize = mRef.CreateIntGauge(METRIC_RUNNER_EBPF_PROCESS_DATA_MAP_SIZE);
         auto retryableEventCacheSize = mRef.CreateIntGauge(METRIC_RUNNER_EBPF_RETRYABLE_EVENT_CACHE_SIZE);
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(mRef);
         mProcessCacheManager = std::make_shared<ProcessCacheManager>(mEBPFAdapter,
                                                                      "test_host",
                                                                      "/",

--- a/core/unittest/ebpf/ProcessCacheManagerWrapper.h
+++ b/core/unittest/ebpf/ProcessCacheManagerWrapper.h
@@ -41,7 +41,7 @@ public:
         mTestRoot = std::filesystem::path(GetProcessExecutionDir()) / ss.str();
         mProcDir = mTestRoot / "proc";
         DynamicMetricLabels dynamicLabels;
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             mMetricRef,
             MetricCategory::METRIC_CATEGORY_RUNNER,
             {{METRIC_LABEL_KEY_RUNNER_NAME, METRIC_LABEL_VALUE_RUNNER_NAME_EBPF_SERVER}},
@@ -52,6 +52,7 @@ public:
         auto processCacheSize = mMetricRef.CreateIntGauge(METRIC_RUNNER_EBPF_PROCESS_CACHE_SIZE);
         auto processDataMapSize = mMetricRef.CreateIntGauge(METRIC_RUNNER_EBPF_PROCESS_DATA_MAP_SIZE);
         auto retryableEventCacheSize = mMetricRef.CreateIntGauge(METRIC_RUNNER_EBPF_RETRYABLE_EVENT_CACHE_SIZE);
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricRef);
         mProcessCacheManager = std::make_shared<ProcessCacheManager>(mEBPFAdapter,
                                                                      "test_host",
                                                                      mTestRoot.string(),

--- a/core/unittest/flusher/FlusherSLSUnittest.cpp
+++ b/core/unittest/flusher/FlusherSLSUnittest.cpp
@@ -114,7 +114,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
 #endif
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(optionalGoPipeline.isNull());
     APSARA_TEST_EQUAL("test_project", flusher->mProject);
@@ -171,7 +171,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
 #endif
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL("test_region", flusher->mRegion);
 #ifdef __ENTERPRISE__
@@ -207,7 +207,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
 #endif
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(STRING_FLAG(default_region_name), flusher->mRegion);
 #ifdef __ENTERPRISE__
@@ -234,7 +234,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(STRING_FLAG(default_region_name), flusher->mRegion);
     EnterpriseConfigProvider::GetInstance()->mIsPrivateCloud = false;
@@ -258,7 +258,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(EndpointMode::ACCELERATE, flusher->mEndpointMode);
     APSARA_TEST_EQUAL(EnterpriseSLSClientManager::GetInstance()->mRegionCandidateEndpointsMap.end(),
@@ -282,7 +282,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(EndpointMode::DEFAULT, flusher->mEndpointMode);
     auto& endpoints
@@ -308,7 +308,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(EndpointMode::DEFAULT, flusher->mEndpointMode);
     endpoints = EnterpriseSLSClientManager::GetInstance()->mRegionCandidateEndpointsMap["test_region"].mRemoteEndpoints;
@@ -335,7 +335,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL("test_region.log.aliyuncs.com", flusher->mEndpoint);
     SenderQueueManager::GetInstance()->Clear();
@@ -355,7 +355,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(sls_logs::SlsTelemetryType::SLS_TELEMETRY_TYPE_METRICS, flusher->mTelemetryType);
     SenderQueueManager::GetInstance()->Clear();
@@ -373,7 +373,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(sls_logs::SlsTelemetryType::SLS_TELEMETRY_TYPE_LOGS, flusher->mTelemetryType);
     SenderQueueManager::GetInstance()->Clear();
@@ -395,7 +395,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     flusher.reset(new FlusherSLS());
     ctx.SetExactlyOnceFlag(true);
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(flusher->mShardHashKeys.empty());
     ctx.SetExactlyOnceFlag(false);
@@ -417,7 +417,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_FALSE(flusher->mBatcher.GetGroupFlushStrategy().has_value());
     SenderQueueManager::GetInstance()->Clear();
@@ -435,7 +435,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     flusher.reset(new FlusherSLS());
     ctx.SetExactlyOnceFlag(true);
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_FALSE(flusher->mBatcher.GetGroupFlushStrategy().has_value());
     APSARA_TEST_EQUAL(nullptr, SenderQueueManager::GetInstance()->GetQueue(flusher->GetQueueKey()));
@@ -455,7 +455,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_FALSE(flusher->mBatcher.GetGroupFlushStrategy().has_value());
     SenderQueueManager::GetInstance()->Clear();
@@ -473,7 +473,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_FALSE(flusher->mBatcher.GetGroupFlushStrategy().has_value());
     SenderQueueManager::GetInstance()->Clear();
@@ -532,7 +532,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
         APSARA_TEST_TRUE(ParseJsonTable(cfg, configJson, errorMsg));
         flusher.reset(new FlusherSLS());
         flusher->SetContext(ctx);
-        flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+        flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
         APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
         APSARA_TEST_EQUAL(flusher->mSubpath, apmSubpath[ii]);
         APSARA_TEST_EQUAL(flusher->mTelemetryType, apmTelemetryTypes[ii]);
@@ -565,7 +565,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     pipeline.mPluginID.store(4);
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(optionalGoPipelineJson == optionalGoPipeline);
     optionalGoPipeline.clear();
@@ -597,7 +597,7 @@ void FlusherSLSUnittest::OnSuccessfulInit() {
     pipeline.mPluginID.store(4);
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(optionalGoPipelineJson.toStyledString(), optionalGoPipeline.toStyledString());
     ctx.SetIsFlushingThroughGoPipelineFlag(false);
@@ -620,7 +620,7 @@ void FlusherSLSUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_FALSE(flusher->Init(configJson, optionalGoPipeline));
 
     configStr = R"(
@@ -634,7 +634,7 @@ void FlusherSLSUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_FALSE(flusher->Init(configJson, optionalGoPipeline));
 
     // invalid Logstore
@@ -648,7 +648,7 @@ void FlusherSLSUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_FALSE(flusher->Init(configJson, optionalGoPipeline));
 
     configStr = R"(
@@ -662,7 +662,7 @@ void FlusherSLSUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_FALSE(flusher->Init(configJson, optionalGoPipeline));
 
 #ifndef __ENTERPRISE__
@@ -677,7 +677,7 @@ void FlusherSLSUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_FALSE(flusher->Init(configJson, optionalGoPipeline));
 
     configStr = R"(
@@ -691,7 +691,7 @@ void FlusherSLSUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     flusher.reset(new FlusherSLS());
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_FALSE(flusher->Init(configJson, optionalGoPipeline));
 #endif
 }
@@ -703,7 +703,7 @@ void FlusherSLSUnittest::OnPipelineUpdate() {
     Json::Value configJson, optionalGoPipeline;
     FlusherSLS flusher1;
     flusher1.SetContext(ctx1);
-    flusher1.SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher1.CreateMetricsRecordRef(FlusherSLS::sName, "1");
     string configStr, errorMsg;
 
     configStr = R"(
@@ -725,7 +725,7 @@ void FlusherSLSUnittest::OnPipelineUpdate() {
         ctx2.SetConfigName("test_config_2");
         FlusherSLS flusher2;
         flusher2.SetContext(ctx2);
-        flusher2.SetMetricsRecordRef(FlusherSLS::sName, "1");
+        flusher2.CreateMetricsRecordRef(FlusherSLS::sName, "1");
         configStr = R"(
             {
                 "Type": "flusher_sls",
@@ -755,7 +755,7 @@ void FlusherSLSUnittest::OnPipelineUpdate() {
         ctx2.SetConfigName("test_config_1");
         FlusherSLS flusher2;
         flusher2.SetContext(ctx2);
-        flusher2.SetMetricsRecordRef(FlusherSLS::sName, "1");
+        flusher2.CreateMetricsRecordRef(FlusherSLS::sName, "1");
         configStr = R"(
             {
                 "Type": "flusher_sls",
@@ -803,7 +803,7 @@ void FlusherSLSUnittest::TestBuildRequest() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     FlusherSLS flusher;
     flusher.SetContext(ctx);
-    flusher.SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher.CreateMetricsRecordRef(FlusherSLS::sName, "1");
     APSARA_TEST_TRUE(flusher.Init(configJson, optionalGoPipeline));
 
     string body = "hello, world!";
@@ -1466,7 +1466,7 @@ void FlusherSLSUnittest::TestSend() {
         ctx.SetConfigName("test_config");
         ctx.SetExactlyOnceFlag(true);
         flusher.SetContext(ctx);
-        flusher.SetMetricsRecordRef(FlusherSLS::sName, "1");
+        flusher.CreateMetricsRecordRef(FlusherSLS::sName, "1");
         flusher.Init(configJson, optionalGoPipeline);
 
         // create exactly once queue
@@ -1607,7 +1607,7 @@ void FlusherSLSUnittest::TestSend() {
         ParseJsonTable(configStr, configJson, errorMsg);
         FlusherSLS flusher;
         flusher.SetContext(ctx);
-        flusher.SetMetricsRecordRef(FlusherSLS::sName, "1");
+        flusher.CreateMetricsRecordRef(FlusherSLS::sName, "1");
         flusher.Init(configJson, optionalGoPipeline);
         {
             // empty group
@@ -1696,7 +1696,7 @@ void FlusherSLSUnittest::TestSend() {
         ParseJsonTable(configStr, configJson, errorMsg);
         FlusherSLS flusher;
         flusher.SetContext(ctx);
-        flusher.SetMetricsRecordRef(FlusherSLS::sName, "1");
+        flusher.CreateMetricsRecordRef(FlusherSLS::sName, "1");
         flusher.Init(configJson, optionalGoPipeline);
 
         PipelineEventGroup group(make_shared<SourceBuffer>());
@@ -1795,7 +1795,7 @@ void FlusherSLSUnittest::TestFlush() {
     ParseJsonTable(configStr, configJson, errorMsg);
     FlusherSLS flusher;
     flusher.SetContext(ctx);
-    flusher.SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher.CreateMetricsRecordRef(FlusherSLS::sName, "1");
     flusher.Init(configJson, optionalGoPipeline);
 
     PipelineEventGroup group(make_shared<SourceBuffer>());
@@ -1838,7 +1838,7 @@ void FlusherSLSUnittest::TestFlushAll() {
     ParseJsonTable(configStr, configJson, errorMsg);
     FlusherSLS flusher;
     flusher.SetContext(ctx);
-    flusher.SetMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher.CreateMetricsRecordRef(FlusherSLS::sName, "1");
     flusher.Init(configJson, optionalGoPipeline);
 
     PipelineEventGroup group(make_shared<SourceBuffer>());
@@ -1889,7 +1889,7 @@ void FlusherSLSUnittest::OnGoPipelineSend() {
         ParseJsonTable(configStr, configJson, errorMsg);
         FlusherSLS flusher;
         flusher.SetContext(ctx);
-        flusher.SetMetricsRecordRef(FlusherSLS::sName, "1");
+        flusher.CreateMetricsRecordRef(FlusherSLS::sName, "1");
         flusher.Init(configJson, optionalGoPipeline);
         {
             APSARA_TEST_TRUE(flusher.Send("content", "shardhash_key", "other_logstore"));

--- a/core/unittest/input/InputContainerStdioUnittest.cpp
+++ b/core/unittest/input/InputContainerStdioUnittest.cpp
@@ -121,7 +121,7 @@ void InputContainerStdioUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputContainerStdio());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputContainerStdio::sName, "1");
+    input->CreateMetricsRecordRef(InputContainerStdio::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
 
     // valid optional param
@@ -136,7 +136,7 @@ void InputContainerStdioUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputContainerStdio());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputContainerStdio::sName, "1");
+    input->CreateMetricsRecordRef(InputContainerStdio::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
 
     // invalid optional param
@@ -149,7 +149,7 @@ void InputContainerStdioUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputContainerStdio());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputContainerStdio::sName, "1");
+    input->CreateMetricsRecordRef(InputContainerStdio::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
 
     // TailingAllMatchedFiles
@@ -162,7 +162,7 @@ void InputContainerStdioUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputContainerStdio());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputContainerStdio::sName, "1");
+    input->CreateMetricsRecordRef(InputContainerStdio::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->mFileReader.mTailingAllMatchedFiles);
 
@@ -174,7 +174,7 @@ void InputContainerStdioUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputContainerStdio());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputContainerStdio::sName, "1");
+    input->CreateMetricsRecordRef(InputContainerStdio::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
 }
 
@@ -215,7 +215,7 @@ void InputContainerStdioUnittest::OnEnableContainerDiscovery() {
     PluginInstance::PluginMeta meta = ctx.GetPipeline().GenNextPluginMeta(false);
     input.reset(new InputContainerStdio());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputContainerStdio::sName, meta.mPluginID);
+    input->CreateMetricsRecordRef(InputContainerStdio::sName, meta.mPluginID);
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(optionalGoPipelineJson.toStyledString(), optionalGoPipeline.toStyledString());
 }
@@ -232,7 +232,7 @@ void InputContainerStdioUnittest::OnPipelineUpdate() {
     )";
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.SetContext(ctx);
-    input.SetMetricsRecordRef(InputContainerStdio::sName, "1");
+    input.CreateMetricsRecordRef(InputContainerStdio::sName, "1");
     APSARA_TEST_TRUE(input.Init(configJson, optionalGoPipeline));
 
     APSARA_TEST_TRUE(input.Start());

--- a/core/unittest/input/InputFileUnittest.cpp
+++ b/core/unittest/input/InputFileUnittest.cpp
@@ -82,7 +82,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     ctx.SetExactlyOnceFlag(false);
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputFile::sName, "1");
+    input->CreateMetricsRecordRef(InputFile::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_FALSE(input->mEnableContainerDiscovery);
     APSARA_TEST_EQUAL(0U, input->mMaxCheckpointDirSearchDepth);
@@ -104,7 +104,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     ctx.SetExactlyOnceFlag(false);
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputFile::sName, "1");
+    input->CreateMetricsRecordRef(InputFile::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->mEnableContainerDiscovery);
     APSARA_TEST_EQUAL(1U, input->mMaxCheckpointDirSearchDepth);
@@ -126,7 +126,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     ctx.SetExactlyOnceFlag(false);
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputFile::sName, "1");
+    input->CreateMetricsRecordRef(InputFile::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_FALSE(input->mEnableContainerDiscovery);
     APSARA_TEST_EQUAL(0U, input->mMaxCheckpointDirSearchDepth);
@@ -146,7 +146,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     ctx.SetExactlyOnceFlag(false);
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputFile::sName, "1");
+    input->CreateMetricsRecordRef(InputFile::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->mFileReader.mTailingAllMatchedFiles);
     APSARA_TEST_TRUE(input->mFileDiscovery.IsTailingAllMatchedFiles());
@@ -164,7 +164,7 @@ void InputFileUnittest::OnSuccessfulInit() {
     input.reset(new InputFile());
     ctx.SetExactlyOnceFlag(false);
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputFile::sName, "1");
+    input->CreateMetricsRecordRef(InputFile::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(0U, input->mExactlyOnceConcurrency);
     APSARA_TEST_FALSE(ctx.IsExactlyOnceEnabled());
@@ -176,7 +176,7 @@ void InputFileUnittest::OnFailedInit() {
 
     input.reset(new InputFile());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputFile::sName, "1");
+    input->CreateMetricsRecordRef(InputFile::sName, "1");
     APSARA_TEST_FALSE(input->Init(configJson, optionalGoPipeline));
 }
 
@@ -222,7 +222,7 @@ void InputFileUnittest::OnEnableContainerDiscovery() {
     PluginInstance::PluginMeta meta = ctx.GetPipeline().GenNextPluginMeta(false);
     input.reset(new InputFile());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputFile::sName, meta.mPluginID);
+    input->CreateMetricsRecordRef(InputFile::sName, meta.mPluginID);
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->mEnableContainerDiscovery);
     APSARA_TEST_TRUE(input->mFileDiscovery.IsContainerDiscoveryEnabled());
@@ -242,7 +242,7 @@ void InputFileUnittest::OnEnableContainerDiscovery() {
     meta = ctx.GetPipeline().GenNextPluginMeta(false);
     input.reset(new InputFile());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputFile::sName, meta.mPluginID);
+    input->CreateMetricsRecordRef(InputFile::sName, meta.mPluginID);
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_FALSE(input->mEnableContainerDiscovery);
     APSARA_TEST_FALSE(input->mFileDiscovery.IsContainerDiscoveryEnabled());
@@ -267,7 +267,7 @@ void InputFileUnittest::TestCreateInnerProcessors() {
         configJson["FilePaths"].append(Json::Value(filePath.string()));
         input.reset(new InputFile());
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputFile::sName, "1");
+        input->CreateMetricsRecordRef(InputFile::sName, "1");
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
         APSARA_TEST_EQUAL(1U, input->mInnerProcessors.size());
         APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
@@ -295,7 +295,7 @@ void InputFileUnittest::TestCreateInnerProcessors() {
         configJson["FilePaths"].append(Json::Value(filePath.string()));
         input.reset(new InputFile());
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputFile::sName, "1");
+        input->CreateMetricsRecordRef(InputFile::sName, "1");
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
         APSARA_TEST_EQUAL(1U, input->mInnerProcessors.size());
         APSARA_TEST_EQUAL(ProcessorSplitMultilineLogStringNative::sName, input->mInnerProcessors[0]->Name());
@@ -324,7 +324,7 @@ void InputFileUnittest::TestCreateInnerProcessors() {
         configJson["FilePaths"].append(Json::Value(filePath.string()));
         input.reset(new InputFile());
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputFile::sName, "1");
+        input->CreateMetricsRecordRef(InputFile::sName, "1");
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
         APSARA_TEST_EQUAL(1U, input->mInnerProcessors.size());
         APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
@@ -351,7 +351,7 @@ void InputFileUnittest::TestCreateInnerProcessors() {
         configJson["FilePaths"].append(Json::Value(filePath.string()));
         input.reset(new InputFile());
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputFile::sName, "1");
+        input->CreateMetricsRecordRef(InputFile::sName, "1");
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
         APSARA_TEST_EQUAL(1U, input->mInnerProcessors.size());
         APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
@@ -374,7 +374,7 @@ void InputFileUnittest::TestCreateInnerProcessors() {
         configJson["FilePaths"].append(Json::Value(filePath.string()));
         input.reset(new InputFile());
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputFile::sName, "1");
+        input->CreateMetricsRecordRef(InputFile::sName, "1");
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
         APSARA_TEST_EQUAL(1U, input->mInnerProcessors.size());
         APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
@@ -395,7 +395,7 @@ void InputFileUnittest::TestCreateInnerProcessors() {
         configJson["FilePaths"].append(Json::Value(filePath.string()));
         input.reset(new InputFile());
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputFile::sName, "1");
+        input->CreateMetricsRecordRef(InputFile::sName, "1");
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
         APSARA_TEST_EQUAL(1U, input->mInnerProcessors.size());
         APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
@@ -416,7 +416,7 @@ void InputFileUnittest::TestCreateInnerProcessors() {
         configJson["FilePaths"].append(Json::Value(filePath.string()));
         input.reset(new InputFile());
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputFile::sName, "1");
+        input->CreateMetricsRecordRef(InputFile::sName, "1");
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
         APSARA_TEST_EQUAL(1U, input->mInnerProcessors.size());
         APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
@@ -436,7 +436,7 @@ void InputFileUnittest::TestCreateInnerProcessors() {
         configJson["FilePaths"].append(Json::Value(filePath.string()));
         input.reset(new InputFile());
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputFile::sName, "1");
+        input->CreateMetricsRecordRef(InputFile::sName, "1");
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
         APSARA_TEST_EQUAL(1U, input->mInnerProcessors.size());
         APSARA_TEST_EQUAL(ProcessorSplitLogStringNative::sName, input->mInnerProcessors[0]->Name());
@@ -462,7 +462,7 @@ void InputFileUnittest::OnPipelineUpdate() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     configJson["FilePaths"].append(Json::Value(filePath.string()));
     input.SetContext(ctx);
-    input.SetMetricsRecordRef(InputFile::sName, "1");
+    input.CreateMetricsRecordRef(InputFile::sName, "1");
     APSARA_TEST_TRUE(input.Init(configJson, optionalGoPipeline));
 
     APSARA_TEST_TRUE(input.Start());

--- a/core/unittest/input/InputHostMetaUnittest.cpp
+++ b/core/unittest/input/InputHostMetaUnittest.cpp
@@ -73,7 +73,7 @@ void InputHostMetaUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputHostMeta());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(input->sName, "input_host_meta");
 }
@@ -94,7 +94,7 @@ void InputHostMetaUnittest::OnSuccessfulStart() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputHostMeta());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
 }
@@ -112,7 +112,7 @@ void InputHostMetaUnittest::OnSuccessfulStop() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputHostMeta());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
     APSARA_TEST_TRUE(input->Stop(false));

--- a/core/unittest/input/InputHostMonitorUnittest.cpp
+++ b/core/unittest/input/InputHostMonitorUnittest.cpp
@@ -73,7 +73,7 @@ void InputHostMonitorUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputHostMonitor());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(input->sName, "input_host_monitor");
 }
@@ -93,7 +93,7 @@ void InputHostMonitorUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputHostMonitor());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL_FATAL(input->mInterval, 15);
 }
@@ -111,7 +111,7 @@ void InputHostMonitorUnittest::OnSuccessfulStart() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputHostMonitor());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
 }
@@ -129,7 +129,7 @@ void InputHostMonitorUnittest::OnSuccessfulStop() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputHostMonitor());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
     APSARA_TEST_TRUE(input->Stop(false));

--- a/core/unittest/input/InputInternalAlarmsUnittest.cpp
+++ b/core/unittest/input/InputInternalAlarmsUnittest.cpp
@@ -73,7 +73,7 @@ void InputInternalAlarmsUnittest::OnPipelineUpdate() {
     )";
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.SetContext(ctx);
-    input.SetMetricsRecordRef(InputInternalAlarms::sName, "1");
+    input.CreateMetricsRecordRef(InputInternalAlarms::sName, "1");
     APSARA_TEST_TRUE(input.Init(configJson, optionalGoPipeline));
 
     APSARA_TEST_EQUAL(nullptr, SelfMonitorServer::GetInstance()->mAlarmPipelineCtx);

--- a/core/unittest/input/InputInternalMetricsUnittest.cpp
+++ b/core/unittest/input/InputInternalMetricsUnittest.cpp
@@ -98,7 +98,7 @@ void InputInternalMetricsUnittest::OnInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputInternalMetrics());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputInternalMetrics::sName, "1");
+    input->CreateMetricsRecordRef(InputInternalMetrics::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
     APSARA_TEST_EQUAL(input->mSelfMonitorMetricRules.mAgentMetricsRule.mEnable, true);
@@ -153,7 +153,7 @@ void InputInternalMetricsUnittest::OnPipelineUpdate() {
     )";
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.SetContext(ctx);
-    input.SetMetricsRecordRef(InputInternalMetrics::sName, "1");
+    input.CreateMetricsRecordRef(InputInternalMetrics::sName, "1");
     APSARA_TEST_TRUE(input.Init(configJson, optionalGoPipeline));
 
     APSARA_TEST_TRUE(input.Start());

--- a/core/unittest/input/InputNetworkObserverUnittest.cpp
+++ b/core/unittest/input/InputNetworkObserverUnittest.cpp
@@ -93,7 +93,7 @@ void InputNetworkObserverUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkObserver());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(input->sName, "input_network_observer");
     logtail::ebpf::ObserverNetworkOption thisObserver = input->mNetworkOption;
@@ -127,7 +127,7 @@ void InputNetworkObserverUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkObserver());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(input->sName, "input_network_observer");
     logtail::ebpf::ObserverNetworkOption thisObserver = input->mNetworkOption;
@@ -152,7 +152,7 @@ void InputNetworkObserverUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkObserver());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_FALSE(input->Init(configJson, optionalGoPipeline));
 }
 
@@ -178,7 +178,7 @@ void InputNetworkObserverUnittest::OnSuccessfulStart() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkObserver());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
     string serverPipelineName
@@ -210,7 +210,7 @@ void InputNetworkObserverUnittest::OnSuccessfulStop() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkObserver());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
     string serverPipelineName

--- a/core/unittest/input/InputNetworkSecurityUnittest.cpp
+++ b/core/unittest/input/InputNetworkSecurityUnittest.cpp
@@ -93,7 +93,7 @@ void InputNetworkSecurityUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(input->sName, "input_network_security");
     logtail::ebpf::SecurityNetworkFilter thisFilter1
@@ -128,7 +128,7 @@ void InputNetworkSecurityUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(input->sName, "input_network_security");
     logtail::ebpf::SecurityNetworkFilter thisFilter1
@@ -155,7 +155,7 @@ void InputNetworkSecurityUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     logtail::ebpf::SecurityNetworkFilter thisFilter5
         = std::get<logtail::ebpf::SecurityNetworkFilter>(input->mSecurityOptions.mOptionList[0].mFilter);
@@ -183,7 +183,7 @@ void InputNetworkSecurityUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     logtail::ebpf::SecurityNetworkFilter thisFilter6
         = std::get<logtail::ebpf::SecurityNetworkFilter>(input->mSecurityOptions.mOptionList[0].mFilter);
@@ -212,7 +212,7 @@ void InputNetworkSecurityUnittest::OnSuccessfulStart() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
     string serverPipelineName
@@ -244,7 +244,7 @@ void InputNetworkSecurityUnittest::OnSuccessfulStop() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputNetworkSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
     string serverPipelineName

--- a/core/unittest/input/InputProcessSecurityUnittest.cpp
+++ b/core/unittest/input/InputProcessSecurityUnittest.cpp
@@ -83,7 +83,7 @@ void InputProcessSecurityUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputProcessSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_EQUAL(input->sName, "input_process_security");
     APSARA_TEST_EQUAL(input->mSecurityOptions.mOptionList[0].mCallNames.size(), 5UL);
@@ -104,7 +104,7 @@ void InputProcessSecurityUnittest::OnSuccessfulStart() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputProcessSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
     string serverPipelineName
@@ -127,7 +127,7 @@ void InputProcessSecurityUnittest::OnSuccessfulStop() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input.reset(new InputProcessSecurity());
     input->SetContext(ctx);
-    input->SetMetricsRecordRef("test", "1");
+    input->CreateMetricsRecordRef("test", "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
     APSARA_TEST_TRUE(input->Start());
     string serverPipelineName

--- a/core/unittest/input/InputPrometheusUnittest.cpp
+++ b/core/unittest/input/InputPrometheusUnittest.cpp
@@ -79,7 +79,7 @@ void InputPrometheusUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input = make_unique<InputPrometheus>();
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(input->Name(), "1");
+    input->CreateMetricsRecordRef(input->Name(), "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
 
     APSARA_TEST_EQUAL("_arms-prom/node-exporter/0", input->mTargetSubscirber->mJobName);
@@ -114,7 +114,7 @@ void InputPrometheusUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input = make_unique<InputPrometheus>();
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputPrometheus::sName, "1");
+    input->CreateMetricsRecordRef(InputPrometheus::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
 
     APSARA_TEST_EQUAL("_arms-prom/node-exporter/0", input->mTargetSubscirber->mJobName);
@@ -142,7 +142,7 @@ void InputPrometheusUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input = make_unique<InputPrometheus>();
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputPrometheus::sName, "1");
+    input->CreateMetricsRecordRef(InputPrometheus::sName, "1");
     APSARA_TEST_FALSE(input->Init(configJson, optionalGoPipeline));
 
     // with invalid ScrapeConfig
@@ -166,7 +166,7 @@ void InputPrometheusUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input = make_unique<InputPrometheus>();
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputPrometheus::sName, "1");
+    input->CreateMetricsRecordRef(InputPrometheus::sName, "1");
     APSARA_TEST_FALSE(input->Init(configJson, optionalGoPipeline));
     PrometheusInputRunner::GetInstance()->Stop();
 }
@@ -197,7 +197,7 @@ void InputPrometheusUnittest::OnPipelineUpdate() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     input = make_unique<InputPrometheus>();
     input->SetContext(ctx);
-    input->SetMetricsRecordRef(InputPrometheus::sName, "1");
+    input->CreateMetricsRecordRef(InputPrometheus::sName, "1");
     APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
 
     APSARA_TEST_TRUE(input->Start());
@@ -241,7 +241,7 @@ void InputPrometheusUnittest::TestCreateInnerProcessor() {
         APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
         input = make_unique<InputPrometheus>();
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputPrometheus::sName, "1");
+        input->CreateMetricsRecordRef(InputPrometheus::sName, "1");
 
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
 
@@ -348,7 +348,7 @@ void InputPrometheusUnittest::TestCreateInnerProcessor() {
         APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
         input = make_unique<InputPrometheus>();
         input->SetContext(ctx);
-        input->SetMetricsRecordRef(InputPrometheus::sName, "1");
+        input->CreateMetricsRecordRef(InputPrometheus::sName, "1");
 
         APSARA_TEST_TRUE(input->Init(configJson, optionalGoPipeline));
 

--- a/core/unittest/monitor/MetricManagerUnittest.cpp
+++ b/core/unittest/monitor/MetricManagerUnittest.cpp
@@ -55,12 +55,12 @@ void MetricManagerUnittest::TestCreateMetricAutoDelete() {
     labels.emplace_back(std::make_pair<std::string, std::string>("region", "cn-hangzhou"));
 
     MetricsRecordRef fileMetric;
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         fileMetric, MetricCategory::METRIC_CATEGORY_UNKNOWN, std::move(labels));
     APSARA_TEST_EQUAL(fileMetric->GetLabels()->size(), 3);
 
-
     CounterPtr fileCounter = fileMetric.CreateCounter("filed1");
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(fileMetric);
     ADD_COUNTER(fileCounter, 111UL);
     ADD_COUNTER(fileCounter, 111UL);
     APSARA_TEST_EQUAL(fileCounter->GetValue(), 222);
@@ -94,9 +94,10 @@ void MetricManagerUnittest::TestCreateMetricAutoDelete() {
         labels.emplace_back(std::make_pair<std::string, std::string>("region", "cn-hangzhou"));
 
         MetricsRecordRef fileMetric2;
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             fileMetric2, MetricCategory::METRIC_CATEGORY_UNKNOWN, std::move(labels));
         CounterPtr fileCounter2 = fileMetric2.CreateCounter("filed2");
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(fileMetric2);
         ADD_COUNTER(fileCounter2, 222UL);
     }
 
@@ -106,9 +107,10 @@ void MetricManagerUnittest::TestCreateMetricAutoDelete() {
         labels.emplace_back(std::make_pair<std::string, std::string>("logstore", "logstore1"));
         labels.emplace_back(std::make_pair<std::string, std::string>("region", "cn-hangzhou"));
         MetricsRecordRef fileMetric3;
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             fileMetric3, MetricCategory::METRIC_CATEGORY_UNKNOWN, std::move(labels));
         CounterPtr fileCounter3 = fileMetric3.CreateCounter("filed3");
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(fileMetric3);
         ADD_COUNTER(fileCounter3, 333UL);
     }
 
@@ -141,9 +143,10 @@ void createMetrics(int count) {
         labels.emplace_back(std::make_pair<std::string, std::string>("count", std::to_string(count)));
         labels.emplace_back(std::make_pair<std::string, std::string>("region", "cn-beijing"));
         MetricsRecordRef fileMetric;
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             fileMetric, MetricCategory::METRIC_CATEGORY_UNKNOWN, std::move(labels));
         CounterPtr fileCounter = fileMetric.CreateCounter("filed1");
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(fileMetric);
         ADD_COUNTER(fileCounter, 111UL);
     }
 }
@@ -210,9 +213,10 @@ void MetricManagerUnittest::TestCreateAndDeleteMetric() {
     labels.emplace_back(std::make_pair<std::string, std::string>("project", "test1"));
     labels.emplace_back(std::make_pair<std::string, std::string>("logstore", "test1"));
     labels.emplace_back(std::make_pair<std::string, std::string>("region", "cn-beijing"));
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         *fileMetric1, MetricCategory::METRIC_CATEGORY_UNKNOWN, std::move(labels));
     CounterPtr fileCounter = fileMetric1->CreateCounter("filed1");
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(*fileMetric1);
     ADD_COUNTER(fileCounter, 111UL);
 
     {
@@ -220,9 +224,10 @@ void MetricManagerUnittest::TestCreateAndDeleteMetric() {
         labels.emplace_back(std::make_pair<std::string, std::string>("project", "test2"));
         labels.emplace_back(std::make_pair<std::string, std::string>("logstore", "test2"));
         labels.emplace_back(std::make_pair<std::string, std::string>("region", "cn-beijing"));
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             *fileMetric2, MetricCategory::METRIC_CATEGORY_UNKNOWN, std::move(labels));
         CounterPtr fileCounter = fileMetric2->CreateCounter("filed1");
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(*fileMetric2);
         ADD_COUNTER(fileCounter, 111UL);
     }
 
@@ -231,9 +236,10 @@ void MetricManagerUnittest::TestCreateAndDeleteMetric() {
         labels.emplace_back(std::make_pair<std::string, std::string>("project", "test3"));
         labels.emplace_back(std::make_pair<std::string, std::string>("logstore", "test3"));
         labels.emplace_back(std::make_pair<std::string, std::string>("region", "cn-beijing"));
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             *fileMetric3, MetricCategory::METRIC_CATEGORY_UNKNOWN, std::move(labels));
         CounterPtr fileCounter = fileMetric3->CreateCounter("filed1");
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(*fileMetric3);
         ADD_COUNTER(fileCounter, 111UL);
     }
     std::thread t3(createMetrics, 3);

--- a/core/unittest/monitor/PluginMetricManagerUnittest.cpp
+++ b/core/unittest/monitor/PluginMetricManagerUnittest.cpp
@@ -28,8 +28,9 @@ public:
         defaultLabels->emplace_back(METRIC_LABEL_KEY_PIPELINE_NAME, "default_config");
         defaultLabels->emplace_back(METRIC_LABEL_KEY_PLUGIN_TYPE, "default_plugin");
         defaultLabels->emplace_back(METRIC_LABEL_KEY_PLUGIN_ID, "default_id");
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_UNKNOWN, std::move(*defaultLabels));
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(mMetricsRecordRef);
         std::unordered_map<std::string, MetricType> metricKeys;
         metricKeys.emplace("default_counter", MetricType::METRIC_TYPE_COUNTER);
         metricKeys.emplace("default_gauge", MetricType::METRIC_TYPE_INT_GAUGE);

--- a/core/unittest/pipeline/PipelineUnittest.cpp
+++ b/core/unittest/pipeline/PipelineUnittest.cpp
@@ -2746,7 +2746,7 @@ void PipelineUnittest::TestProcess() const {
     processor->Init(Json::Value(), ctx);
     pipeline.mProcessorLine.emplace_back(std::move(processor));
 
-    WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+    WriteMetrics::GetInstance()->CreateMetricsRecordRef(
         pipeline.mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_UNKNOWN, {});
     pipeline.mProcessorsInEventsTotal
         = pipeline.mMetricsRecordRef.CreateCounter(METRIC_PIPELINE_PROCESSORS_IN_EVENTS_TOTAL);
@@ -2756,6 +2756,7 @@ void PipelineUnittest::TestProcess() const {
         = pipeline.mMetricsRecordRef.CreateCounter(METRIC_PIPELINE_PROCESSORS_IN_SIZE_BYTES);
     pipeline.mProcessorsTotalProcessTimeMs
         = pipeline.mMetricsRecordRef.CreateTimeCounter(METRIC_PIPELINE_PROCESSORS_TOTAL_PROCESS_TIME_MS);
+    WriteMetrics::GetInstance()->CommitMetricsRecordRef(pipeline.mMetricsRecordRef);
 
     vector<PipelineEventGroup> groups;
     groups.emplace_back(make_shared<SourceBuffer>());
@@ -2795,7 +2796,7 @@ void PipelineUnittest::TestSend() const {
         configs.emplace_back(1, nullptr);
         pipeline.mRouter.Init(configs, ctx);
 
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             pipeline.mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_UNKNOWN, {});
         pipeline.mFlushersInGroupsTotal
             = pipeline.mMetricsRecordRef.CreateCounter(METRIC_PIPELINE_FLUSHERS_IN_EVENT_GROUPS_TOTAL);
@@ -2805,6 +2806,7 @@ void PipelineUnittest::TestSend() const {
             = pipeline.mMetricsRecordRef.CreateCounter(METRIC_PIPELINE_FLUSHERS_IN_SIZE_BYTES);
         pipeline.mFlushersTotalPackageTimeMs
             = pipeline.mMetricsRecordRef.CreateTimeCounter(METRIC_PIPELINE_FLUSHERS_TOTAL_PACKAGE_TIME_MS);
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(pipeline.mMetricsRecordRef);
         {
             // all valid
             vector<PipelineEventGroup> group;
@@ -2862,7 +2864,7 @@ void PipelineUnittest::TestSend() const {
         configs.emplace_back(configJson.size(), nullptr);
         pipeline.mRouter.Init(configs, ctx);
 
-        WriteMetrics::GetInstance()->PrepareMetricsRecordRef(
+        WriteMetrics::GetInstance()->CreateMetricsRecordRef(
             pipeline.mMetricsRecordRef, MetricCategory::METRIC_CATEGORY_UNKNOWN, {});
         pipeline.mFlushersInGroupsTotal
             = pipeline.mMetricsRecordRef.CreateCounter(METRIC_PIPELINE_FLUSHERS_IN_EVENT_GROUPS_TOTAL);
@@ -2872,6 +2874,7 @@ void PipelineUnittest::TestSend() const {
             = pipeline.mMetricsRecordRef.CreateCounter(METRIC_PIPELINE_FLUSHERS_IN_SIZE_BYTES);
         pipeline.mFlushersTotalPackageTimeMs
             = pipeline.mMetricsRecordRef.CreateTimeCounter(METRIC_PIPELINE_FLUSHERS_TOTAL_PACKAGE_TIME_MS);
+        WriteMetrics::GetInstance()->CommitMetricsRecordRef(pipeline.mMetricsRecordRef);
 
         {
             vector<PipelineEventGroup> group;

--- a/core/unittest/processor/ParseContainerLogBenchmark.cpp
+++ b/core/unittest/processor/ParseContainerLogBenchmark.cpp
@@ -52,7 +52,7 @@ static void BM_DockerJson(int size, int batchSize) {
     config["IgnoringStderr"] = false;
     ProcessorParseContainerLogNative processor;
     processor.SetContext(mContext);
-    processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+    processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
 
     std::string data1
         = R"({"log":"Exception in thread \"main\" java.lang.NullPointerExceptionat  com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitle\n","stream":"stdout","time":"2024-04-07T08:02:40.873971412Z"})";
@@ -165,7 +165,7 @@ static void BM_ContainerdText(int size, int batchSize) {
     config["IgnoringStderr"] = false;
     ProcessorParseContainerLogNative processor;
     processor.SetContext(mContext);
-    processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+    processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
 
     std::string data1
         = R"(2024-04-08T12:48:59.665663286+08:00 stdout P Exception in thread "main" java.lang.NullPointerExceptionat  com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat com.example.myproject.Book.getTitleat )";

--- a/core/unittest/processor/ProcessorDesensitizeNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorDesensitizeNativeUnittest.cpp
@@ -162,7 +162,7 @@ dbf@@@324 FS2$%pwd,pwd=saf543#$@,,"
         // run function ProcessorSplitMultilineLogStringNative
         ProcessorSplitMultilineLogStringNative processorSplitMultilineLogStringNative;
         processorSplitMultilineLogStringNative.SetContext(mContext);
-        processorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+        processorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processorSplitMultilineLogStringNative.Init(config));
         processorSplitMultilineLogStringNative.Process(eventGroup);
 
@@ -268,7 +268,7 @@ dbf@@@324 FS2$%pwd,pwd=saf543#$@,,"
         // run function ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
         processorMergeMultilineLogNative.SetContext(mContext);
-        processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+        processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
         processorMergeMultilineLogNative.Process(eventGroup);
 

--- a/core/unittest/processor/ProcessorFilterNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorFilterNativeUnittest.cpp
@@ -66,7 +66,7 @@ void ProcessorFilterNativeUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     processor.reset(new ProcessorFilterNative());
     processor->SetContext(mContext);
-    processor->SetMetricsRecordRef(ProcessorFilterNative::sName, "1");
+    processor->CreateMetricsRecordRef(ProcessorFilterNative::sName, "1");
     APSARA_TEST_TRUE(processor->Init(configJson));
     APSARA_TEST_EQUAL(1, processor->mFilterRule->FilterKeys.size());
     APSARA_TEST_EQUAL(1, processor->mFilterRule->FilterRegs.size());
@@ -81,7 +81,7 @@ void ProcessorFilterNativeUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     processor.reset(new ProcessorFilterNative());
     processor->SetContext(mContext);
-    processor->SetMetricsRecordRef(ProcessorFilterNative::sName, "1");
+    processor->CreateMetricsRecordRef(ProcessorFilterNative::sName, "1");
     APSARA_TEST_TRUE(processor->Init(configJson));
     APSARA_TEST_TRUE(processor->mDiscardingNonUTF8);
 
@@ -94,7 +94,7 @@ void ProcessorFilterNativeUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     processor.reset(new ProcessorFilterNative());
     processor->SetContext(mContext);
-    processor->SetMetricsRecordRef(ProcessorFilterNative::sName, "1");
+    processor->CreateMetricsRecordRef(ProcessorFilterNative::sName, "1");
     APSARA_TEST_TRUE(processor->Init(configJson));
     APSARA_TEST_FALSE(processor->mDiscardingNonUTF8);
 }
@@ -115,7 +115,7 @@ void ProcessorFilterNativeUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     processor.reset(new ProcessorFilterNative());
     processor->SetContext(mContext);
-    processor->SetMetricsRecordRef(ProcessorFilterNative::sName, "1");
+    processor->CreateMetricsRecordRef(ProcessorFilterNative::sName, "1");
     APSARA_TEST_FALSE(processor->Init(configJson));
 
     configStr = R"(
@@ -132,7 +132,7 @@ void ProcessorFilterNativeUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     processor.reset(new ProcessorFilterNative());
     processor->SetContext(mContext);
-    processor->SetMetricsRecordRef(ProcessorFilterNative::sName, "1");
+    processor->CreateMetricsRecordRef(ProcessorFilterNative::sName, "1");
     APSARA_TEST_FALSE(processor->Init(configJson));
 
     configStr = R"(
@@ -150,7 +150,7 @@ void ProcessorFilterNativeUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     processor.reset(new ProcessorFilterNative());
     processor->SetContext(mContext);
-    processor->SetMetricsRecordRef(ProcessorFilterNative::sName, "1");
+    processor->CreateMetricsRecordRef(ProcessorFilterNative::sName, "1");
     APSARA_TEST_FALSE(processor->Init(configJson));
 
     configStr = R"(
@@ -169,7 +169,7 @@ void ProcessorFilterNativeUnittest::OnFailedInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     processor.reset(new ProcessorFilterNative());
     processor->SetContext(mContext);
-    processor->SetMetricsRecordRef(ProcessorFilterNative::sName, "1");
+    processor->CreateMetricsRecordRef(ProcessorFilterNative::sName, "1");
     APSARA_TEST_FALSE(processor->Init(configJson));
 }
 

--- a/core/unittest/processor/ProcessorMergeMultilineLogNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorMergeMultilineLogNativeUnittest.cpp
@@ -51,7 +51,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_TRUE(processor.mMultiline.IsMultiline());
         }
@@ -63,7 +63,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_TRUE(processor.mMultiline.IsMultiline());
         }
@@ -75,7 +75,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_TRUE(processor.mMultiline.IsMultiline());
         }
@@ -86,7 +86,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_TRUE(processor.mMultiline.IsMultiline());
         }
@@ -98,7 +98,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_TRUE(processor.mMultiline.IsMultiline());
         }
@@ -113,7 +113,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_TRUE(processor.mMultiline.IsMultiline());
         }
@@ -124,7 +124,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_FALSE(processor.mMultiline.IsMultiline());
         }
@@ -135,7 +135,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_FALSE(processor.mMultiline.IsMultiline());
         }
@@ -146,7 +146,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_FALSE(processor.mMultiline.IsMultiline());
         }
@@ -156,7 +156,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_FALSE(processor.mMultiline.IsMultiline());
         }
@@ -169,7 +169,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
             APSARA_TEST_FALSE(processor.mMultiline.IsMultiline());
         }
@@ -179,7 +179,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "flag";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
         }
         // unknown init不通过
@@ -189,7 +189,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "unknown";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_FALSE(processor.Init(config));
         }
         // 格式错误 init不通过
@@ -199,7 +199,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = 1;
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_FALSE(processor.Init(config));
         }
         // 不存在 init不通过
@@ -208,7 +208,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["StartPattern"] = ".*";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_FALSE(processor.Init(config));
         }
     }
@@ -222,7 +222,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["UnmatchedContentTreatment"] = "single_line";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
         }
         // discard init通过
@@ -233,7 +233,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["UnmatchedContentTreatment"] = "discard";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
         }
         // unknown init通过
@@ -244,7 +244,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["UnmatchedContentTreatment"] = "unknown";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
         }
         // 格式错误 init通过
@@ -255,7 +255,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["UnmatchedContentTreatment"] = 1;
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
         }
         // 不存在 init通过
@@ -265,7 +265,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestInit() {
             config["MergeType"] = "regex";
             ProcessorMergeMultilineLogNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE(processor.Init(config));
         }
     }
@@ -286,7 +286,7 @@ void ProcessorMergeMultilineLogNativeUnittest::TestProcess() {
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // group为空
     {
@@ -877,7 +877,7 @@ void ProcessEventsWithPartLogUnittest::TestProcessEventsWithPartLog() {
         // ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
         processorMergeMultilineLogNative.SetContext(mContext);
-        processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+        processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
         APSARA_TEST_TRUE(processorMergeMultilineLogNative.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -929,7 +929,7 @@ void ProcessEventsWithPartLogUnittest::TestProcessEventsWithPartLog() {
         // ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
         processorMergeMultilineLogNative.SetContext(mContext);
-        processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+        processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
         APSARA_TEST_TRUE(processorMergeMultilineLogNative.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -977,7 +977,7 @@ void ProcessEventsWithPartLogUnittest::TestProcessEventsWithPartLog() {
         // ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
         processorMergeMultilineLogNative.SetContext(mContext);
-        processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+        processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
         APSARA_TEST_TRUE(processorMergeMultilineLogNative.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -1039,7 +1039,7 @@ void ProcessEventsWithPartLogUnittest::TestProcessEventsWithPartLog() {
         // ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
         processorMergeMultilineLogNative.SetContext(mContext);
-        processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+        processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
         APSARA_TEST_TRUE(processorMergeMultilineLogNative.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -1100,7 +1100,7 @@ void ProcessEventsWithPartLogUnittest::TestProcessEventsWithPartLog() {
         // ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
         processorMergeMultilineLogNative.SetContext(mContext);
-        processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+        processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
         APSARA_TEST_TRUE(processorMergeMultilineLogNative.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -1171,7 +1171,7 @@ void ProcessEventsWithPartLogUnittest::TestProcessEventsWithPartLog() {
         // ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
         processorMergeMultilineLogNative.SetContext(mContext);
-        processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+        processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
         APSARA_TEST_TRUE(processorMergeMultilineLogNative.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -1251,7 +1251,7 @@ void ProcessEventsWithPartLogUnittest::TestProcessEventsWithPartLog() {
         // ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
         processorMergeMultilineLogNative.SetContext(mContext);
-        processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+        processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
         APSARA_TEST_TRUE(processorMergeMultilineLogNative.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -1332,7 +1332,7 @@ void ProcessEventsWithPartLogUnittest::TestProcess() {
     // make ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE(processorMergeMultilineLogNative.Init(config));
     // event 不支持
     {
@@ -1872,7 +1872,7 @@ void ProcessorMergeMultilineLogDisacardUnmatchUnittest::TestLogSplitWithBeginCon
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: unmatch + unmatch
     {
@@ -2141,7 +2141,7 @@ void ProcessorMergeMultilineLogDisacardUnmatchUnittest::TestLogSplitWithBeginEnd
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: unmatch + unmatch
     {
@@ -2385,7 +2385,7 @@ void ProcessorMergeMultilineLogDisacardUnmatchUnittest::TestLogSplitWithBegin() 
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: unmatch + start
     {
@@ -2579,7 +2579,7 @@ void ProcessorMergeMultilineLogDisacardUnmatchUnittest::TestLogSplitWithContinue
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: unmatch
     {
@@ -2774,7 +2774,7 @@ void ProcessorMergeMultilineLogDisacardUnmatchUnittest::TestLogSplitWithEnd() {
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: end
     {
@@ -2931,7 +2931,7 @@ void ProcessorMergeMultilineLogKeepUnmatchUnittest::TestLogSplitWithBeginContinu
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: unmatch + unmatch
     {
@@ -3293,7 +3293,7 @@ void ProcessorMergeMultilineLogKeepUnmatchUnittest::TestLogSplitWithBeginEnd() {
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: unmatch + unmatch
     {
@@ -3664,7 +3664,7 @@ void ProcessorMergeMultilineLogKeepUnmatchUnittest::TestLogSplitWithBegin() {
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: unmatch + start
     {
@@ -3883,7 +3883,7 @@ void ProcessorMergeMultilineLogKeepUnmatchUnittest::TestLogSplitWithContinueEnd(
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: unmatch
     {
@@ -4137,7 +4137,7 @@ void ProcessorMergeMultilineLogKeepUnmatchUnittest::TestLogSplitWithEnd() {
     // ProcessorMergeMultilineLogNative
     ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
     processorMergeMultilineLogNative.SetContext(mContext);
-    processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+    processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
     // case: end
     {

--- a/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseApsaraNativeUnittest.cpp
@@ -572,7 +572,7 @@ void ProcessorParseApsaraNativeUnittest::TestMultipleLines() {
         // run function ProcessorSplitMultilineLogStringNative
         ProcessorSplitMultilineLogStringNative processorSplitMultilineLogStringNative;
         processorSplitMultilineLogStringNative.SetContext(mContext);
-        processorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+        processorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processorSplitMultilineLogStringNative.Init(config));
         processorSplitMultilineLogStringNative.Process(eventGroup);
 

--- a/core/unittest/processor/ProcessorParseContainerLogNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseContainerLogNativeUnittest.cpp
@@ -140,7 +140,7 @@ void ProcessorParseContainerLogNativeUnittest::TestInit() {
     config["IgnoringStderr"] = 1;
     ProcessorParseContainerLogNative processor;
     processor.SetContext(mContext);
-    processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+    processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processor.Init(config));
 }
 
@@ -154,7 +154,7 @@ void ProcessorParseContainerLogNativeUnittest::TestIgnoringStdoutStderr() {
         // make ProcessorParseContainerLogNative
         ProcessorParseContainerLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -260,7 +260,7 @@ void ProcessorParseContainerLogNativeUnittest::TestIgnoringStdoutStderr() {
         // make ProcessorParseContainerLogNative
         ProcessorParseContainerLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -398,7 +398,7 @@ void ProcessorParseContainerLogNativeUnittest::TestIgnoringStdoutStderr() {
         // make ProcessorParseContainerLogNative
         ProcessorParseContainerLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -560,7 +560,7 @@ void ProcessorParseContainerLogNativeUnittest::TestIgnoringStdoutStderr() {
         // make ProcessorParseContainerLogNative
         ProcessorParseContainerLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // make eventGroup
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -751,7 +751,7 @@ void ProcessorParseContainerLogNativeUnittest::TestContainerdLog() {
     // make ProcessorParseContainerLogNative
     ProcessorParseContainerLogNative processor;
     processor.SetContext(mContext);
-    processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+    processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processor.Init(config));
     // make eventGroup
     auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -1020,7 +1020,7 @@ void ProcessorParseContainerLogNativeUnittest::TestContainerdLogWithSplit() {
         // make ProcessorSplitLogStringNative
         ProcessorSplitLogStringNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // run test function
         processor.Process(eventGroup);
@@ -1034,7 +1034,7 @@ void ProcessorParseContainerLogNativeUnittest::TestContainerdLogWithSplit() {
         // make ProcessorParseContainerLogNative
         ProcessorParseContainerLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // run test function
         processor.Process(eventGroup);
@@ -1048,7 +1048,7 @@ void ProcessorParseContainerLogNativeUnittest::TestContainerdLogWithSplit() {
         // make ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // run test function
         processor.Process(eventGroup);
@@ -1063,7 +1063,7 @@ void ProcessorParseContainerLogNativeUnittest::TestContainerdLogWithSplit() {
         // make ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // run test function
         processor.Process(eventGroup);
@@ -1133,7 +1133,7 @@ void ProcessorParseContainerLogNativeUnittest::TestDockerJsonLogLineParserWithSp
         // make ProcessorSplitLogStringNative
         ProcessorSplitLogStringNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // run test function
         processor.Process(eventGroup);
@@ -1147,7 +1147,7 @@ void ProcessorParseContainerLogNativeUnittest::TestDockerJsonLogLineParserWithSp
         // make ProcessorParseContainerLogNative
         ProcessorParseContainerLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // run test function
         processor.Process(eventGroup);
@@ -1161,7 +1161,7 @@ void ProcessorParseContainerLogNativeUnittest::TestDockerJsonLogLineParserWithSp
         // make ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // run test function
         processor.Process(eventGroup);
@@ -1176,7 +1176,7 @@ void ProcessorParseContainerLogNativeUnittest::TestDockerJsonLogLineParserWithSp
         // make ProcessorMergeMultilineLogNative
         ProcessorMergeMultilineLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // run test function
         processor.Process(eventGroup);
@@ -1224,7 +1224,7 @@ void ProcessorParseContainerLogNativeUnittest::TestDockerJsonLogLineParser() {
     config["IgnoringStderr"] = false;
     ProcessorParseContainerLogNative processor;
     processor.SetContext(mContext);
-    processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+    processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(processor.Init(config));
     // log 测试
     { // log 不存在情况下
@@ -1643,7 +1643,7 @@ void ProcessorParseContainerLogNativeUnittest::TestKeepingSourceWhenParseFail() 
 
         ProcessorParseContainerLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
 
         auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -1763,7 +1763,7 @@ void ProcessorParseContainerLogNativeUnittest::TestKeepingSourceWhenParseFail() 
         config["KeepingSourceWhenParseFail"] = false;
         ProcessorParseContainerLogNative processor;
         processor.SetContext(mContext);
-        processor.SetMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
+        processor.CreateMetricsRecordRef(ProcessorParseContainerLogNative::sName, "1");
         APSARA_TEST_TRUE_FATAL(processor.Init(config));
         // log 测试
         { // log 不存在情况下

--- a/core/unittest/processor/ProcessorParseDelimiterNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseDelimiterNativeUnittest.cpp
@@ -251,7 +251,7 @@ void ProcessorParseDelimiterNativeUnittest::TestAllowingShortenedFields() {
             // run function ProcessorSplitMultilineLogStringNative
             ProcessorSplitMultilineLogStringNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processor.Init(config));
             processor.Process(eventGroup);
 
@@ -371,7 +371,7 @@ void ProcessorParseDelimiterNativeUnittest::TestAllowingShortenedFields() {
             // run function ProcessorSplitMultilineLogStringNative
             ProcessorSplitMultilineLogStringNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processor.Init(config));
             processor.Process(eventGroup);
             // run function ProcessorParseDelimiterNative
@@ -519,7 +519,7 @@ void ProcessorParseDelimiterNativeUnittest::TestExtend() {
             // run function ProcessorSplitMultilineLogStringNative
             ProcessorSplitMultilineLogStringNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processor.Init(config));
             processor.Process(eventGroup);
             // run function ProcessorParseDelimiterNative
@@ -643,7 +643,7 @@ void ProcessorParseDelimiterNativeUnittest::TestExtend() {
             // run function ProcessorSplitMultilineLogStringNative
             ProcessorSplitMultilineLogStringNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processor.Init(config));
             processor.Process(eventGroup);
             // run function ProcessorParseDelimiterNative
@@ -764,7 +764,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLines() {
             // run function ProcessorSplitMultilineLogStringNative
             ProcessorSplitMultilineLogStringNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processor.Init(config));
             processor.Process(eventGroup);
             // run function ProcessorParseDelimiterNative
@@ -883,7 +883,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLines() {
             // run function ProcessorSplitMultilineLogStringNative
             ProcessorSplitMultilineLogStringNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processor.Init(config));
             processor.Process(eventGroup);
             // run function ProcessorParseDelimiterNative
@@ -1007,7 +1007,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLines() {
             // run function ProcessorSplitMultilineLogStringNative
             ProcessorSplitMultilineLogStringNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processor.Init(config));
             processor.Process(eventGroup);
             // run function ProcessorParseDelimiterNative
@@ -1135,7 +1135,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLinesWithProcessorMergeM
             // run function ProcessorMergeMultilineLogNative
             ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
             processorMergeMultilineLogNative.SetContext(mContext);
-            processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
             processorMergeMultilineLogNative.Process(eventGroup);
             // run function ProcessorParseDelimiterNative
@@ -1261,7 +1261,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLinesWithProcessorMergeM
             // run function ProcessorMergeMultilineLogNative
             ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
             processorMergeMultilineLogNative.SetContext(mContext);
-            processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
             processorMergeMultilineLogNative.Process(eventGroup);
             // run function ProcessorParseDelimiterNative
@@ -1392,7 +1392,7 @@ void ProcessorParseDelimiterNativeUnittest::TestMultipleLinesWithProcessorMergeM
             // run function ProcessorMergeMultilineLogNative
             ProcessorMergeMultilineLogNative processorMergeMultilineLogNative;
             processorMergeMultilineLogNative.SetContext(mContext);
-            processorMergeMultilineLogNative.SetMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
+            processorMergeMultilineLogNative.CreateMetricsRecordRef(ProcessorMergeMultilineLogNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processorMergeMultilineLogNative.Init(config));
             processorMergeMultilineLogNative.Process(eventGroup);
             // run function ProcessorParseDelimiterNative
@@ -1690,7 +1690,7 @@ HTTP/2.0' '200' '154' 'go-sdk'"
             // run function ProcessorSplitMultilineLogStringNative
             ProcessorSplitMultilineLogStringNative processor;
             processor.SetContext(mContext);
-            processor.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+            processor.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
             APSARA_TEST_TRUE_FATAL(processor.Init(config));
             processor.Process(eventGroup);
 

--- a/core/unittest/processor/ProcessorParseRegexNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorParseRegexNativeUnittest.cpp
@@ -85,7 +85,7 @@ void ProcessorParseRegexNativeUnittest::OnSuccessfulInit() {
     APSARA_TEST_TRUE(ParseJsonTable(configStr, configJson, errorMsg));
     processor.reset(new ProcessorParseRegexNative());
     processor->SetContext(ctx);
-    processor->SetMetricsRecordRef(ProcessorParseRegexNative::sName, "1");
+    processor->CreateMetricsRecordRef(ProcessorParseRegexNative::sName, "1");
     APSARA_TEST_TRUE(processor->Init(configJson));
     APSARA_TEST_EQUAL(2, processor->mKeys.size());
     APSARA_TEST_EQUAL("k1", processor->mKeys[0]);

--- a/core/unittest/processor/ProcessorSplitMultilineLogStringNativeUnittest.cpp
+++ b/core/unittest/processor/ProcessorSplitMultilineLogStringNativeUnittest.cpp
@@ -65,7 +65,7 @@ void ProcessorSplitMultilineLogDisacardUnmatchUnittest::TestLogSplitWithBeginCon
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: unmatch + unmatch
     // input: 1 event, 2 lines
@@ -343,7 +343,7 @@ void ProcessorSplitMultilineLogDisacardUnmatchUnittest::TestLogSplitWithBeginEnd
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: unmatch + unmatch
     // input: 1 event, 2 lines
@@ -596,7 +596,7 @@ void ProcessorSplitMultilineLogDisacardUnmatchUnittest::TestLogSplitWithBegin() 
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: unmatch + start
     // input: 1 event, 2 lines
@@ -841,7 +841,7 @@ void ProcessorSplitMultilineLogDisacardUnmatchUnittest::TestLogSplitWithContinue
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: unmatch
     // input: 1 event, 1 line
@@ -1042,7 +1042,7 @@ void ProcessorSplitMultilineLogDisacardUnmatchUnittest::TestLogSplitWithEnd() {
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: end
     // input: 1 event, 1 line
@@ -1185,7 +1185,7 @@ void ProcessorSplitMultilineLogDisacardUnmatchUnittest::TestEnableRawEvent() {
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
 
     auto sourceBuffer = std::make_shared<SourceBuffer>();
@@ -1257,7 +1257,7 @@ void ProcessorSplitMultilineLogKeepUnmatchUnittest::TestLogSplitWithBeginContinu
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: unmatch + unmatch
     // input: 1 event, 2 lines
@@ -1629,7 +1629,7 @@ void ProcessorSplitMultilineLogKeepUnmatchUnittest::TestLogSplitWithBeginEnd() {
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: unmatch + unmatch
     // input: 1 event, 2 lines
@@ -2009,7 +2009,7 @@ void ProcessorSplitMultilineLogKeepUnmatchUnittest::TestLogSplitWithBegin() {
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: unmatch + start
     // input: 1 event, 2 lines
@@ -2279,7 +2279,7 @@ void ProcessorSplitMultilineLogKeepUnmatchUnittest::TestLogSplitWithContinueEnd(
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: unmatch
     // input: 1 event, 1 line
@@ -2543,7 +2543,7 @@ void ProcessorSplitMultilineLogKeepUnmatchUnittest::TestLogSplitWithEnd() {
     // ProcessorSplitMultilineLogStringNative
     ProcessorSplitMultilineLogStringNative ProcessorSplitMultilineLogStringNative;
     ProcessorSplitMultilineLogStringNative.SetContext(mContext);
-    ProcessorSplitMultilineLogStringNative.SetMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
+    ProcessorSplitMultilineLogStringNative.CreateMetricsRecordRef(ProcessorSplitMultilineLogStringNative::sName, "1");
     APSARA_TEST_TRUE_FATAL(ProcessorSplitMultilineLogStringNative.Init(config));
     // case: end
     // input: 1 event, 1 line

--- a/core/unittest/sender/FlusherRunnerUnittest.cpp
+++ b/core/unittest/sender/FlusherRunnerUnittest.cpp
@@ -47,7 +47,7 @@ void FlusherRunnerUnittest::TestDispatch() {
         Json::Value tmp;
         CollectionPipelineContext ctx;
         flusher->SetContext(ctx);
-        flusher->SetMetricsRecordRef("name", "1");
+        flusher->CreateMetricsRecordRef("name", "1");
         flusher->Init(Json::Value(), tmp);
 
         auto item = make_unique<SenderQueueItem>("content", 10, flusher.get(), flusher->GetQueueKey());
@@ -66,7 +66,7 @@ void FlusherRunnerUnittest::TestDispatch() {
         Json::Value tmp;
         CollectionPipelineContext ctx;
         flusher->SetContext(ctx);
-        flusher->SetMetricsRecordRef("name", "1");
+        flusher->CreateMetricsRecordRef("name", "1");
         flusher->Init(Json::Value(), tmp);
 
         auto item = make_unique<SenderQueueItem>("content", 10, flusher.get(), flusher->GetQueueKey());
@@ -84,7 +84,7 @@ void FlusherRunnerUnittest::TestPushToHttpSink() {
     Json::Value tmp;
     CollectionPipelineContext ctx;
     flusher->SetContext(ctx);
-    flusher->SetMetricsRecordRef("name", "1");
+    flusher->CreateMetricsRecordRef("name", "1");
     flusher->Init(Json::Value(), tmp);
     {
         // keep item

--- a/core/unittest/serializer/JsonSerializerUnittest.cpp
+++ b/core/unittest/serializer/JsonSerializerUnittest.cpp
@@ -33,7 +33,7 @@ protected:
     void SetUp() override {
         mCtx.SetConfigName("test_config");
         sFlusher->SetContext(mCtx);
-        sFlusher->SetMetricsRecordRef(FlusherMock::sName, "1");
+        sFlusher->CreateMetricsRecordRef(FlusherMock::sName, "1");
     }
 
 private:

--- a/core/unittest/serializer/SLSSerializerUnittest.cpp
+++ b/core/unittest/serializer/SLSSerializerUnittest.cpp
@@ -33,7 +33,7 @@ protected:
     void SetUp() override {
         mCtx.SetConfigName("test_config");
         sFlusher->SetContext(mCtx);
-        sFlusher->SetMetricsRecordRef(FlusherSLS::sName, "1");
+        sFlusher->CreateMetricsRecordRef(FlusherSLS::sName, "1");
     }
 
 private:

--- a/core/unittest/serializer/SerializerUnittest.cpp
+++ b/core/unittest/serializer/SerializerUnittest.cpp
@@ -46,7 +46,7 @@ protected:
     void SetUp() override {
         mCtx.SetConfigName("test_config");
         sFlusher->SetContext(mCtx);
-        sFlusher->SetMetricsRecordRef(FlusherMock::sName, "1");
+        sFlusher->CreateMetricsRecordRef(FlusherMock::sName, "1");
     }
 
 private:


### PR DESCRIPTION
# 问题描述

线上发现有如下crash信息：

```shell
signal : 11 
0xb6e6a5:  (_ZN7logtail14CrashBackTraceEi+0x15) 
0x7f57880062f0:  (killpg+0x40) 
0x906c7e:  (_ZN7logtail13MetricsRecord7CollectEv+0x61e) 
0x8f5d6c:  (_ZN7logtail12WriteMetrics10DoSnapshotEv+0x38c) 
0x8f6423:  (_ZN7logtail11ReadMetrics13UpdateMetricsEv+0x53) 
0x90371a:  (_ZN7logtail17SelfMonitorServer11SendMetricsEv+0x3a) 
0x904db4:  (_ZN7logtail17SelfMonitorServer7MonitorEv+0x384) 
0x904f7d:  (_ZNSt17_Function_handlerIFSt10unique_ptrINSt13__future_base12_Result_baseENS2_8_DeleterEEvENS1_12_Task_setterIS0_INS1_7_ResultIvEES3_ENSt6thread8_InvokerISt5tupleIJMN7logtail17SelfMonitorServerEFvvEPSE_EEEEvEEE9_M_invokeERKSt9_Any_data+0x2d) 
0x8ff61b:  (_ZNSt13__future_base13_State_baseV29_M_do_setEPSt8functionIFSt10unique_ptrINS_12_Result_baseENS3_8_DeleterEEvEEPb+0x1b) 
0x7f57886ace90:  (pthread_once+0x50) 
0x905636:  (_ZNSt6thread11_State_implINS_8_InvokerISt5tupleIJZNSt13__future_base17_Async_state_implINS1_IS2_IJMN7logtail17SelfMonitorServerEFvvEPS6_EEEEvEC4EOSB_EUlvE_EEEEE6_M_runEv+0xe6) 
0x4ac1c90:  (execute_n
```

在添加profile后，问题触发会更频繁，每几小时触发一次

# 问题排查

在堆栈对应位置添加了日志，并获取到了触发的结果：

![image](https://github.com/user-attachments/assets/7a62d92a-817f-419e-90be-a8f7a6d0d693)

```shell
[2025-06-17 22:27:13.977568]	[warning]	[93111]	/workspaces/ilogtail-internal/core/monitor/metric_models/MetricRecord.cpp:96		Collect MetricsRecord:start
[2025-06-17 22:27:13.978116]	[warning]	[93111]	/workspaces/ilogtail-internal/core/monitor/metric_models/MetricRecord.cpp:99		Collect MetricsRecord:Counters
[2025-06-17 22:27:13.978438]	[warning]	[93111]	/workspaces/ilogtail-internal/core/monitor/metric_models/MetricRecord.cpp:100		size:1
[2025-06-17 22:27:13.978704]	[warning]	[93111]	/workspaces/ilogtail-internal/core/monitor/metric_models/MetricRecord.cpp:102		Collect MetricsRecord item:0x8e2c790
[2025-06-17 22:27:13.979360]	[warning]	[93111]	/workspaces/ilogtail-internal/core/monitor/metric_models/MetricRecord.cpp:102		Collect MetricsRecord item:0
```

发现是mCounters这个vector数组被多线程读写了。

* 写：MetricRecord在创建的时候就被加到链表里（WriteMetrics::PrepareMetricsRecordRef），加到链表里之后才开始CreateCounters等操作，而CreateCounters等操作是在其他线程进行

* 读：WriteMetrics::DoSnapshot的时候会遍历mCounters

![image](https://github.com/user-attachments/assets/444cfcbe-dcdc-4d7d-940d-b24b9e5d862c)

# 问题修复

方案有两个：

1. MetricRecord内对mCounters这些vector加锁，这个改法非常简单，已发到测试机器运行一天没有触发crash，可以认为问题解决。
2. 废除PrepareMetricsRecordRef，全部改为先CreateMetricsRecordRef，再CreateCounters等，最后CommitMetricsRecordRef，这样能保持无锁，性能更优。本pr就是基于这个方案改造
