### PR TITLE
support vendor-neutral config prefix (LOONG_) while keeping ALIYUN_ backward compatibility

### DIFF
--- a/core/app_config/AppConfig.h
+++ b/core/app_config/AppConfig.h
@@ -76,7 +76,7 @@ std::string GetAgentName();
 std::string GetMonitorInfoFileName();
 std::string GetSymLinkName();
 std::string GetAgentPrefix();
-std::string GetFileTagsDir();
+std::string GenerateFileTagsDir();
 
 template <class T>
 class DoubleBuffer {
@@ -110,6 +110,7 @@ private:
     std::map<std::string, std::function<bool()>*> mCallbacks;
 
     DoubleBuffer<std::vector<sls_logs::LogTag>> mFileTags;
+    std::string mFileTagsDir;
     DoubleBuffer<std::map<std::string, std::string>> mAgentAttrs;
 
     Json::Value mFileTagsJson;
@@ -311,8 +312,8 @@ private:
     // Read values will replace corresponding configs in loongcollector_config.json.
     void LoadEnvResourceLimit();
 
-    // logtail is in purage container mode when STRING_FLAG(ilogtail_user_defined_id_env_name) exist and /logtail_host
-    // exist
+    // logtail is in purage container mode when STRING_FLAG(ilogtail_user_defined_id_env_name) or
+    // "ALIYUN_LOGTAIL_USER_DEFINED_ID" exist and /logtail_host exist
     void CheckPurageContainerMode();
     bool CheckAndResetProxyEnv();
     bool CheckAndResetProxyAddress(const char* envKey, std::string& address);
@@ -389,6 +390,8 @@ public:
     std::vector<sls_logs::LogTag>& GetFileTags() { return mFileTags.getReadBuffer(); }
     // 更新从文件中来的tags
     void UpdateFileTags();
+
+    std::string GetFileTagsDir() { return mFileTagsDir; }
 
     // Agent属性相关，获取从文件中来的attrs
     std::map<std::string, std::string>& GetAgentAttrs() { return mAgentAttrs.getReadBuffer(); }

--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -27,6 +27,7 @@
 #include "collection_pipeline/queue/ExactlyOnceQueueManager.h"
 #include "collection_pipeline/queue/SenderQueueManager.h"
 #include "common/CrashBackTraceUtil.h"
+#include "common/EnvUtil.h"
 #include "common/Flags.h"
 #include "common/MachineInfoUtil.h"
 #include "common/RuntimeUtil.h"
@@ -259,7 +260,7 @@ void Application::Start() { // GCOVR_EXCL_START
     }
     // Actually, docker env config will not work if not in purage container mode, so there is no need to load plugin
     // base if not in purage container mode. However, we still load it here for backward compatability.
-    const char* dockerEnvConfig = getenv("ALICLOUD_LOG_DOCKER_ENV_CONFIG");
+    const char* dockerEnvConfig = GetEnv("LOONG_DOCKER_ENV_CONFIG", "ALICLOUD_LOG_DOCKER_ENV_CONFIG");
     if (dockerEnvConfig != NULL && strlen(dockerEnvConfig) > 0
         && (dockerEnvConfig[0] == 't' || dockerEnvConfig[0] == 'T')) {
         LogtailPlugin::GetInstance()->LoadPluginBase();

--- a/core/common/EnvUtil.cpp
+++ b/core/common/EnvUtil.cpp
@@ -34,4 +34,12 @@ void UnsetEnv(const char* key) {
 #endif
 }
 
+char* GetEnv(const char* firstKey, const char* secondKey) {
+    char* value = std::getenv(firstKey);
+    if (value == nullptr) {
+        value = std::getenv(secondKey);
+    }
+    return value;
+}
+
 } // namespace logtail

--- a/core/common/EnvUtil.cpp
+++ b/core/common/EnvUtil.cpp
@@ -35,9 +35,9 @@ void UnsetEnv(const char* key) {
 }
 
 char* GetEnv(const char* firstKey, const char* secondKey) {
-    char* value = std::getenv(firstKey);
+    char* value = getenv(firstKey);
     if (value == nullptr) {
-        value = std::getenv(secondKey);
+        value = getenv(secondKey);
     }
     return value;
 }

--- a/core/common/EnvUtil.h
+++ b/core/common/EnvUtil.h
@@ -21,6 +21,7 @@ namespace logtail {
 
 void SetEnv(const char* key, const char* value);
 void UnsetEnv(const char* key);
+char* GetEnv(const char* firstKey, const char* secondKey);
 
 } // namespace logtail
 

--- a/core/go_pipeline/LogtailPlugin.cpp
+++ b/core/go_pipeline/LogtailPlugin.cpp
@@ -38,7 +38,6 @@
 #endif
 
 DEFINE_FLAG_BOOL(enable_sls_metrics_format, "if enable format metrics in SLS metricstore log pattern", true);
-DECLARE_FLAG_STRING(ALIYUN_LOG_FILE_TAGS);
 DECLARE_FLAG_INT32(file_tags_update_interval);
 DECLARE_FLAG_STRING(agent_host_id);
 DECLARE_FLAG_BOOL(ilogtail_disable_core);

--- a/core/plugin/flusher/sls/SLSClientManager.cpp
+++ b/core/plugin/flusher/sls/SLSClientManager.cpp
@@ -33,6 +33,7 @@
 #ifdef __ENTERPRISE__
 #include "plugin/flusher/sls/EnterpriseSLSClientManager.h"
 #endif
+#include "common/EnvUtil.h"
 
 DEFINE_FLAG_STRING(custom_user_agent, "custom user agent appended at the end of the exsiting ones", "");
 DEFINE_FLAG_STRING(default_access_key_id, "", "");
@@ -100,7 +101,7 @@ void SLSClientManager::GenerateUserAgent() {
 
 string SLSClientManager::GetRunningEnvironment() {
     string env;
-    if (getenv("ALIYUN_LOG_STATIC_CONTAINER_INFO")) {
+    if (GetEnv("LOONG_STATIC_CONTAINER_INFO", "ALIYUN_LOG_STATIC_CONTAINER_INFO")) {
         env = "ECI";
     } else if (getenv("ACK_NODE_LOCAL_DNS_ADMISSION_CONTROLLER_SERVICE_HOST")) {
         // logtail-ds installed by ACK will possess the above env
@@ -117,7 +118,7 @@ string SLSClientManager::GetRunningEnvironment() {
         } else {
             env = "K8S-Sidecar";
         }
-    } else if (AppConfig::GetInstance()->IsPurageContainerMode() || getenv("ALIYUN_LOGTAIL_CONFIG")) {
+    } else if (AppConfig::GetInstance()->IsPurageContainerMode() || GetEnv("LOONG_CONFIG", "ALIYUN_LOGTAIL_CONFIG")) {
         env = "Docker";
     } else if (InstanceIdentity::Instance()->GetEntity()->IsECSValid()) {
         env = "ECS";

--- a/core/plugin/processor/inner/ProcessorTagNative.cpp
+++ b/core/plugin/processor/inner/ProcessorTagNative.cpp
@@ -109,7 +109,7 @@ void ProcessorTagNative::Process(PipelineEventGroup& logGroup) {
     AddTag(logGroup, TagKey::HOST_IP_TAG_KEY, LoongCollectorMonitor::GetInstance()->mIpAddr);
 #endif
 
-    if (!STRING_FLAG(ALIYUN_LOG_FILE_TAGS).empty()) {
+    if (!AppConfig::GetInstance()->GetFileTagsDir().empty()) {
         vector<sls_logs::LogTag>& fileTags = AppConfig::GetInstance()->GetFileTags();
         if (!fileTags.empty()) { // reloadable, so we must get it every time and copy value
             for (size_t i = 0; i < fileTags.size(); ++i) {

--- a/core/unittest/common/CMakeLists.txt
+++ b/core/unittest/common/CMakeLists.txt
@@ -48,6 +48,9 @@ target_link_libraries(yaml_util_unittest ${UT_BASE_TARGET})
 add_executable(safe_queue_unittest SafeQueueUnittest.cpp)
 target_link_libraries(safe_queue_unittest ${UT_BASE_TARGET})
 
+add_executable(env_util_unittest EnvUtilUnittest.cpp)
+target_link_libraries(env_util_unittest ${UT_BASE_TARGET})
+
 add_executable(http_request_timer_event_unittest timer/HttpRequestTimerEventUnittest.cpp)
 target_link_libraries(http_request_timer_event_unittest ${UT_BASE_TARGET})
 
@@ -80,6 +83,7 @@ gtest_discover_tests(common_machine_info_util_unittest)
 gtest_discover_tests(encoding_converter_unittest)
 gtest_discover_tests(yaml_util_unittest)
 gtest_discover_tests(safe_queue_unittest)
+gtest_discover_tests(env_util_unittest)
 gtest_discover_tests(http_request_timer_event_unittest)
 gtest_discover_tests(timer_unittest)
 gtest_discover_tests(curl_unittest)

--- a/core/unittest/common/EnvUtilUnittest.cpp
+++ b/core/unittest/common/EnvUtilUnittest.cpp
@@ -1,0 +1,69 @@
+// Copyright 2025 loongcollector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/EnvUtil.h"
+#include "unittest/Unittest.h"
+
+using namespace logtail;
+
+class EnvUtilUnittest : public ::testing::Test {
+protected:
+    static constexpr const char* TEST_KEY1 = "LOONG_TEST_ENV_KEY1";
+    static constexpr const char* TEST_KEY2 = "ALIYUN_TEST_ENV_KEY1";
+
+    static constexpr const char* TEST_VALUE1 = "loong_test_value_1";
+    static constexpr const char* TEST_VALUE2 = "aliyun_test_value_1";
+    static constexpr const char* TEST_VALUE_EMPTY = "";
+
+    void CleanupTestEnv() {
+        logtail::UnsetEnv(TEST_KEY1);
+        logtail::UnsetEnv(TEST_KEY2);
+    }
+};
+
+TEST_F(EnvUtilUnittest, TestGetEnv) {
+    {
+        CleanupTestEnv();
+        logtail::SetEnv(TEST_KEY1, TEST_VALUE1);
+
+        char* result = logtail::GetEnv(TEST_KEY1, TEST_KEY2);
+        APSARA_TEST_STREQ(result, TEST_VALUE1);
+    }
+
+    {
+        CleanupTestEnv();
+        logtail::SetEnv(TEST_KEY2, TEST_VALUE2);
+
+        char* result = logtail::GetEnv(TEST_KEY1, TEST_KEY2);
+        APSARA_TEST_STREQ(result, TEST_VALUE2);
+    }
+
+    {
+        CleanupTestEnv();
+
+        char* result = logtail::GetEnv(TEST_KEY1, TEST_KEY2);
+        APSARA_TEST_EQUAL(result, nullptr);
+    }
+
+    {
+        CleanupTestEnv();
+        logtail::SetEnv(TEST_KEY1, TEST_VALUE1);
+        logtail::SetEnv(TEST_KEY2, TEST_VALUE2);
+
+        char* result = logtail::GetEnv(TEST_KEY1, TEST_KEY2);
+        APSARA_TEST_STREQ(result, TEST_VALUE1);
+    }
+}
+
+UNIT_TEST_MAIN

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -35,10 +35,11 @@ const (
 )
 
 const (
-	DefaultGlobalConfig     = `{"InputIntervalMs":5000,"AggregatIntervalMs":30,"FlushIntervalMs":30,"DefaultLogQueueSize":11,"DefaultLogGroupQueueSize":12}`
-	DefaultPluginConfig     = `{"inputs":[{"type":"metric_mock","detail":{"Tags":{"tag1":"aaaa","tag2":"bbb"},"Fields":{"Content":"xxxxx","time":"2017.09.12 20:55:36"}}}],"flushers":[{"type":"flusher_stdout"}]}`
-	DefaultFlusherConfig    = `{"type":"flusher_sls","detail":{}}`
-	LoongcollectorEnvPrefix = "LOONG_"
+	DefaultGlobalConfig                 = `{"InputIntervalMs":5000,"AggregatIntervalMs":30,"FlushIntervalMs":30,"DefaultLogQueueSize":11,"DefaultLogGroupQueueSize":12}`
+	DefaultPluginConfig                 = `{"inputs":[{"type":"metric_mock","detail":{"Tags":{"tag1":"aaaa","tag2":"bbb"},"Fields":{"Content":"xxxxx","time":"2017.09.12 20:55:36"}}}],"flushers":[{"type":"flusher_stdout"}]}`
+	DefaultFlusherConfig                = `{"type":"flusher_sls","detail":{}}`
+	LoongcollectorEnvPrefix             = "LOONG_"
+	LoongcollectorContainerLogEnvPrefix = "loong_logs_"
 )
 
 var (

--- a/pkg/helper/containercenter/container_center.go
+++ b/pkg/helper/containercenter/container_center.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 
+	"github.com/alibaba/ilogtail/pkg/flags"
 	"github.com/alibaba/ilogtail/pkg/helper"
 	"github.com/alibaba/ilogtail/pkg/logger"
 	"github.com/alibaba/ilogtail/pkg/util"
@@ -380,6 +381,7 @@ func (did *DockerInfoDetail) FindAllEnvConfig(envConfigPrefix string, selfConfig
 		return
 	}
 	selfEnvConfig := false
+	envMap := make(map[string]string)
 	for _, env := range did.ContainerInfo.Config.Env {
 		kvPair := strings.SplitN(env, "=", 2)
 		if len(kvPair) != 2 {
@@ -388,17 +390,29 @@ func (did *DockerInfoDetail) FindAllEnvConfig(envConfigPrefix string, selfConfig
 		key := kvPair[0]
 		value := kvPair[1]
 
-		if key == "ALICLOUD_LOG_DOCKER_ENV_CONFIG_SELF" && (value == "true" || value == "TRUE") {
+		if (key == "ALICLOUD_LOG_DOCKER_ENV_CONFIG_SELF" || key == "LOONG_LOG_DOCKER_ENV_CONFIG_SELF") && (value == "true" || value == "TRUE") {
 			logger.Debug(context.Background(), "this container is self env config", did.ContainerInfo.Name)
 			selfEnvConfig = true
 			continue
 		}
-
-		if !strings.HasPrefix(key, envConfigPrefix) {
-			continue
+		logEnvPrefix := envConfigPrefix
+		if !strings.HasPrefix(key, logEnvPrefix) {
+			if strings.HasPrefix(key, flags.LoongcollectorContainerLogEnvPrefix) {
+				logEnvPrefix = flags.LoongcollectorContainerLogEnvPrefix
+			} else {
+				continue
+			}
 		}
-		logger.Debug(context.Background(), "docker env config, name", did.ContainerInfo.Name, "item", key)
-		envKey := key[len(envConfigPrefix):]
+		envKey := key[len(logEnvPrefix):]
+		if _, ok := envMap[envKey]; !ok {
+			envMap[envKey] = value
+		} else if logEnvPrefix == flags.LoongcollectorContainerLogEnvPrefix {
+			envMap[envKey] = value
+		}
+	}
+
+	for envKey, value := range envMap {
+		logger.Debug(context.Background(), "docker env config, name", did.ContainerInfo.Name, "item", envKey)
 		lastIndex := strings.LastIndexByte(envKey, '_')
 		var configName string
 		// end with '_', invalid, just skip

--- a/pkg/helper/containercenter/container_center.go
+++ b/pkg/helper/containercenter/container_center.go
@@ -407,6 +407,8 @@ func (did *DockerInfoDetail) FindAllEnvConfig(envConfigPrefix string, selfConfig
 		if _, ok := envMap[envKey]; !ok {
 			envMap[envKey] = value
 		} else if logEnvPrefix == flags.LoongcollectorContainerLogEnvPrefix {
+			// If environment variables with the prefix 'loong_logs_' and 'aliyun_logs_' both exist,
+			// then override the variable with the prefix 'loong_logs_'.
 			envMap[envKey] = value
 		}
 	}

--- a/pkg/helper/env_tags.go
+++ b/pkg/helper/env_tags.go
@@ -18,9 +18,12 @@ import (
 	"os"
 	"strings"
 	"sync"
+
+	"github.com/alibaba/ilogtail/pkg/util"
 )
 
 const defaultEnvTagKeys = "ALIYUN_LOG_ENV_TAGS"
+const defaultLoongEnvTagKeys = "LOONG_LOG_ENV_TAGS"
 
 // EnvTags to be add to every logroup
 var EnvTags []string
@@ -30,7 +33,7 @@ var envTagsLock sync.RWMutex
 func LoadEnvTags() {
 	envTagsLock.Lock() // Lock for writing
 	defer envTagsLock.Unlock()
-	envTagKeys := os.Getenv(defaultEnvTagKeys)
+	envTagKeys := util.GetEnvTags(defaultLoongEnvTagKeys, defaultEnvTagKeys)
 	if len(envTagKeys) == 0 || len(EnvTags) > 0 {
 		return
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -44,6 +44,8 @@ const alphanum string = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrs
 const (
 	ShardHashTagKey = "__shardhash__"
 	PackIDTagKey    = "__pack_id__"
+	AliCloudPrefix  = "ALICLOUD_"
+	LoongPrefix     = "LOONG_"
 )
 
 var (
@@ -257,7 +259,13 @@ func SplitPath(path string) (dir string, filename string) {
 }
 
 func InitFromEnvBool(key string, value *bool, defaultValue bool) error {
-	if envValue := os.Getenv(key); len(envValue) > 0 {
+	var envValue string
+	if strings.Contains(key, AliCloudPrefix) {
+		envValue = GetEnvTags(strings.Replace(key, AliCloudPrefix, LoongPrefix, 1), key)
+	} else {
+		envValue = os.Getenv(key)
+	}
+	if len(envValue) > 0 {
 		lowErVal := strings.ToLower(envValue)
 		if strings.HasPrefix(lowErVal, "y") || strings.HasPrefix(lowErVal, "t") || strings.HasPrefix(lowErVal, "on") || strings.HasPrefix(lowErVal, "ok") {
 			*value = true
@@ -271,7 +279,13 @@ func InitFromEnvBool(key string, value *bool, defaultValue bool) error {
 }
 
 func InitFromEnvInt(key string, value *int, defaultValue int) error {
-	if envValue := os.Getenv(key); len(envValue) > 0 {
+	var envValue string
+	if strings.Contains(key, AliCloudPrefix) {
+		envValue = GetEnvTags(strings.Replace(key, AliCloudPrefix, LoongPrefix, 1), key)
+	} else {
+		envValue = os.Getenv(key)
+	}
+	if len(envValue) > 0 {
 		if val, err := strconv.Atoi(envValue); err == nil {
 			*value = val
 			return nil
@@ -284,12 +298,26 @@ func InitFromEnvInt(key string, value *int, defaultValue int) error {
 }
 
 func InitFromEnvString(key string, value *string, defaultValue string) error {
-	if envValue := os.Getenv(key); len(envValue) > 0 {
+	var envValue string
+	if strings.Contains(key, AliCloudPrefix) {
+		envValue = GetEnvTags(strings.Replace(key, AliCloudPrefix, LoongPrefix, 1), key)
+	} else {
+		envValue = os.Getenv(key)
+	}
+	if len(envValue) > 0 {
 		*value = envValue
 		return nil
 	}
 	*value = defaultValue
 	return nil
+}
+
+func GetEnvTags(firstKey, secondKey string) string {
+	tag := os.Getenv(firstKey)
+	if len(tag) == 0 {
+		return os.Getenv(secondKey)
+	}
+	return tag
 }
 
 // GuessRegionByEndpoint guess region

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -22,21 +22,21 @@ import (
 )
 
 const (
-	TEST_KEY1 = "LOONG_TEST_ENV_KEY1"
-	TEST_KEY2 = "ALIYUN_TEST_ENV_KEY1"
-	TEST_KEY3 = "ALICLOUD_TEST_ENV_KEY1"
+	testKey1 = "LOONG_TEST_ENV_KEY1"
+	testKey2 = "ALIYUN_TEST_ENV_KEY1"
+	testKey3 = "ALICLOUD_TEST_ENV_KEY1"
 
-	TEST_VALUE1 = "loong_test_value_1"
-	TEST_VALUE2 = "aliyun_test_value_1"
-	TEST_VALUE3 = "alicloud_test_value_1"
+	testValue1 = "loong_test_value_1"
+	testValue2 = "aliyun_test_value_1"
+	testValue3 = "alicloud_test_value_1"
 
 	DEFAULT_VALUE = "default_value"
 )
 
 func cleanupTestEnv() {
-	os.Unsetenv(TEST_KEY1)
-	os.Unsetenv(TEST_KEY2)
-	os.Unsetenv(TEST_KEY3)
+	os.Unsetenv(testKey1)
+	os.Unsetenv(testKey2)
+	os.Unsetenv(testKey3)
 }
 
 func Test(t *testing.T) {
@@ -54,84 +54,84 @@ func Test(t *testing.T) {
 func TestGetEnvTags(t *testing.T) {
 	{
 		cleanupTestEnv()
-		os.Setenv(TEST_KEY1, TEST_VALUE1)
+		os.Setenv(testKey1, testValue1)
 
-		result := GetEnvTags(TEST_KEY1, TEST_KEY2)
-		assert.Equal(t, TEST_VALUE1, result)
+		result := GetEnvTags(testKey1, testKey2)
+		assert.Equal(t, testValue1, result)
 	}
 
 	{
 		cleanupTestEnv()
-		os.Setenv(TEST_KEY2, TEST_VALUE2)
+		os.Setenv(testKey2, testValue2)
 
-		result := GetEnvTags(TEST_KEY1, TEST_KEY2)
-		assert.Equal(t, TEST_VALUE2, result)
+		result := GetEnvTags(testKey1, testKey2)
+		assert.Equal(t, testValue2, result)
 	}
 
 	{
 		cleanupTestEnv()
 
-		result := GetEnvTags(TEST_KEY1, TEST_KEY2)
+		result := GetEnvTags(testKey1, testKey2)
 		assert.Equal(t, "", result)
 	}
 
 	{
 		cleanupTestEnv()
-		os.Setenv(TEST_KEY1, TEST_VALUE1)
-		os.Setenv(TEST_KEY2, TEST_VALUE2)
+		os.Setenv(testKey1, testValue1)
+		os.Setenv(testKey2, testValue2)
 
-		result := GetEnvTags(TEST_KEY1, TEST_KEY2)
-		assert.Equal(t, TEST_VALUE1, result)
+		result := GetEnvTags(testKey1, testKey2)
+		assert.Equal(t, testValue1, result)
 	}
 }
 
 func TestInitFromEnvString(t *testing.T) {
 	{
 		cleanupTestEnv()
-		os.Setenv(TEST_KEY1, TEST_VALUE1)
+		os.Setenv(testKey1, testValue1)
 
 		var result string
-		err := InitFromEnvString(TEST_KEY1, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey1, &result, DEFAULT_VALUE)
 		assert.NoError(t, err)
-		assert.Equal(t, TEST_VALUE1, result)
+		assert.Equal(t, testValue1, result)
 	}
 
 	{
 		cleanupTestEnv()
 
 		var result string
-		err := InitFromEnvString(TEST_KEY1, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey1, &result, DEFAULT_VALUE)
 		assert.NoError(t, err)
 		assert.Equal(t, DEFAULT_VALUE, result)
 	}
 
 	{
 		cleanupTestEnv()
-		os.Setenv("LOONG_TEST_ENV_KEY1", TEST_VALUE1)
-		os.Setenv("ALICLOUD_TEST_ENV_KEY1", TEST_VALUE3)
+		os.Setenv("LOONG_TEST_ENV_KEY1", testValue1)
+		os.Setenv("ALICLOUD_TEST_ENV_KEY1", testValue3)
 
 		var result string
-		err := InitFromEnvString(TEST_KEY3, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey3, &result, DEFAULT_VALUE)
 		assert.NoError(t, err)
-		assert.Equal(t, TEST_VALUE1, result)
+		assert.Equal(t, testValue1, result)
 	}
 
 	{
 		cleanupTestEnv()
-		os.Setenv("ALICLOUD_TEST_ENV_KEY1", TEST_VALUE3)
+		os.Setenv("ALICLOUD_TEST_ENV_KEY1", testValue3)
 
 		var result string
-		err := InitFromEnvString(TEST_KEY3, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey3, &result, DEFAULT_VALUE)
 		assert.NoError(t, err)
-		assert.Equal(t, TEST_VALUE3, result)
+		assert.Equal(t, testValue3, result)
 	}
 
 	{
 		cleanupTestEnv()
-		os.Setenv(TEST_KEY1, "")
+		os.Setenv(testKey1, "")
 
 		var result string
-		err := InitFromEnvString(TEST_KEY1, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey1, &result, DEFAULT_VALUE)
 		assert.NoError(t, err)
 		assert.Equal(t, DEFAULT_VALUE, result)
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -30,7 +30,7 @@ const (
 	testValue2 = "aliyun_test_value_1"
 	testValue3 = "alicloud_test_value_1"
 
-	DEFAULT_VALUE = "default_value"
+	defaultValue = "default_value"
 )
 
 func cleanupTestEnv() {
@@ -91,7 +91,7 @@ func TestInitFromEnvString(t *testing.T) {
 		os.Setenv(testKey1, testValue1)
 
 		var result string
-		err := InitFromEnvString(testKey1, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey1, &result, defaultValue)
 		assert.NoError(t, err)
 		assert.Equal(t, testValue1, result)
 	}
@@ -100,9 +100,9 @@ func TestInitFromEnvString(t *testing.T) {
 		cleanupTestEnv()
 
 		var result string
-		err := InitFromEnvString(testKey1, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey1, &result, defaultValue)
 		assert.NoError(t, err)
-		assert.Equal(t, DEFAULT_VALUE, result)
+		assert.Equal(t, defaultValue, result)
 	}
 
 	{
@@ -111,7 +111,7 @@ func TestInitFromEnvString(t *testing.T) {
 		os.Setenv("ALICLOUD_TEST_ENV_KEY1", testValue3)
 
 		var result string
-		err := InitFromEnvString(testKey3, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey3, &result, defaultValue)
 		assert.NoError(t, err)
 		assert.Equal(t, testValue1, result)
 	}
@@ -121,7 +121,7 @@ func TestInitFromEnvString(t *testing.T) {
 		os.Setenv("ALICLOUD_TEST_ENV_KEY1", testValue3)
 
 		var result string
-		err := InitFromEnvString(testKey3, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey3, &result, defaultValue)
 		assert.NoError(t, err)
 		assert.Equal(t, testValue3, result)
 	}
@@ -131,8 +131,8 @@ func TestInitFromEnvString(t *testing.T) {
 		os.Setenv(testKey1, "")
 
 		var result string
-		err := InitFromEnvString(testKey1, &result, DEFAULT_VALUE)
+		err := InitFromEnvString(testKey1, &result, defaultValue)
 		assert.NoError(t, err)
-		assert.Equal(t, DEFAULT_VALUE, result)
+		assert.Equal(t, defaultValue, result)
 	}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -107,8 +107,8 @@ func TestInitFromEnvString(t *testing.T) {
 
 	{
 		cleanupTestEnv()
-		os.Setenv("LOONG_TEST_ENV_KEY1", testValue1)
-		os.Setenv("ALICLOUD_TEST_ENV_KEY1", testValue3)
+		os.Setenv(testKey1, testValue1)
+		os.Setenv(testKey3, testValue3)
 
 		var result string
 		err := InitFromEnvString(testKey3, &result, defaultValue)
@@ -118,7 +118,7 @@ func TestInitFromEnvString(t *testing.T) {
 
 	{
 		cleanupTestEnv()
-		os.Setenv("ALICLOUD_TEST_ENV_KEY1", testValue3)
+		os.Setenv(testKey3, testValue3)
 
 		var result string
 		err := InitFromEnvString(testKey3, &result, defaultValue)


### PR DESCRIPTION
This PR introduces a vendor-neutral configuration prefix `LOONG_` as the new standard,  
while maintaining backward compatibility with the existing `ALIYUN_` prefixed  
environment variables and configurations.  

Key changes:  
- Added `LOONG_` prefix as the preferred vendor-neutral option  
- Retained `ALIYUN_` prefix support for backward compatibility  
- Updated documentation to recommend `LOONG_` for new usage  
- Ensured both prefixes function identically  

Examples:
- Setting the LOONG_USER_ID environment variable achieves the same effect as the ALIYUN_LOGTAIL_USER_ID environment variable (retrieving the tenant UID).
- If both LOONG_USER_ID and ALIYUN_LOGTAIL_USER_ID environment variables exist, LOONG_USER_ID takes precedence.
- In a container environment, loong_logs_{configName} can achieve the same effect as aliyun_logs_{configName} (automatically creating a collection configuration).