### PR TITLE
optimize: speed up metric get size

### DIFF
--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -48,10 +48,10 @@ const (
 )
 
 var (
-	NilStringValues    = &keyValuesNil[string]{}
-	NilTypedValues     = &keyValuesNil[*TypedValue]{}
-	NilFloatValues     = &keyValuesNil[float64]{}
-	NilInterfaceValues = &keyValuesNil[interface{}]{}
+	NilStringValues    = &keyValuesNil[string]{m: make(map[string]string)}
+	NilTypedValues     = &keyValuesNil[*TypedValue]{m: make(map[string]*TypedValue)}
+	NilFloatValues     = &keyValuesNil[float64]{m: make(map[string]float64)}
+	NilInterfaceValues = &keyValuesNil[interface{}]{m: make(map[string]interface{})}
 )
 
 type TypedValue struct {
@@ -189,6 +189,7 @@ func (kv *keyValuesImpl[TValue]) SortTo(buf []KeyValue[TValue]) []KeyValue[TValu
 }
 
 type keyValuesNil[TValue string | float64 | *TypedValue | any] struct {
+	m map[string]TValue
 }
 
 func (kv *keyValuesNil[TValue]) Add(key string, value TValue) {
@@ -213,7 +214,7 @@ func (kv *keyValuesNil[TValue]) Merge(other KeyValues[TValue]) {
 }
 
 func (kv *keyValuesNil[TValue]) Iterator() map[string]TValue {
-	return make(map[string]TValue)
+	return kv.m
 }
 
 func (kv *keyValuesNil[TValue]) Len() int {

--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -41,6 +41,12 @@ const (
 	BodyKey    = ContentKey
 )
 
+const (
+	intValueBytes    = 4
+	longValueBytes   = 8
+	doubleValueBytes = 8
+)
+
 var (
 	NilStringValues    = &keyValuesNil[string]{}
 	NilTypedValues     = &keyValuesNil[*TypedValue]{}

--- a/pkg/models/common_test.go
+++ b/pkg/models/common_test.go
@@ -98,3 +98,15 @@ func BenchmarkMetricGetSize(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkNilKeyValueGetIterator(b *testing.B) {
+	kvs := NilStringValues
+
+	b.Run("NilKeyValueGetIterator", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = kvs.Iterator()
+		}
+	})
+}

--- a/pkg/models/common_test.go
+++ b/pkg/models/common_test.go
@@ -15,8 +15,10 @@
 package models
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
@@ -71,4 +73,28 @@ func Test_Tags_SortTo(t *testing.T) {
 			assert.Equalf(t, (*reflect.SliceHeader)(unsafe.Pointer(&cases.buf)).Data, (*reflect.SliceHeader)(unsafe.Pointer(&result)).Data, cases.caseName)
 		}
 	}
+}
+
+func BenchmarkMetricGetSize(b *testing.B) {
+	tags := NewTags()
+	for i := 0; i < 15; i++ {
+		tags.Add(fmt.Sprintf("tag_%d", i), fmt.Sprintf("value_%d", i))
+	}
+	metric := NewSingleValueMetric("cpu_usage", MetricTypeGauge, tags, time.Now().UnixNano(), 1.0)
+
+	b.Run("GetSizeByString", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = int64(len(metric.String()))
+		}
+	})
+
+	b.Run("MetricGetSize", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = metric.GetSize()
+		}
+	})
 }


### PR DESCRIPTION
Change-Id: I976ab23f38e278d44c96def134b73f7af1133ada

原先的实现有点太重了，已经成为metric执行链路上的主要开销
<img width="883" alt="image" src="https://github.com/user-attachments/assets/622d2af1-0b88-4046-90d5-36229c7f81d3" />

同时优化一下nil KV的内存分配
<img width="549" alt="image" src="https://github.com/user-attachments/assets/db33c510-b3c9-43b2-93c0-ed522fca11ee" />

