### PR TITLE
docs: add '--recurse-submodules' after 'git clone'

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ LoongCollector has been battle-tested in some of the world's most demanding prod
 
 ```bash
 # Clone the repository
-git clone --recurse-submodules https://github.com/alibaba/loongcollector.git
+git clone https://github.com/alibaba/loongcollector.git
 cd loongcollector
+git submodule update --init
 
 # Build LoongCollector
 make all

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ LoongCollector has been battle-tested in some of the world's most demanding prod
 
 ```bash
 # Clone the repository
-git clone https://github.com/alibaba/loongcollector.git
+git clone --recurse-submodules https://github.com/alibaba/loongcollector.git
 cd loongcollector
 
 # Build LoongCollector


### PR DESCRIPTION
The submodule coolbpf will not be downloaded and compiled following the current **Build and Run** process.