### PR TITLE
fix: optimize mem  of k8s meta entity

### DIFF
--- a/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
+++ b/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
@@ -356,6 +356,11 @@ func (m *DeferredDeletionMetaStore) getIdxKeys(obj *ObjectWrapper) []string {
 
 // getIndexKeyDiff returns keys to remove and keys to add for incremental index update
 func (m *DeferredDeletionMetaStore) getIndexKeyDiff(oldKeys, newKeys []string) (toRemove, toAdd []string) {
+
+	if len(oldKeys) == 0 && len(newKeys) == 0 {
+		return nil, nil
+	}
+
 	oldKeySet := make(map[string]struct{})
 	newKeySet := make(map[string]struct{})
 

--- a/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
+++ b/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
@@ -229,9 +229,11 @@ func (m *DeferredDeletionMetaStore) handleAddOrUpdateEvent(event *K8sMetaEvent) 
 
 		// Remove only the keys that are no longer needed
 		for _, idxKey := range keysToRemove {
-			m.Index[idxKey].Remove(key)
-			if len(m.Index[idxKey].Keys) == 0 {
-				delete(m.Index, idxKey)
+			if indexItem, ok := m.Index[idxKey]; ok {
+				indexItem.Remove(key)
+				if len(indexItem.Keys) == 0 {
+					delete(m.Index, idxKey)
+				}
 			}
 		}
 

--- a/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
+++ b/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
@@ -243,7 +243,8 @@ func (m *DeferredDeletionMetaStore) handleAddOrUpdateEvent(event *K8sMetaEvent) 
 			m.Index[idxKey].Add(key)
 		}
 
-		// Release memory by setting Raw to nil before overwriting
+		// Safe memory cleanup: clear Raw after index operations but before unlock
+		// This ensures no concurrent readers can access the old Raw during cleanup
 		obj.Raw = nil
 	} else {
 		// New object: add all index keys

--- a/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
+++ b/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
@@ -221,11 +221,11 @@ func (m *DeferredDeletionMetaStore) handleAddOrUpdateEvent(event *K8sMetaEvent) 
 	// 1. update event
 	// 2. add event when the previous object is between deleted and deferred delete
 	if obj, ok := m.Items[key]; ok {
-		existingIdxKeys := m.getIdxKeys(obj)
+		oldIdxKeys := m.getIdxKeys(obj)
 		event.Object.FirstObservedTime = obj.FirstObservedTime
 
 		// Use incremental index update: only modify changed index keys
-		keysToRemove, keysToAdd := m.getIndexKeyDiff(existingIdxKeys, newIdxKeys)
+		keysToRemove, keysToAdd := m.getIndexKeyDiff(oldIdxKeys, newIdxKeys)
 
 		// Remove only the keys that are no longer needed
 		for _, idxKey := range keysToRemove {

--- a/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
+++ b/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
@@ -244,10 +244,6 @@ func (m *DeferredDeletionMetaStore) handleAddOrUpdateEvent(event *K8sMetaEvent) 
 			}
 			m.Index[idxKey].Add(key)
 		}
-
-		// Safe memory cleanup: clear Raw after index operations but before unlock
-		// This ensures no concurrent readers can access the old Raw during cleanup
-		obj.Raw = nil
 	} else {
 		// New object: add all index keys
 		for _, idxKey := range newIdxKeys {

--- a/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
+++ b/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
@@ -231,9 +231,6 @@ func (m *DeferredDeletionMetaStore) handleAddOrUpdateEvent(event *K8sMetaEvent) 
 		for _, idxKey := range keysToRemove {
 			if indexItem, ok := m.Index[idxKey]; ok {
 				indexItem.Remove(key)
-				if len(indexItem.Keys) == 0 {
-					delete(m.Index, idxKey)
-				}
 			}
 		}
 

--- a/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
+++ b/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store.go
@@ -231,6 +231,9 @@ func (m *DeferredDeletionMetaStore) handleAddOrUpdateEvent(event *K8sMetaEvent) 
 		for _, idxKey := range keysToRemove {
 			if indexItem, ok := m.Index[idxKey]; ok {
 				indexItem.Remove(key)
+				if len(indexItem.Keys) == 0 {
+					delete(m.Index, idxKey)
+				}
 			}
 		}
 

--- a/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store_test.go
+++ b/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store_test.go
@@ -1,6 +1,8 @@
 package k8smeta
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -433,4 +435,100 @@ func TestRegisterAndUnRegisterSendFunc(t *testing.T) {
 	}
 	time.Sleep(time.Duration(interval) * time.Second)
 	assert.Equal(t, 3, counter)
+}
+
+func TestGetIndexKeyDiff(t *testing.T) {
+eventCh := make(chan *K8sMetaEvent)
+stopCh := make(chan struct{})
+store := NewDeferredDeletionMetaStore(eventCh, stopCh, 60, cache.MetaNamespaceKeyFunc)
+
+// Test case 1: Empty slices
+toRemove, toAdd := store.getIndexKeyDiff([]string{}, []string{})
+assert.Empty(t, toRemove, "Should have no keys to remove when both slices are empty")
+assert.Empty(t, toAdd, "Should have no keys to add when both slices are empty")
+
+// Test case 2: Only old keys (all should be removed)
+oldKeys := []string{"key1", "key2", "key3"}
+toRemove, toAdd = store.getIndexKeyDiff(oldKeys, []string{})
+assert.ElementsMatch(t, oldKeys, toRemove, "All old keys should be removed")
+assert.Empty(t, toAdd, "Should have no keys to add")
+
+// Test case 3: Only new keys (all should be added)
+newKeys := []string{"key4", "key5", "key6"}
+toRemove, toAdd = store.getIndexKeyDiff([]string{}, newKeys)
+assert.Empty(t, toRemove, "Should have no keys to remove")
+assert.ElementsMatch(t, newKeys, toAdd, "All new keys should be added")
+
+// Test case 4: Partial overlap
+oldKeys = []string{"key1", "key2", "key3"}
+newKeys = []string{"key2", "key3", "key4"}
+toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
+assert.ElementsMatch(t, []string{"key1"}, toRemove, "key1 should be removed")
+assert.ElementsMatch(t, []string{"key4"}, toAdd, "key4 should be added")
+
+// Test case 5: Complete overlap (no changes)
+oldKeys = []string{"key1", "key2", "key3"}
+newKeys = []string{"key1", "key2", "key3"}
+toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
+assert.Empty(t, toRemove, "Should have no keys to remove when keys are identical")
+assert.Empty(t, toAdd, "Should have no keys to add when keys are identical")
+
+// Test case 6: Different order (should still work correctly)
+oldKeys = []string{"key1", "key2", "key3"}
+newKeys = []string{"key3", "key1", "key2"}
+toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
+assert.Empty(t, toRemove, "Should have no keys to remove when keys are identical but in different order")
+assert.Empty(t, toAdd, "Should have no keys to add when keys are identical but in different order")
+
+// Test case 7: Duplicate keys in input (edge case)
+oldKeys = []string{"key1", "key2", "key2", "key3"}
+newKeys = []string{"key2", "key3", "key3", "key4"}
+toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
+assert.ElementsMatch(t, []string{"key1"}, toRemove, "key1 should be removed (duplicates handled)")
+assert.ElementsMatch(t, []string{"key4"}, toAdd, "key4 should be added (duplicates handled)")
+
+// Test case 8: Large dataset performance test
+largeOldKeys := make([]string, 1000)
+largeNewKeys := make([]string, 1000)
+for i := 0; i < 1000; i++ {
+largeOldKeys[i] = fmt.Sprintf("old_key_%d", i)
+largeNewKeys[i] = fmt.Sprintf("new_key_%d", i)
+}
+
+start := time.Now()
+toRemove, toAdd = store.getIndexKeyDiff(largeOldKeys, largeNewKeys)
+duration := time.Since(start)
+
+assert.Len(t, toRemove, 1000, "Should remove all 1000 old keys")
+assert.Len(t, toAdd, 1000, "Should add all 1000 new keys")
+assert.Less(t, duration, 10*time.Millisecond, "Should complete within 10ms for 1000 keys")
+}
+
+func TestGetIndexKeyDiffEdgeCases(t *testing.T) {
+eventCh := make(chan *K8sMetaEvent)
+stopCh := make(chan struct{})
+store := NewDeferredDeletionMetaStore(eventCh, stopCh, 60, cache.MetaNamespaceKeyFunc)
+
+// Test case 1: Single key scenarios
+toRemove, toAdd := store.getIndexKeyDiff([]string{"single"}, []string{"different"})
+assert.ElementsMatch(t, []string{"single"}, toRemove, "Single old key should be removed")
+assert.ElementsMatch(t, []string{"different"}, toAdd, "Single new key should be added")
+
+// Test case 2: Empty string keys
+toRemove, toAdd = store.getIndexKeyDiff([]string{""}, []string{""})
+assert.Empty(t, toRemove, "Empty string key should not be removed when present in both")
+assert.Empty(t, toAdd, "Empty string key should not be added when present in both")
+
+// Test case 3: Very long key names
+longKey1 := strings.Repeat("a", 1000)
+longKey2 := strings.Repeat("b", 1000)
+toRemove, toAdd = store.getIndexKeyDiff([]string{longKey1}, []string{longKey2})
+assert.ElementsMatch(t, []string{longKey1}, toRemove, "Long key should be removed")
+assert.ElementsMatch(t, []string{longKey2}, toAdd, "Long key should be added")
+
+// Test case 4: Special characters in keys
+specialKeys := []string{"key/with/slashes", "key:with:colons", "key.with.dots", "key-with-dashes"}
+toRemove, toAdd = store.getIndexKeyDiff(specialKeys[:2], specialKeys[2:])
+assert.Len(t, toRemove, 2, "Should remove 2 keys with special characters")
+assert.Len(t, toAdd, 2, "Should add 2 keys with special characters")
 }

--- a/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store_test.go
+++ b/pkg/helper/k8smeta/k8s_meta_deferred_deletion_meta_store_test.go
@@ -1,7 +1,6 @@
 package k8smeta
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -438,97 +437,97 @@ func TestRegisterAndUnRegisterSendFunc(t *testing.T) {
 }
 
 func TestGetIndexKeyDiff(t *testing.T) {
-eventCh := make(chan *K8sMetaEvent)
-stopCh := make(chan struct{})
-store := NewDeferredDeletionMetaStore(eventCh, stopCh, 60, cache.MetaNamespaceKeyFunc)
+	eventCh := make(chan *K8sMetaEvent)
+	stopCh := make(chan struct{})
+	store := NewDeferredDeletionMetaStore(eventCh, stopCh, 60, cache.MetaNamespaceKeyFunc)
 
-// Test case 1: Empty slices
-toRemove, toAdd := store.getIndexKeyDiff([]string{}, []string{})
-assert.Empty(t, toRemove, "Should have no keys to remove when both slices are empty")
-assert.Empty(t, toAdd, "Should have no keys to add when both slices are empty")
+	// Test case 1: Empty slices
+	toRemove, toAdd := store.getIndexKeyDiff([]string{}, []string{})
+	assert.Empty(t, toRemove, "Should have no keys to remove when both slices are empty")
+	assert.Empty(t, toAdd, "Should have no keys to add when both slices are empty")
 
-// Test case 2: Only old keys (all should be removed)
-oldKeys := []string{"key1", "key2", "key3"}
-toRemove, toAdd = store.getIndexKeyDiff(oldKeys, []string{})
-assert.ElementsMatch(t, oldKeys, toRemove, "All old keys should be removed")
-assert.Empty(t, toAdd, "Should have no keys to add")
+	// Test case 2: Only old keys (all should be removed)
+	oldKeys := []string{"key1", "key2", "key3"}
+	toRemove, toAdd = store.getIndexKeyDiff(oldKeys, []string{})
+	assert.ElementsMatch(t, oldKeys, toRemove, "All old keys should be removed")
+	assert.Empty(t, toAdd, "Should have no keys to add")
 
-// Test case 3: Only new keys (all should be added)
-newKeys := []string{"key4", "key5", "key6"}
-toRemove, toAdd = store.getIndexKeyDiff([]string{}, newKeys)
-assert.Empty(t, toRemove, "Should have no keys to remove")
-assert.ElementsMatch(t, newKeys, toAdd, "All new keys should be added")
+	// Test case 3: Only new keys (all should be added)
+	newKeys := []string{"key4", "key5", "key6"}
+	toRemove, toAdd = store.getIndexKeyDiff([]string{}, newKeys)
+	assert.Empty(t, toRemove, "Should have no keys to remove")
+	assert.ElementsMatch(t, newKeys, toAdd, "All new keys should be added")
 
-// Test case 4: Partial overlap
-oldKeys = []string{"key1", "key2", "key3"}
-newKeys = []string{"key2", "key3", "key4"}
-toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
-assert.ElementsMatch(t, []string{"key1"}, toRemove, "key1 should be removed")
-assert.ElementsMatch(t, []string{"key4"}, toAdd, "key4 should be added")
+	// Test case 4: Partial overlap
+	oldKeys = []string{"key1", "key2", "key3"}
+	newKeys = []string{"key2", "key3", "key4"}
+	toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
+	assert.ElementsMatch(t, []string{"key1"}, toRemove, "key1 should be removed")
+	assert.ElementsMatch(t, []string{"key4"}, toAdd, "key4 should be added")
 
-// Test case 5: Complete overlap (no changes)
-oldKeys = []string{"key1", "key2", "key3"}
-newKeys = []string{"key1", "key2", "key3"}
-toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
-assert.Empty(t, toRemove, "Should have no keys to remove when keys are identical")
-assert.Empty(t, toAdd, "Should have no keys to add when keys are identical")
+	// Test case 5: Complete overlap (no changes)
+	oldKeys = []string{"key1", "key2", "key3"}
+	newKeys = []string{"key1", "key2", "key3"}
+	toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
+	assert.Empty(t, toRemove, "Should have no keys to remove when keys are identical")
+	assert.Empty(t, toAdd, "Should have no keys to add when keys are identical")
 
-// Test case 6: Different order (should still work correctly)
-oldKeys = []string{"key1", "key2", "key3"}
-newKeys = []string{"key3", "key1", "key2"}
-toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
-assert.Empty(t, toRemove, "Should have no keys to remove when keys are identical but in different order")
-assert.Empty(t, toAdd, "Should have no keys to add when keys are identical but in different order")
+	// Test case 6: Different order (should still work correctly)
+	oldKeys = []string{"key1", "key2", "key3"}
+	newKeys = []string{"key3", "key1", "key2"}
+	toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
+	assert.Empty(t, toRemove, "Should have no keys to remove when keys are identical but in different order")
+	assert.Empty(t, toAdd, "Should have no keys to add when keys are identical but in different order")
 
-// Test case 7: Duplicate keys in input (edge case)
-oldKeys = []string{"key1", "key2", "key2", "key3"}
-newKeys = []string{"key2", "key3", "key3", "key4"}
-toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
-assert.ElementsMatch(t, []string{"key1"}, toRemove, "key1 should be removed (duplicates handled)")
-assert.ElementsMatch(t, []string{"key4"}, toAdd, "key4 should be added (duplicates handled)")
+	// Test case 7: Duplicate keys in input (edge case)
+	oldKeys = []string{"key1", "key2", "key2", "key3"}
+	newKeys = []string{"key2", "key3", "key3", "key4"}
+	toRemove, toAdd = store.getIndexKeyDiff(oldKeys, newKeys)
+	assert.ElementsMatch(t, []string{"key1"}, toRemove, "key1 should be removed (duplicates handled)")
+	assert.ElementsMatch(t, []string{"key4"}, toAdd, "key4 should be added (duplicates handled)")
 
-// Test case 8: Large dataset performance test
-largeOldKeys := make([]string, 1000)
-largeNewKeys := make([]string, 1000)
-for i := 0; i < 1000; i++ {
-largeOldKeys[i] = fmt.Sprintf("old_key_%d", i)
-largeNewKeys[i] = fmt.Sprintf("new_key_%d", i)
-}
+	// // Test case 8: Large dataset performance test
+	// largeOldKeys := make([]string, 1000)
+	// largeNewKeys := make([]string, 1000)
+	// for i := 0; i < 1000; i++ {
+	// largeOldKeys[i] = fmt.Sprintf("old_key_%d", i)
+	// largeNewKeys[i] = fmt.Sprintf("new_key_%d", i)
+	// }
 
-start := time.Now()
-toRemove, toAdd = store.getIndexKeyDiff(largeOldKeys, largeNewKeys)
-duration := time.Since(start)
+	// start := time.Now()
+	// toRemove, toAdd = store.getIndexKeyDiff(largeOldKeys, largeNewKeys)
+	// duration := time.Since(start)
 
-assert.Len(t, toRemove, 1000, "Should remove all 1000 old keys")
-assert.Len(t, toAdd, 1000, "Should add all 1000 new keys")
-assert.Less(t, duration, 10*time.Millisecond, "Should complete within 10ms for 1000 keys")
+	// assert.Len(t, toRemove, 1000, "Should remove all 1000 old keys")
+	// assert.Len(t, toAdd, 1000, "Should add all 1000 new keys")
+	// assert.Less(t, duration, 10*time.Millisecond, "Should complete within 10ms for 1000 keys")
 }
 
 func TestGetIndexKeyDiffEdgeCases(t *testing.T) {
-eventCh := make(chan *K8sMetaEvent)
-stopCh := make(chan struct{})
-store := NewDeferredDeletionMetaStore(eventCh, stopCh, 60, cache.MetaNamespaceKeyFunc)
+	eventCh := make(chan *K8sMetaEvent)
+	stopCh := make(chan struct{})
+	store := NewDeferredDeletionMetaStore(eventCh, stopCh, 60, cache.MetaNamespaceKeyFunc)
 
-// Test case 1: Single key scenarios
-toRemove, toAdd := store.getIndexKeyDiff([]string{"single"}, []string{"different"})
-assert.ElementsMatch(t, []string{"single"}, toRemove, "Single old key should be removed")
-assert.ElementsMatch(t, []string{"different"}, toAdd, "Single new key should be added")
+	// Test case 1: Single key scenarios
+	toRemove, toAdd := store.getIndexKeyDiff([]string{"single"}, []string{"different"})
+	assert.ElementsMatch(t, []string{"single"}, toRemove, "Single old key should be removed")
+	assert.ElementsMatch(t, []string{"different"}, toAdd, "Single new key should be added")
 
-// Test case 2: Empty string keys
-toRemove, toAdd = store.getIndexKeyDiff([]string{""}, []string{""})
-assert.Empty(t, toRemove, "Empty string key should not be removed when present in both")
-assert.Empty(t, toAdd, "Empty string key should not be added when present in both")
+	// Test case 2: Empty string keys
+	toRemove, toAdd = store.getIndexKeyDiff([]string{""}, []string{""})
+	assert.Empty(t, toRemove, "Empty string key should not be removed when present in both")
+	assert.Empty(t, toAdd, "Empty string key should not be added when present in both")
 
-// Test case 3: Very long key names
-longKey1 := strings.Repeat("a", 1000)
-longKey2 := strings.Repeat("b", 1000)
-toRemove, toAdd = store.getIndexKeyDiff([]string{longKey1}, []string{longKey2})
-assert.ElementsMatch(t, []string{longKey1}, toRemove, "Long key should be removed")
-assert.ElementsMatch(t, []string{longKey2}, toAdd, "Long key should be added")
+	// Test case 3: Very long key names
+	longKey1 := strings.Repeat("a", 1000)
+	longKey2 := strings.Repeat("b", 1000)
+	toRemove, toAdd = store.getIndexKeyDiff([]string{longKey1}, []string{longKey2})
+	assert.ElementsMatch(t, []string{longKey1}, toRemove, "Long key should be removed")
+	assert.ElementsMatch(t, []string{longKey2}, toAdd, "Long key should be added")
 
-// Test case 4: Special characters in keys
-specialKeys := []string{"key/with/slashes", "key:with:colons", "key.with.dots", "key-with-dashes"}
-toRemove, toAdd = store.getIndexKeyDiff(specialKeys[:2], specialKeys[2:])
-assert.Len(t, toRemove, 2, "Should remove 2 keys with special characters")
-assert.Len(t, toAdd, 2, "Should add 2 keys with special characters")
+	// Test case 4: Special characters in keys
+	specialKeys := []string{"key/with/slashes", "key:with:colons", "key.with.dots", "key-with-dashes"}
+	toRemove, toAdd = store.getIndexKeyDiff(specialKeys[:2], specialKeys[2:])
+	assert.Len(t, toRemove, 2, "Should remove 2 keys with special characters")
+	assert.Len(t, toAdd, 2, "Should add 2 keys with special characters")
 }


### PR DESCRIPTION
在k8s 元数据 高频变更场景下（前提 entity数量并无改动），存在内存上涨问题， 问题原因之一在于：每次更新都重建索引，如果索引键没有变化，那么删除和添加的操作是多余的，另外在Update事件中，即使某个索引键的Keys map为空，我们也没有删除它，这可能导致一些空的IndexItem残留，占用内存。
（1）保证实体数不变，触发高频更新事件
<img width="1934" height="612" alt="image" src="https://github.com/user-attachments/assets/b9af1a3a-e0ca-4afe-9e07-cc4319c4eb05" />

（2）对照 内存变化
<img width="1898" height="630" alt="image" src="https://github.com/user-attachments/assets/a3ce5707-4989-474b-8b3b-03490528f714" />
（3）ai review
<img width="1170" height="1472" alt="image" src="https://github.com/user-attachments/assets/99e33e05-26c9-4432-81f7-6c5e1aa62742" />

