### PR TITLE
fix(plugins/metric_system_v2): report fd metrics as string to avoid float64 precision loss

### DIFF
--- a/plugins/input/systemv2/input_system_linux.go
+++ b/plugins/input/systemv2/input_system_linux.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/alibaba/ilogtail/pkg/helper/containercenter"
@@ -163,10 +162,8 @@ func (r *InputSystem) CollectOpenFD(collector pipeline.Collector) {
 		logger.Warning(r.context.GetRuntimeContext(), "FILENR_PATTERN_ALARM", "want", 3, "got", len(parts))
 		return
 	}
-	allocated, _ := strconv.ParseFloat(string(parts[0]), 64)
-	maximum, _ := strconv.ParseFloat(string(parts[2]), 64)
-	r.addMetric(collector, "fd_allocated", &r.commonLabels, allocated)
-	r.addMetric(collector, "fd_max", &r.commonLabels, maximum)
+	r.addMetricStringVal(collector, "fd_allocated", &r.commonLabels, string(parts[0]))
+	r.addMetricStringVal(collector, "fd_max", &r.commonLabels, string(parts[2]))
 }
 
 // CollectDiskUsage use `/proc/1/mounts` to find the device rather than `proc/self/mounts`

--- a/plugins/input/systemv2/input_system_v2.go
+++ b/plugins/input/systemv2/input_system_v2.go
@@ -108,6 +108,10 @@ func (r *InputSystem) addMetric(collector pipeline.Collector, name string, label
 	collector.AddRawLog(helper.NewMetricLog(name, r.collectTime.UnixNano(), value, labels))
 }
 
+func (r *InputSystem) addMetricStringVal(collector pipeline.Collector, name string, labels *helper.MetricLabels, value string) {
+	collector.AddRawLog(helper.NewMetricLogStringVal(name, r.collectTime.UnixNano(), value, labels))
+}
+
 func (r *InputSystem) CollectCore(collector pipeline.Collector) {
 
 	// host info


### PR DESCRIPTION
Hi maintainers,

I noticed that input plugin **metric_system_v2** reports **fd_max** as float64. However, fd_max is fixed at max int64(2^63-1 or 9223372036854775807), which exceeds the range of float64. Therefore, the data, with its loss of precision, is represented as 9.223372036854776e+18 in Metric.

https://github.com/alibaba/loongcollector/blob/68ba314f5176e6101fbe03007efa871b84cb3e6a/plugins/input/systemv2/input_system_linux.go#L166-L169

Since the metric is eventually converted to a string (see [log_helper.go#L258](https://github.com/alibaba/loongcollector/blob/68ba314f5176e6101fbe03007efa871b84cb3e6a/pkg/helper/log_helper.go#L258)), it would be more accurate to record fd_max directly as a string.

Alternatively, how about considering simply removing fd_max, since it's a constant on Linux anyway?