### PR TITLE
fix: grpc find_package link ssl so

### DIFF
--- a/.github/workflows/build-core.yaml
+++ b/.github/workflows/build-core.yaml
@@ -73,7 +73,7 @@ jobs:
           ENABLE_COMPATIBLE_MODE: ON
           ENABLE_STATIC_LINK_CRT: ON
           WITHOUTGDB: ON
-        run: make dist && scripts/check_glibc.sh && scripts/check_cpu_instruction.sh
+        run: make dist && scripts/check_glibc.sh && scripts/check_cpu_instruction.sh && scripts/check_dependencies.sh
 
   actions-timeline:
     needs: [BuildCore]

--- a/core/dependencies.cmake
+++ b/core/dependencies.cmake
@@ -365,22 +365,7 @@ macro(link_crypto target_name)
     if (crypto_${LINK_OPTION_SUFFIX})
         target_link_libraries(${target_name} "${crypto_${LINK_OPTION_SUFFIX}}")
     elseif (UNIX)
-        # Check if we're on ARM and building a shared library
-        # TODO：armv8使用了汇编优化，尝试多种方法编译成fPIC失败，所以当需要编译成动态库时，使用crypto动态库
-        set(use_shared_crypto FALSE)
-        if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
-            # Check if the target itself is a shared library
-            get_target_property(target_type ${target_name} TYPE)
-            if (target_type STREQUAL "SHARED_LIBRARY")
-                set(use_shared_crypto TRUE)
-            endif()
-        endif()
-        
-        if (use_shared_crypto)
-            target_link_libraries(${target_name} "${crypto_${LIBRARY_DIR_SUFFIX}}/libcrypto.so")
-        else()
-            target_link_libraries(${target_name} "${crypto_${LIBRARY_DIR_SUFFIX}}/libcrypto.a")
-        endif()
+        target_link_libraries(${target_name} "${crypto_${LIBRARY_DIR_SUFFIX}}/libcrypto.a")
     elseif (MSVC)
         #target_link_libraries (${target_name}
         #   debug "libcurl-d"
@@ -424,6 +409,8 @@ endmacro()
 # grpc
 macro(link_grpc target_name)
     if (UNIX)
+        set(OPENSSL_USE_STATIC_LIBS ON)
+        set(OPENSSL_ROOT_DIR ${DEFAULT_DEPS_ROOT})
         find_package(re2 QUIET PATHS ${DEPS_ROOT}/lib64/cmake/re2 NO_DEFAULT_PATH)
         if(NOT re2_FOUND)
             message(FATAL_ERROR "re2 not found, please upgrade your development image to compile!")

--- a/docker/Dockerfile_build
+++ b/docker/Dockerfile_build
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.7 AS build
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.8 AS build
 
 USER root
 WORKDIR /src

--- a/docker/Dockerfile_coverage
+++ b/docker/Dockerfile_coverage
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.7
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.8
 
 USER root
 WORKDIR /src

--- a/docker/Dockerfile_development_part
+++ b/docker/Dockerfile_development_part
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.7
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.8
 
 ARG HOST_OS=Linux
 ARG VERSION=0.0.1

--- a/docker/Dockerfile_e2e
+++ b/docker/Dockerfile_e2e
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.7
+FROM sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.8
 
 ARG HOST_OS=Linux
 ARG VERSION=0.0.1

--- a/docker/Dockerfile_edge_linux
+++ b/docker/Dockerfile_edge_linux
@@ -1,7 +1,7 @@
 #########################################################################################################################
 # Step 1: Build
 #########################################################################################################################
-FROM sls-opensource-registry.us-east-1.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.7 AS builder
+FROM sls-opensource-registry.us-east-1.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.8 AS builder
 
 USER root
 WORKDIR /src

--- a/docs/cn/developer-guide/development-environment.md
+++ b/docs/cn/developer-guide/development-environment.md
@@ -84,7 +84,7 @@ go install ...
 
 ```json
 {
-  "image": "sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.7",
+  "image": "sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.8",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -190,7 +190,7 @@ cp -a ./core/build/go_pipeline/libGoPluginAdapter.so ./output
 ```bash
 docker run --name loongcollector-build -d \
   -v `pwd`:/src -w /src \
-  sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.7 \
+  sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector-build-linux:2.1.8 \
   bash -c "sleep infinity"
 ```
 

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 iLogtail Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ue
+set -o pipefail
+
+# initialize variables
+OUT_DIR=${1:-output}
+ROOTDIR=$(cd $(dirname "${BASH_SOURCE[0]}") && cd .. && pwd)
+# BIN="${BIN_TO_CHECK:-${ROOTDIR}/${OUT_DIR}/loongcollector}"
+BIN=/workspaces/ilogtail-debug/debug/loongcollector
+
+# Define allowed dynamic libraries
+# These are the only libraries that should be linked to the binary
+ALLOWED_LIBRARIES=(
+    "linux-vdso.so.1"
+    "libpthread.so.0"
+    "libdl.so.2"
+    "libuuid.so.1"
+    "librt.so.1"
+    "libm.so.6"
+    "libc.so.6"
+    "/lib64/ld-linux-x86-64.so.2"
+)
+
+echo "Checking dynamic library dependencies..."
+echo "Allowed libraries: ${ALLOWED_LIBRARIES[*]}"
+echo ""
+
+# Function to check if a library is in the allowed list
+is_library_allowed() {
+    local lib_name="$1"
+    
+    # Extract the library name from the ldd output
+    # Handle different formats: 
+    # - "linux-vdso.so.1 (0x...)"
+    # - "libpthread.so.0 => /lib64/libpthread.so.0 (0x...)"
+    # - "/lib64/ld-linux-x86-64.so.2 (0x...)"
+    
+    for allowed in "${ALLOWED_LIBRARIES[@]}"; do
+        if [[ "$lib_name" == "$allowed"* ]] || [[ "$lib_name" == *"$allowed"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Function to check a single binary file
+check_binary_dependencies() {
+    local obj="$1"
+    local failed=0
+    
+    echo "Checking dependencies in $obj ..."
+    
+    # Use ldd to get dynamic library dependencies
+    if ! ldd_output=$(ldd "$obj" 2>&1); then
+        echo -e "\033[0;31mError: Failed to run ldd on $obj\033[0m"
+        echo "$ldd_output"
+        return 1
+    fi
+    
+    # Parse ldd output and check each library
+    local unwanted_libs=()
+    
+    while IFS= read -r line; do
+        # Skip empty lines
+        [[ -z "$line" ]] && continue
+        
+        # Extract library name from different ldd output formats
+        if [[ "$line" =~ ^[[:space:]]*([^[:space:]]+)[[:space:]]*\( ]]; then
+            # Format: "linux-vdso.so.1 (0x...)"
+            lib_name="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ ^[[:space:]]*([^[:space:]]+)[[:space:]]*=\>[[:space:]]*([^[:space:]]+)[[:space:]]*\( ]]; then
+            # Format: "libpthread.so.0 => /lib64/libpthread.so.0 (0x...)"
+            lib_name="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ ^[[:space:]]*(/[^[:space:]]+)[[:space:]]*\( ]]; then
+            # Format: "/lib64/ld-linux-x86-64.so.2 (0x...)"
+            lib_name="${BASH_REMATCH[1]}"
+        else
+            continue
+        fi
+        
+        # Check if this library is allowed
+        if ! is_library_allowed "$lib_name"; then
+            unwanted_libs+=("$line")
+        fi
+    done <<< "$ldd_output"
+    
+    # Report results
+    if [[ ${#unwanted_libs[@]} -gt 0 ]]; then
+        echo -e "\033[0;31mError: Found unwanted library dependencies in $obj:\033[0m"
+        printf '%s\n' "${unwanted_libs[@]}"
+        echo ""
+        echo -e "\033[0;31mFull ldd output:\033[0m"
+        echo "$ldd_output"
+        echo ""
+        failed=1
+    else
+        echo -e "\033[0;32m✓ All library dependencies are allowed in $obj\033[0m"
+        echo "Dependencies found:"
+        echo "$ldd_output" | sed 's/^/  /'
+        echo ""
+    fi
+    
+    return $failed
+}
+
+# Check all binaries
+all=("$BIN")
+failed=0
+
+for obj in "${all[@]}"; do
+    if [[ -f "$obj" ]]; then
+        check_binary_dependencies "$obj" || failed+=1
+    else
+        echo -e "\033[0;33mWarning: $obj not found, skipping...\033[0m"
+    fi
+done
+
+# Final result
+if [[ $failed -gt 0 ]]; then
+    echo -e "\033[0;31mError: Found unwanted library dependencies in $failed binary file(s)\033[0m"
+    echo -e "\033[0;31mThese dependencies may cause compatibility issues or security concerns\033[0m"
+    echo -e "\033[0;31mConsider static linking or removing unnecessary dependencies\033[0m"
+    exit 1
+else
+    echo -e "\033[0;32mAll dependency checks passed\033[0m"
+    echo -e "\033[0;32mOnly allowed library dependencies found\033[0m"
+fi 


### PR DESCRIPTION
grpc find_package会默认优先链接so。但是如果不使用find_package，那么CMake中要手动链接几十个库。
因此，通过设置两个CMake参数，可以让grpc链接静态库。