### PR TITLE
fix: self telemetry metrics missing for input v2 wrapper

### DIFF
--- a/pkg/models/pipeline.go
+++ b/pkg/models/pipeline.go
@@ -57,3 +57,21 @@ type PipelineGroupEvents struct {
 	Group  *GroupInfo
 	Events []PipelineEvent
 }
+
+func (g *PipelineGroupEvents) GetEventCount() int64 {
+	if g == nil {
+		return 0
+	}
+	return int64(len(g.Events))
+}
+
+func (g *PipelineGroupEvents) GetSize() int64 {
+	if g == nil {
+		return 0
+	}
+	var size int64
+	for _, event := range g.Events {
+		size += event.GetSize()
+	}
+	return size
+}

--- a/pluginmanager/plugin_wrapper_aggregator_v2.go
+++ b/pluginmanager/plugin_wrapper_aggregator_v2.go
@@ -57,11 +57,9 @@ func (wrapper *AggregatorWrapperV2) Record(events *models.PipelineGroupEvents, c
 
 	err := wrapper.Aggregator.Record(events, context)
 	if err == nil {
-		wrapper.outEventsTotal.Add(int64(len(events.Events)))
+		wrapper.outEventsTotal.Add(events.GetEventCount())
 		wrapper.outEventGroupsTotal.Add(1)
-		for _, event := range events.Events {
-			wrapper.outSizeBytes.Add(event.GetSize())
-		}
+		wrapper.outSizeBytes.Add(events.GetSize())
 	}
 	wrapper.totalDelayTimeMs.Add(time.Since(startTime).Milliseconds())
 	return err

--- a/pluginmanager/plugin_wrapper_flusher_v2.go
+++ b/pluginmanager/plugin_wrapper_flusher_v2.go
@@ -39,11 +39,9 @@ func (wrapper *FlusherWrapperV2) IsReady(projectName string, logstoreName string
 func (wrapper *FlusherWrapperV2) Export(pipelineGroupEvents []*models.PipelineGroupEvents, pipelineContext pipeline.PipelineContext) error {
 	startTime := time.Now()
 	for _, groups := range pipelineGroupEvents {
-		wrapper.inEventsTotal.Add(int64(len(groups.Events)))
+		wrapper.inEventsTotal.Add(groups.GetEventCount())
 		wrapper.inEventGroupsTotal.Add(1)
-		for _, event := range groups.Events {
-			wrapper.inSizeBytes.Add(event.GetSize())
-		}
+		wrapper.inSizeBytes.Add(groups.GetSize())
 	}
 
 	err := wrapper.Flusher.Export(pipelineGroupEvents, pipelineContext)

--- a/pluginmanager/plugin_wrapper_processor_v2.go
+++ b/pluginmanager/plugin_wrapper_processor_v2.go
@@ -42,17 +42,14 @@ func (wrapper *ProcessorWrapperV2) Process(in *models.PipelineGroupEvents, conte
 	startTime := time.Now().UnixMilli()
 
 	wrapper.inEventGroupsTotal.Add(1)
-	wrapper.inEventsTotal.Add(int64(len(in.Events)))
-	for _, event := range in.Events {
-		wrapper.inSizeBytes.Add(event.GetSize())
-	}
+	wrapper.inEventsTotal.Add(in.GetEventCount())
+	wrapper.inSizeBytes.Add(in.GetSize())
 
 	wrapper.Processor.Process(in, context)
 
 	wrapper.outEventGroupsTotal.Add(1)
-	wrapper.outEventsTotal.Add(int64(len(in.Events)))
-	for _, event := range in.Events {
-		wrapper.outSizeBytes.Add(event.GetSize())
-	}
+	wrapper.outEventsTotal.Add(in.GetEventCount())
+	wrapper.outSizeBytes.Add(in.GetSize())
+
 	wrapper.totalProcessTimeMs.Add(time.Now().UnixMilli() - startTime)
 }

--- a/pluginmanager/plugin_wrapper_service_v2.go
+++ b/pluginmanager/plugin_wrapper_service_v2.go
@@ -118,7 +118,7 @@ func newPipelineContextWrapper(pipelineContext pipeline.PipelineContext, outEven
 	w := &PipelineContextWrapper{}
 
 	var innerCollector pipeline.PipelineCollector
-	if pipelineContext == nil {
+	if pipelineContext != nil {
 		innerCollector = pipelineContext.Collector()
 	}
 

--- a/pluginmanager/plugin_wrapper_service_v2.go
+++ b/pluginmanager/plugin_wrapper_service_v2.go
@@ -14,12 +14,15 @@
 package pluginmanager
 
 import (
+	"github.com/alibaba/ilogtail/pkg/models"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
+	"github.com/alibaba/ilogtail/pkg/selfmonitor"
 )
 
 type ServiceWrapperV2 struct {
 	ServiceWrapper
-	Input pipeline.ServiceInputV2
+	pipelineCtxWrapper *PipelineContextWrapper
+	Input              pipeline.ServiceInputV2
 }
 
 func (wrapper *ServiceWrapperV2) Init(pluginMeta *pipeline.PluginMeta) error {
@@ -30,5 +33,91 @@ func (wrapper *ServiceWrapperV2) Init(pluginMeta *pipeline.PluginMeta) error {
 }
 
 func (wrapper *ServiceWrapperV2) StartService(pipelineContext pipeline.PipelineContext) error {
-	return wrapper.Input.StartService(pipelineContext)
+	wrapper.pipelineCtxWrapper = newPipelineContextWrapper(pipelineContext, wrapper.outEventsTotal, wrapper.outEventGroupsTotal, wrapper.outSizeBytes)
+	return wrapper.Input.StartService(wrapper.pipelineCtxWrapper)
+}
+
+type PipelineContextWrapper struct {
+	PipelineCollectorWrapper
+}
+
+func (wrapper *PipelineContextWrapper) Collector() pipeline.PipelineCollector {
+	return wrapper.PipelineCollectorWrapper
+}
+
+type PipelineCollectorWrapper struct {
+	inner pipeline.PipelineCollector
+
+	outEventsTotal      selfmonitor.CounterMetric
+	outEventGroupsTotal selfmonitor.CounterMetric
+	outSizeBytes        selfmonitor.CounterMetric
+}
+
+// Collect single group and events data belonging to this group
+func (collectorWrapper PipelineCollectorWrapper) Collect(groupInfo *models.GroupInfo, eventList ...models.PipelineEvent) {
+	if collectorWrapper.inner == nil {
+		return
+	}
+
+	collectorWrapper.outEventsTotal.Add(int64(len(eventList)))
+	collectorWrapper.outEventGroupsTotal.Add(1)
+	size := int64(0)
+	for _, event := range eventList {
+		size += event.GetSize()
+	}
+	collectorWrapper.outSizeBytes.Add(int64(size))
+	collectorWrapper.inner.Collect(groupInfo, eventList...)
+}
+
+// CollectList collect GroupEvents list that have been grouped
+func (collectorWrapper PipelineCollectorWrapper) CollectList(groupEventsList ...*models.PipelineGroupEvents) {
+	if collectorWrapper.inner == nil {
+		return
+	}
+	var eventCount int64
+	var size int64
+	for _, groupEvents := range groupEventsList {
+		eventCount += groupEvents.GetEventCount()
+		size += groupEvents.GetSize()
+	}
+	collectorWrapper.outEventGroupsTotal.Add(int64(len(groupEventsList)))
+	collectorWrapper.outEventsTotal.Add(eventCount)
+	collectorWrapper.outSizeBytes.Add(size)
+	collectorWrapper.inner.CollectList(groupEventsList...)
+}
+
+// ToArray returns an array containing all of the PipelineGroupEvents in this collector.
+func (collectorWrapper PipelineCollectorWrapper) ToArray() []*models.PipelineGroupEvents {
+	if collectorWrapper.inner == nil {
+		return nil
+	}
+	return collectorWrapper.inner.ToArray()
+}
+
+// Observe returns a chan that can consume PipelineGroupEvents from this collector.
+func (collectorWrapper PipelineCollectorWrapper) Observe() chan *models.PipelineGroupEvents {
+	if collectorWrapper.inner == nil {
+		return nil
+	}
+	return collectorWrapper.inner.Observe()
+}
+
+// Close closes the collector.
+func (collectorWrapper PipelineCollectorWrapper) Close() {
+	if collectorWrapper.inner == nil {
+		return
+	}
+	collectorWrapper.inner.Close()
+}
+
+func newPipelineContextWrapper(pipelineContext pipeline.PipelineContext, outEventsTotal selfmonitor.CounterMetric, outEventGroupsTotal selfmonitor.CounterMetric, outSizeBytes selfmonitor.CounterMetric) *PipelineContextWrapper {
+	w := &PipelineContextWrapper{}
+
+	var innerCollector pipeline.PipelineCollector
+	if pipelineContext == nil {
+		innerCollector = pipelineContext.Collector()
+	}
+
+	w.PipelineCollectorWrapper = PipelineCollectorWrapper{innerCollector, outEventsTotal, outEventGroupsTotal, outSizeBytes}
+	return w
 }

--- a/pluginmanager/plugin_wrapper_service_v2.go
+++ b/pluginmanager/plugin_wrapper_service_v2.go
@@ -37,6 +37,9 @@ func (wrapper *ServiceWrapperV2) StartService(pipelineContext pipeline.PipelineC
 	return wrapper.Input.StartService(wrapper.pipelineCtxWrapper)
 }
 
+// PipelineContextWrapper is a wrapper of pipeline.PipelineContext
+// When call Collector(), it replaces the original pipeline.PipelineCollector with PipelineCollectorWrapper
+// for counting the traffic of the plugin
 type PipelineContextWrapper struct {
 	PipelineCollectorWrapper
 }
@@ -45,6 +48,7 @@ func (wrapper *PipelineContextWrapper) Collector() pipeline.PipelineCollector {
 	return wrapper.PipelineCollectorWrapper
 }
 
+// PipelineCollectorWrapper is a wrapper of pipeline.PipelineCollector with extra telemetry metrics.
 type PipelineCollectorWrapper struct {
 	inner pipeline.PipelineCollector
 


### PR DESCRIPTION
Change-Id: Id8e7f8dc4c28b101e325abd07b15b45f164e51d0

可以统计到 input 类型的指标信息，
<img width="1835" height="661" alt="image" src="https://github.com/user-attachments/assets/e5e96ee3-7d3a-45a7-9268-55a31dd02289" />

实现方式对 cpu 和 mem 无明显影响
<img width="3584" height="752" alt="image" src="https://github.com/user-attachments/assets/e10cc21a-195a-420e-9251-f638409e452d" />
