### PR TITLE
fix: fix multiple eBPF plugin management and event handling issues

### DIFF
--- a/core/ebpf/EBPFAdapter.cpp
+++ b/core/ebpf/EBPFAdapter.cpp
@@ -83,18 +83,8 @@ namespace logtail::ebpf {
 EBPFAdapter::EBPFAdapter() = default;
 
 EBPFAdapter::~EBPFAdapter() {
-    if (!dynamicLibSuccess()) {
-        return;
-    }
-
-    for (size_t i = 0; i < mRunning.size(); i++) {
-        auto& x = mRunning[i];
-        if (!x) {
-            continue;
-        }
-        // stop plugin
-        StopPlugin(static_cast<PluginType>(i));
-    }
+    // Plugin cleanup is handled by EBPFServer::Stop() to avoid 
+    // accessing potentially freed resources during global destruction
 }
 
 void EBPFAdapter::Init() {
@@ -104,9 +94,6 @@ void EBPFAdapter::Init() {
     mInited = true;
     mBinaryPath = GetProcessExecutionDir();
     setenv("SYSAK_WORK_PATH", mBinaryPath.c_str(), 1);
-    for (auto& x : mRunning) {
-        x = false;
-    }
 
     mLogPrinter = [](int16_t level, const char* format, va_list args) -> int {
         auto printLevel = (eBPFLogType)level;
@@ -254,14 +241,6 @@ bool EBPFAdapter::dynamicLibSuccess() {
     return true;
 }
 
-bool EBPFAdapter::CheckPluginRunning(PluginType pluginType) {
-    if (!loadDynamicLib(mDriverLibName)) {
-        LOG_ERROR(sLogger, ("dynamic lib not load, plugin type", magic_enum::enum_name(pluginType)));
-        return false;
-    }
-
-    return mRunning[int(pluginType)];
-}
 
 bool EBPFAdapter::SetNetworkObserverConfig(int32_t key, int32_t value) {
     if (!dynamicLibSuccess()) {
@@ -318,12 +297,12 @@ int32_t EBPFAdapter::PollPerfBuffers(PluginType pluginType, int32_t maxEvents, i
 }
 
 bool EBPFAdapter::StartPlugin(PluginType pluginType, std::unique_ptr<PluginConfig> conf) {
-    if (CheckPluginRunning(pluginType)) {
-        // plugin update ...
-        return UpdatePlugin(pluginType, std::move(conf));
+    if (!loadDynamicLib(mDriverLibName)) {
+        LOG_ERROR(sLogger, ("dynamic lib not load, plugin type", magic_enum::enum_name(pluginType)));
+        return false;
     }
 
-    // plugin not started ...
+    // Plugin state is managed by upper layer, directly execute start logic
     LOG_INFO(sLogger, ("begin to start plugin, type", magic_enum::enum_name(pluginType)));
     if (conf->mPluginType == PluginType::NETWORK_OBSERVE) {
         auto* nconf = std::get_if<NetworkObserveConfig>(&conf->mConfig);
@@ -349,20 +328,17 @@ bool EBPFAdapter::StartPlugin(PluginType pluginType, std::unique_ptr<PluginConfi
         return false;
     }
 #ifdef APSARA_UNIT_TEST_MAIN
-    mRunning[int(pluginType)] = true;
     return true;
 #else
     auto startF = (start_plugin_func)f;
     int res = startF(conf.get());
-    if (!res)
-        mRunning[int(pluginType)] = true;
     return !res;
 #endif
 }
 
 bool EBPFAdapter::ResumePlugin(PluginType pluginType, std::unique_ptr<PluginConfig> conf) {
-    if (!CheckPluginRunning(pluginType)) {
-        LOG_ERROR(sLogger, ("plugin not started, type", magic_enum::enum_name(pluginType)));
+    if (!loadDynamicLib(mDriverLibName)) {
+        LOG_ERROR(sLogger, ("dynamic lib not load, plugin type", magic_enum::enum_name(pluginType)));
         return false;
     }
 
@@ -382,8 +358,8 @@ bool EBPFAdapter::ResumePlugin(PluginType pluginType, std::unique_ptr<PluginConf
 }
 
 bool EBPFAdapter::UpdatePlugin(PluginType pluginType, std::unique_ptr<PluginConfig> conf) {
-    if (!CheckPluginRunning(pluginType)) {
-        LOG_ERROR(sLogger, ("plugin not started, type", magic_enum::enum_name(pluginType)));
+    if (!loadDynamicLib(mDriverLibName)) {
+        LOG_ERROR(sLogger, ("dynamic lib not load, plugin type", magic_enum::enum_name(pluginType)));
         return false;
     }
 
@@ -403,10 +379,11 @@ bool EBPFAdapter::UpdatePlugin(PluginType pluginType, std::unique_ptr<PluginConf
 }
 
 bool EBPFAdapter::SuspendPlugin(PluginType pluginType) {
-    if (!CheckPluginRunning(pluginType)) {
-        LOG_WARNING(sLogger, ("plugin not started, cannot suspend. type", magic_enum::enum_name(pluginType)));
+    if (!loadDynamicLib(mDriverLibName)) {
+        LOG_ERROR(sLogger, ("dynamic lib not load, plugin type", magic_enum::enum_name(pluginType)));
         return false;
     }
+
     void* f = mFuncs[(int)ebpf_func::EBPF_SUSPEND_PLUGIN];
     if (!f) {
         LOG_ERROR(sLogger, ("failed to load dynamic lib, suspend func ptr is null", magic_enum::enum_name(pluginType)));
@@ -423,9 +400,9 @@ bool EBPFAdapter::SuspendPlugin(PluginType pluginType) {
 }
 
 bool EBPFAdapter::StopPlugin(PluginType pluginType) {
-    if (!CheckPluginRunning(pluginType)) {
-        LOG_WARNING(sLogger, ("plugin not started, do nothing. type", magic_enum::enum_name(pluginType)));
-        return true;
+    if (!loadDynamicLib(mDriverLibName)) {
+        LOG_ERROR(sLogger, ("dynamic lib not load, plugin type", magic_enum::enum_name(pluginType)));
+        return false;
     }
 
     auto config = std::make_unique<PluginConfig>();
@@ -436,22 +413,19 @@ bool EBPFAdapter::StopPlugin(PluginType pluginType) {
         return false;
     }
 #ifdef APSARA_UNIT_TEST_MAIN
-    mRunning[int(pluginType)] = false;
     return true;
 #else
     auto stopF = (stop_plugin_func)f;
     int res = stopF(pluginType);
-    if (!res)
-        mRunning[int(pluginType)] = false;
     return !res;
 #endif
 }
 
 bool EBPFAdapter::BPFMapUpdateElem(
     PluginType pluginType, const std::string& map_name, void* key, void* value, uint64_t flag) {
-    if (!CheckPluginRunning(pluginType)) {
-        LOG_WARNING(sLogger, ("plugin not started, do nothing. type", magic_enum::enum_name(pluginType)));
-        return true;
+    if (!loadDynamicLib(mDriverLibName)) {
+        LOG_ERROR(sLogger, ("dynamic lib not load, plugin type", magic_enum::enum_name(pluginType)));
+        return false;
     }
 
     void* f = mFuncs[(int)ebpf_func::EBPF_MAP_UPDATE_ELEM];

--- a/core/ebpf/EBPFAdapter.h
+++ b/core/ebpf/EBPFAdapter.h
@@ -52,7 +52,6 @@ public:
     // re-attach bpf progs ...
     bool ResumePlugin(PluginType pluginType, std::unique_ptr<PluginConfig> conf);
 
-    bool CheckPluginRunning(PluginType pluginType);
 
     int32_t PollPerfBuffers(PluginType, int32_t, int32_t*, int);
     int32_t ConsumePerfBufferData(PluginType pluginType);
@@ -104,7 +103,6 @@ private:
     std::shared_ptr<DynamicLibLoader> mCoolbpfLib;
     std::array<void*, (int)ebpf_func::EBPF_FUNC_MAX> mFuncs = {};
     std::array<long, (int)network_observer_uprobe_funcs::EBPF_NETWORK_OBSERVER_MAX> mOffsets = {};
-    std::array<std::atomic_bool, (int)PluginType::MAX> mRunning = {};
     std::string mBinaryPath;
     std::string mFullLibName;
 

--- a/core/ebpf/EBPFServer.cpp
+++ b/core/ebpf/EBPFServer.cpp
@@ -437,7 +437,9 @@ bool EBPFServer::DisablePlugin(const std::string& pipelineName, PluginType type)
         }
 
         // do real destroy ...
-        UnregisterPluginPerfBuffers(type);
+        if (type != PluginType::PROCESS_SECURITY && type != PluginType::NETWORK_OBSERVE) {
+            UnregisterPluginPerfBuffers(type);
+        }
         ret = pluginManager->Destroy();
         if (ret != 0) {
             LOG_ERROR(sLogger, ("failed to stop plugin for", magic_enum::enum_name(type))("pipeline", pipelineName));
@@ -693,9 +695,14 @@ void EBPFServer::RegisterPluginPerfBuffers(PluginType type) {
             event.events = EPOLLIN;
             event.data.u32 = static_cast<uint32_t>(type);
 
-            if (epoll_ctl(mUnifiedEpollFd, EPOLL_CTL_ADD, epollFd, &event) == 0) {
+            int ret = epoll_ctl(mUnifiedEpollFd, EPOLL_CTL_ADD, epollFd, &event);
+            if (ret == 0) {
                 LOG_DEBUG(sLogger,
                           ("Registered perf buffer epoll fd", epollFd)("plugin type", magic_enum::enum_name(type)));
+            } else if (errno == EEXIST) {
+                // fd already registered, this is normal in some scenarios
+                LOG_WARNING(sLogger,
+                          ("Perf buffer epoll fd already registered", epollFd)("plugin type", magic_enum::enum_name(type)));
             } else {
                 LOG_ERROR(sLogger,
                           ("Failed to register perf buffer epoll fd",
@@ -714,9 +721,19 @@ void EBPFServer::UnregisterPluginPerfBuffers(PluginType type) {
 
     for (int epollFd : epollFds) {
         if (epollFd >= 0) {
-            epoll_ctl(mUnifiedEpollFd, EPOLL_CTL_DEL, epollFd, nullptr);
-            LOG_DEBUG(sLogger,
-                      ("Unregistered perf buffer epoll fd", epollFd)("plugin type", magic_enum::enum_name(type)));
+            int ret = epoll_ctl(mUnifiedEpollFd, EPOLL_CTL_DEL, epollFd, nullptr);
+            if (ret == 0) {
+                LOG_DEBUG(sLogger,
+                          ("Unregistered perf buffer epoll fd", epollFd)("plugin type", magic_enum::enum_name(type)));
+            } else if (errno == ENOENT) {
+                // fd not registered, this is normal in some scenarios
+                LOG_WARNING(sLogger,
+                          ("Perf buffer epoll fd not registered", epollFd)("plugin type", magic_enum::enum_name(type)));
+            } else {
+                LOG_ERROR(sLogger,
+                          ("Failed to unregister perf buffer epoll fd",
+                           epollFd)("error", strerror(errno))("plugin type", magic_enum::enum_name(type)));
+            }
         }
     }
 }

--- a/core/ebpf/plugin/ProcessCacheManager.cpp
+++ b/core/ebpf/plugin/ProcessCacheManager.cpp
@@ -159,10 +159,10 @@ bool ProcessCacheManager::Init() {
     ebpfConfig->mConfig = pconfig;
     bool status = mEBPFAdapter->StartPlugin(PluginType::PROCESS_SECURITY, std::move(ebpfConfig));
     if (!status) {
-        LOG_ERROR(sLogger, ("start process probes", "failed"));
+        LOG_ERROR(sLogger, ("start process security plugin", "failed"));
         return false;
     }
-    LOG_INFO(sLogger, ("start process probes, status", status));
+    LOG_INFO(sLogger, ("start process security plugin", "success"));
     ebpf::EBPFServer::GetInstance()->RegisterPluginPerfBuffers(PluginType::PROCESS_SECURITY);
     mInited = true;
     auto ret = syncAllProc(); // write process cache contention with pollPerfBuffers
@@ -180,7 +180,11 @@ void ProcessCacheManager::Stop() {
     mInited = false;
     waitForConsumeFinished();
     auto res = mEBPFAdapter->StopPlugin(PluginType::PROCESS_SECURITY);
-    LOG_INFO(sLogger, ("stop process probes, status", res));
+    if (res) {
+        LOG_INFO(sLogger, ("stop process security plugin", "success"));
+    } else {
+        LOG_WARNING(sLogger, ("stop process security plugin", "failed"));
+    }
     mProcessCache.Clear();
     mProcessDataMap.Clear();
 }
@@ -248,7 +252,6 @@ bool ProcessCacheManager::AttachProcessData(uint32_t pid,
     auto procPtr = mProcessCache.Lookup({pid, ktime});
     if (!procPtr) {
         ADD_COUNTER(mProcessCacheMissTotal, 1);
-        LOG_WARNING(sLogger, ("cannot find proc in cache, pid", pid)("ktime", ktime)("size", mProcessCache.Size()));
         return false;
     }
 

--- a/core/ebpf/plugin/ProcessCloneRetryableEvent.cpp
+++ b/core/ebpf/plugin/ProcessCloneRetryableEvent.cpp
@@ -140,18 +140,8 @@ bool ProcessCloneRetryableEvent::attachK8sPodMeta(bool isRetry) {
 }
 
 bool ProcessCloneRetryableEvent::flushEvent() {
-    if (!mFlushProcessEvent) {
-        return true;
-    }
-    if (!mCommonEventQueue.try_enqueue(mProcessEvent)) {
-        // don't use move as it will set mProcessEvent to nullptr even
-        // if enqueue failed, this is unexpected but don't know why
-        LOG_WARNING(
-            sLogger,
-            ("event", "Failed to enqueue process clone event")("pid", mRawEvent->tgid)("ktime", mRawEvent->ktime));
-        // TODO: Alarm discard event if it is called by OnDrop
-        return false;
-    }
+    // don't enqueue process clone event
+    // the method is preserved in case of debugging
     return true;
 }
 

--- a/core/ebpf/plugin/network_observer/NetworkObserverManager.cpp
+++ b/core/ebpf/plugin/network_observer/NetworkObserverManager.cpp
@@ -1225,8 +1225,10 @@ int NetworkObserverManager::Init() {
     pc->mConfig = config;
     auto ret = mEBPFAdapter->StartPlugin(PluginType::NETWORK_OBSERVE, std::move(pc));
     if (!ret) {
+        LOG_WARNING(sLogger, ("start network observer plugin", "failed"));
         return -1;
     }
+    LOG_INFO(sLogger, ("start network observer plugin", "success"));
     mInited = true;
 
     return 0;
@@ -1366,7 +1368,7 @@ int NetworkObserverManager::AddOrUpdateConfig(const CollectionPipelineContext* c
     }
 
     updateConfigVersionAndWhitelist({}, std::move(expiredCids));
-    Resume(opt);
+    resume(opt);
     return 0;
 }
 
@@ -1910,8 +1912,12 @@ int NetworkObserverManager::Destroy() {
         return 0;
     }
     LOG_INFO(sLogger, ("prepare to destroy", ""));
-    mEBPFAdapter->StopPlugin(PluginType::NETWORK_OBSERVE);
-    LOG_INFO(sLogger, ("destroy stage", "shutdown ebpf prog"));
+    auto ret = mEBPFAdapter->StopPlugin(PluginType::NETWORK_OBSERVE);
+    if (ret) {
+        LOG_INFO(sLogger, ("destroy stage", "shutdown ebpf prog success"));
+    } else {
+        LOG_WARNING(sLogger, ("destroy stage", "shutdown ebpf prog failed"));
+    }
     this->mInited = false;
 
 #ifdef APSARA_UNIT_TEST_MAIN

--- a/core/ebpf/plugin/network_observer/NetworkObserverManager.h
+++ b/core/ebpf/plugin/network_observer/NetworkObserverManager.h
@@ -108,17 +108,8 @@ public:
         return ebpfConfig;
     }
 
-    int Update([[maybe_unused]] const std::variant<SecurityOptions*, ObserverNetworkOption*>& options) override {
-        return 0;
-    }
-
     int Suspend() override {
         mSuspendFlag = true;
-        return 0;
-    }
-
-    int Resume(const std::variant<SecurityOptions*, ObserverNetworkOption*>&) override {
-        mSuspendFlag = false;
         return 0;
     }
 
@@ -141,6 +132,16 @@ public:
     void ReportAgentInfo();
 
     void HandleHostMetadataUpdate(const std::vector<std::string>& podCidVec);
+
+protected:
+    int update([[maybe_unused]] const std::variant<SecurityOptions*, ObserverNetworkOption*>& options) override {
+        return 0;
+    }
+
+    int resume(const std::variant<SecurityOptions*, ObserverNetworkOption*>&) override {
+        mSuspendFlag = false;
+        return 0;
+    }
 
 private:
     // the following 3 methods are not thread safe ...

--- a/core/ebpf/plugin/process_security/ProcessSecurityManager.cpp
+++ b/core/ebpf/plugin/process_security/ProcessSecurityManager.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include "Lock.h"
+#include "Logger.h"
 #include "TimeKeeper.h"
 #include "collection_pipeline/CollectionPipelineContext.h"
 #include "collection_pipeline/queue/ProcessQueueItem.h"
@@ -59,8 +60,10 @@ ProcessSecurityManager::ProcessSecurityManager(const std::shared_ptr<ProcessCach
 }
 
 int ProcessSecurityManager::Init() {
+    if (mInited) {
+        return 0;
+    }
     mInited = true;
-    mSuspendFlag = false;
     return 0;
 }
 
@@ -84,7 +87,7 @@ int ProcessSecurityManager::AddOrUpdateConfig(
     }
 
     processCacheMgr->MarkProcessEventFlushStatus(true);
-    if (Resume(opt)) {
+    if (resume(opt)) {
         LOG_WARNING(sLogger, ("ProcessSecurity Resume Failed", ""));
         return 1;
     }
@@ -94,7 +97,8 @@ int ProcessSecurityManager::AddOrUpdateConfig(
     mPipelineCtx = ctx;
     mQueueKey = ctx->GetProcessQueueKey();
 
-    mRegisteredConfigCount++;
+    mRegisteredConfigCount = 1;
+    LOG_ERROR(sLogger, ("ProcessSecurity AddOrUpdateConfig count", mRegisteredConfigCount));
 
     return 0;
 }
@@ -111,7 +115,8 @@ int ProcessSecurityManager::RemoveConfig(const std::string&) {
         return 1;
     }
     processCacheMgr->MarkProcessEventFlushStatus(false);
-    mRegisteredConfigCount--;
+    mRegisteredConfigCount = 0;
+    LOG_ERROR(sLogger, ("ProcessSecurity RemoveConfig count", mRegisteredConfigCount));
     return 0;
 }
 

--- a/core/ebpf/plugin/process_security/ProcessSecurityManager.h
+++ b/core/ebpf/plugin/process_security/ProcessSecurityManager.h
@@ -79,7 +79,7 @@ public:
         return ebpfConfig;
     }
 
-    int Update([[maybe_unused]] const std::variant<SecurityOptions*, ObserverNetworkOption*>& options) override {
+    int update([[maybe_unused]] const std::variant<SecurityOptions*, ObserverNetworkOption*>& options) override {
         // do nothing ...
         return 0;
     }

--- a/core/unittest/ebpf/ManagerUnittest.cpp
+++ b/core/unittest/ebpf/ManagerUnittest.cpp
@@ -112,7 +112,7 @@ void ManagerUnittest::TestProcessSecurityManagerBasic() {
     APSARA_TEST_EQUAL(manager->Suspend(), 0);
     APSARA_TEST_FALSE(manager->IsRunning());
 
-    APSARA_TEST_EQUAL(manager->Resume(std::variant<SecurityOptions*, ObserverNetworkOption*>(&options)), 0);
+    APSARA_TEST_EQUAL(manager->resume(std::variant<SecurityOptions*, ObserverNetworkOption*>(&options)), 0);
     APSARA_TEST_TRUE(manager->IsRunning());
 
     APSARA_TEST_EQUAL(manager->Destroy(), 0);
@@ -156,7 +156,7 @@ void ManagerUnittest::TestFileSecurityManagerBasic() {
     APSARA_TEST_EQUAL(manager->Suspend(), 0);
     APSARA_TEST_FALSE(manager->IsRunning());
 
-    APSARA_TEST_EQUAL(manager->Resume(std::variant<SecurityOptions*, ObserverNetworkOption*>(&options)), 0);
+    APSARA_TEST_EQUAL(manager->resume(std::variant<SecurityOptions*, ObserverNetworkOption*>(&options)), 0);
     APSARA_TEST_TRUE(manager->IsRunning());
 
     APSARA_TEST_EQUAL(manager->Destroy(), 0);
@@ -280,7 +280,7 @@ void ManagerUnittest::TestNetworkSecurityManagerBasic() {
     APSARA_TEST_FALSE(manager->IsRunning());
 
     // 测试恢复
-    APSARA_TEST_EQUAL(manager->Resume(std::variant<SecurityOptions*, ObserverNetworkOption*>(&options)), 0);
+    APSARA_TEST_EQUAL(manager->resume(std::variant<SecurityOptions*, ObserverNetworkOption*>(&options)), 0);
     APSARA_TEST_TRUE(manager->IsRunning());
 
     APSARA_TEST_EQUAL(manager->Destroy(), 0);


### PR DESCRIPTION
- Fix duplicate fd registration error handling in unifiedFd
- Fix missing plugin type check causing accidental unregistration  
- Fix ProcessSecurityManager reference counting logic
- Remove duplicate StopPlugin in EBPFAdapter destructor to prevent crashes
- Stop reporting useless clone events to reduce overhead

- 修复fd重复注册unifiedFd时的错误处理
- 修复反注册时缺少插件类型判断导致误操作
- 修复ProcessSecurityManager引用计数错误
- 移除EBPFAdapter析构函数重复StopPlugin避免崩溃
- 停止上报无用的clone事件减少开销

Change-Id: Id2cc0b2b904f6f203c0a434ab46cf628f51d7a9b