### PR TITLE
add nano seconds support in LogFileReader and protocol converter

### DIFF
--- a/core/file_server/reader/LogFileReader.cpp
+++ b/core/file_server/reader/LogFileReader.cpp
@@ -2536,7 +2536,8 @@ PipelineEventGroup LogFileReader::GenerateEventGroup(LogFileReaderPtr reader, Lo
             event->SetTimestamp(logtime, static_cast<uint32_t>(currentTimeNs % kNanoPerSeconds));
         } else {
             // When not auto-adjusting, use the full nanosecond timestamp
-            event->SetTimestamp(static_cast<time_t>(currentTimeNs / kNanoPerSeconds), static_cast<uint32_t>(currentTimeNs % kNanoPerSeconds));
+            event->SetTimestamp(static_cast<time_t>(currentTimeNs / kNanoPerSeconds),
+                                static_cast<uint32_t>(currentTimeNs % kNanoPerSeconds));
         }
     } else {
         // Use regular second timestamp

--- a/pkg/protocol/converter/converter_single_log_flatten.go
+++ b/pkg/protocol/converter/converter_single_log_flatten.go
@@ -48,10 +48,22 @@ func (c *Converter) ConvertToSingleProtocolLogsFlatten(logGroup *protocol.LogGro
 			}
 		}
 
-		if newKey, ok := c.ProtocolKeyRenameMap[protocolKeyTime]; ok {
-			customSingleLog[newKey] = log.Time
+		// Set timestamp with nanosecond precision if enabled
+		timestamp := log.Time
+		if c.GlobalConfig != nil && c.GlobalConfig.EnableTimestampNanosecond {
+			// Combine seconds and nanoseconds
+			timestampNs := uint64(timestamp) * 1000000000 + uint64(log.GetTimeNs())
+			if newKey, ok := c.ProtocolKeyRenameMap[protocolKeyTime]; ok {
+				customSingleLog[newKey] = timestampNs
+			} else {
+				customSingleLog[protocolKeyTime] = timestampNs
+			}
 		} else {
-			customSingleLog[protocolKeyTime] = log.Time
+			if newKey, ok := c.ProtocolKeyRenameMap[protocolKeyTime]; ok {
+				customSingleLog[newKey] = timestamp
+			} else {
+				customSingleLog[protocolKeyTime] = timestamp
+			}
 		}
 
 		convertedLogs[i] = customSingleLog

--- a/pkg/protocol/converter/custom_single_log.go
+++ b/pkg/protocol/converter/custom_single_log.go
@@ -41,10 +41,22 @@ func (c *Converter) ConvertToSingleProtocolLogs(logGroup *protocol.LogGroup, tar
 		desiredValues[i] = desiredValue
 
 		customSingleLog := make(map[string]interface{}, numProtocolKeys)
-		if newKey, ok := c.ProtocolKeyRenameMap[protocolKeyTime]; ok {
-			customSingleLog[newKey] = log.Time
+		// Set timestamp with nanosecond precision if enabled
+		timestamp := log.Time
+		if c.GlobalConfig != nil && c.GlobalConfig.EnableTimestampNanosecond {
+			// Combine seconds and nanoseconds
+			timestampNs := uint64(timestamp) * 1000000000 + uint64(log.GetTimeNs())
+			if newKey, ok := c.ProtocolKeyRenameMap[protocolKeyTime]; ok {
+				customSingleLog[newKey] = timestampNs
+			} else {
+				customSingleLog[protocolKeyTime] = timestampNs
+			}
 		} else {
-			customSingleLog[protocolKeyTime] = log.Time
+			if newKey, ok := c.ProtocolKeyRenameMap[protocolKeyTime]; ok {
+				customSingleLog[newKey] = timestamp
+			} else {
+				customSingleLog[protocolKeyTime] = timestamp
+			}
 		}
 		if newKey, ok := c.ProtocolKeyRenameMap[protocolKeyContent]; ok {
 			customSingleLog[newKey] = contents


### PR DESCRIPTION
1. set nano second support in LogFileReader, which makes input_file plugin can set nanosecond in the log event
2. set nano second in protocol converter when we want to flattern log events