### PR TITLE
Fix: fix GetConvertedPath error on windows

### DIFF
--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -206,7 +206,11 @@ LogFileReader::LogFileReader(const std::string& hostLogPathDir,
       mConfigName(readerConfig.second->GetConfigName()),
       mRegion(readerConfig.second->GetRegion()) {
     mHostLogPath = PathJoin(hostLogPathDir, hostLogPathFile);
-
+#if defined(_MSC_VER)
+    if (BOOL_FLAG(enable_chinese_tag_path)) {
+        mChineseEncodingPath = EncodingConverter::GetInstance()->FromACPToUTF8(mHostLogPath);
+    }
+#endif
 
     BaseLineParse* baseLineParsePtr = nullptr;
     baseLineParsePtr = GetParser<RawTextParser>(0);
@@ -2439,16 +2443,12 @@ PipelineEventGroup LogFileReader::GenerateEventGroup(LogFileReaderPtr reader, Lo
 }
 
 const std::string& LogFileReader::GetConvertedPath() const {
-    const std::string& path = mDockerPath.empty() ? mHostLogPath : mDockerPath;
 #if defined(_MSC_VER)
     if (BOOL_FLAG(enable_chinese_tag_path)) {
-        static std::string newPath = EncodingConverter::GetInstance()->FromACPToUTF8(path);
-        return newPath;
+        return mChineseEncodingPath;
     }
-    return path;
-#else
-    return path;
 #endif
+    return mDockerPath.empty() ? mHostLogPath : mDockerPath;
 }
 
 bool LogFileReader::UpdateContainerInfo() {

--- a/core/file_server/reader/LogFileReader.h
+++ b/core/file_server/reader/LogFileReader.h
@@ -484,6 +484,7 @@ protected:
     std::string mHostLogPathDir;
     std::string mHostLogPathFile;
     std::string mRealLogPath; // real log path
+    std::string mChineseEncodingPath; // On Windows, Chinese config base path's __path__ will be converted to GBK
     bool mSymbolicLinkFlag = false;
     std::string mSourceId;
     // int32_t mTailLimit; // KB


### PR DESCRIPTION
fix #1851

表现为采集loongcollector.LOG，显示为：

<img width="2202" height="388" alt="image" src="https://github.com/user-attachments/assets/d6c53a58-84a6-44e8-af4d-73deb5c5cd05" />
