### PR TITLE
fix: timer concurrently wait wrong

### DIFF
--- a/core/common/timer/Timer.h
+++ b/core/common/timer/Timer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <condition_variable>
 #include <future>
 #include <memory>
@@ -23,6 +24,7 @@
 #include <queue>
 
 #include "common/timer/TimerEvent.h"
+#include "monitor/metric_models/MetricRecord.h"
 
 namespace logtail {
 
@@ -46,6 +48,7 @@ public:
     void Init();
     void Stop();
     void PushEvent(std::unique_ptr<TimerEvent>&& e);
+    void InitMetrics();
 #ifdef APSARA_UNIT_TEST_MAIN
     void Clear();
 #endif
@@ -59,8 +62,7 @@ private:
         mQueue;
 
     std::future<void> mThreadRes;
-    mutable std::mutex mThreadRunningMux;
-    bool mIsThreadRunning = false;
+    std::atomic_bool mIsThreadRunning = false;
     mutable std::condition_variable mCV;
 
 #ifdef APSARA_UNIT_TEST_MAIN


### PR DESCRIPTION
## 现象
主机监控偶尔有漏点的情况
<img width="4058" height="672" alt="image" src="https://github.com/user-attachments/assets/29f09e91-2293-4ae3-b492-771a10707913" />
加了自监控之后发现是Timer的问题。
<img width="1948" height="170" alt="image" src="https://github.com/user-attachments/assets/900f9222-943a-4962-a7c6-ef5c8c81167b" />
正常的延迟（计划调度时间和实际调度时间之差）在200多，但漏点的时间延迟很高。

## 问题
这段代码有并发问题
https://github.com/alibaba/loongcollector/blob/93a60a1c77731d8284a28d78c403a0afd32f019c/core/common/timer/Timer.cpp#L79-L84
queueLock释放之后，在82行和83行之间，如果并发加入了新的更早的事件，并且执行完了notify。那么83行的wait_for就会等待一个错误的timeout，导致调度延迟。

## 解决方案
核心问题在条件变量等待的锁和数据的锁不是同一个。mThreadRunningMux完全可以舍弃掉，argus的timer也是就一个锁。