### PR TITLE
fix: read wrong disk buffer cause high memory

### DIFF
--- a/core/plugin/flusher/sls/DiskBufferWriter.h
+++ b/core/plugin/flusher/sls/DiskBufferWriter.h
@@ -58,6 +58,8 @@ public:
 private:
     static const int32_t BUFFER_META_BASE_SIZE;
     static const size_t BUFFER_META_MAX_SIZE;
+    static const int32_t BUFFER_DATA_MAX_SIZE;
+    static const int32_t PARTIAL_PREREAD_SIZE;
 
     struct EncryptionStateMeta {
         int32_t mLogDataSize;
@@ -93,6 +95,8 @@ private:
     void SetBufferFileName(const std::string& filename);
     std::string GetBufferFileHeader();
     bool CheckBufferMetaValidation(const std::string& filename, const sls_logs::LogtailBufferMeta& bufferMeta);
+
+    bool PartialReadAndValidateAliuid(FILE* fin, int32_t encodedInfoSize, bool isPbMeta, const std::string& filename);
 
     SafeQueue<SenderQueueItem*> mQueue;
 

--- a/core/plugin/flusher/sls/DiskBufferWriter.h
+++ b/core/plugin/flusher/sls/DiskBufferWriter.h
@@ -96,7 +96,8 @@ private:
     std::string GetBufferFileHeader();
     bool CheckBufferMetaValidation(const std::string& filename, const sls_logs::LogtailBufferMeta& bufferMeta);
 
-    bool PartialReadAndValidateAliuid(FILE* fin, int32_t encodedInfoSize, bool isPbMeta, const std::string& filename);
+    bool
+    PartialReadAndValidateKeyFields(FILE* fin, int32_t encodedInfoSize, bool isPbMeta, const std::string& filename);
 
     SafeQueue<SenderQueueItem*> mQueue;
 


### PR DESCRIPTION
核心问题是这一段
<img width="1634" height="462" alt="image" src="https://github.com/user-attachments/assets/b14464cc-5ee0-4b3e-ba16-5e969b664463" />
SenderQueueItem是被clone保存的，但其中的flusher是一个指针。当force stop的时候，flusher可能已经被释放了，但C++访问一个被释放的类的属性是未定义的，通常是可以获取的。但也没办法判断flusher是否已释放，所以只能在读取时拦截。

## 修复方案
### 问题一：超大，导致内存暴涨
通过protobuf流式读取。当size超大时，预读取前16KB，判断其中的元信息的几个字段是否超长，排除数据本身超大导致的错判。

### 问题二：aliuid长度合法，但内容错误
aliuid一定为纯数字组成。校验其每位是否为数字。