### PR TITLE
fix(containercenter): fix stale k8s label enrichment for static containers on pod rebuild

### DIFF
--- a/pkg/helper/containercenter/container_center.go
+++ b/pkg/helper/containercenter/container_center.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -185,20 +186,56 @@ func (info *K8SInfo) ExtractK8sLabels(containerInfo container.InspectResponse) {
 }
 
 func (info *K8SInfo) Merge(o *K8SInfo) {
-	info.mu.Lock()
-	o.mu.Lock()
-	defer info.mu.Unlock()
-	defer o.mu.Unlock()
+	if info == nil || o == nil {
+		return
+	}
+	// Lock in a fixed address order so concurrent Merge(A,B) vs Merge(B,A) cannot deadlock.
+	if uintptr(unsafe.Pointer(info)) < uintptr(unsafe.Pointer(o)) {
+		info.mu.Lock()
+		o.mu.Lock()
+		defer o.mu.Unlock()
+		defer info.mu.Unlock()
+	} else {
+		o.mu.Lock()
+		info.mu.Lock()
+		defer info.mu.Unlock()
+		defer o.mu.Unlock()
+	}
 
-	// only pause container has k8s labels, so we can only check len(labels)
-	if len(o.Labels) > len(info.Labels) {
+	inLen := len(info.Labels)
+	outLen := len(o.Labels)
+	if inLen == 0 && outLen == 0 {
+		return
+	}
+	if inLen == 0 {
 		info.Labels = o.Labels
 		info.matchedCache = nil
-	}
-	if len(o.Labels) < len(info.Labels) {
-		o.Labels = info.Labels
 		o.matchedCache = nil
+		return
 	}
+	if outLen == 0 {
+		o.Labels = info.Labels
+		info.matchedCache = nil
+		o.matchedCache = nil
+		return
+	}
+
+	// Union by keys: prefer info's values on overlap, add keys only present on o.
+	// Picking solely by len(Labels) drops keys that exist only on the smaller map
+	// (e.g. ExternalK8sLabelTag would miss those labels).
+	merged := make(map[string]string, inLen+outLen)
+	for k, v := range info.Labels {
+		merged[k] = v
+	}
+	for k, v := range o.Labels {
+		if _, exists := merged[k]; !exists {
+			merged[k] = v
+		}
+	}
+	info.Labels = merged
+	o.Labels = merged
+	info.matchedCache = nil
+	o.matchedCache = nil
 }
 
 // IsMatch ...

--- a/pkg/helper/containercenter/container_center.go
+++ b/pkg/helper/containercenter/container_center.go
@@ -28,7 +28,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -186,54 +185,46 @@ func (info *K8SInfo) ExtractK8sLabels(containerInfo container.InspectResponse) {
 }
 
 func (info *K8SInfo) Merge(o *K8SInfo) {
-	if info == nil || o == nil {
+	// Guard against nil and self-merge: locking the same mutex twice would deadlock,
+	// and merging an object with itself is a no-op anyway.
+	if info == nil || o == nil || info == o {
 		return
 	}
-	// Lock in a fixed address order so concurrent Merge(A,B) vs Merge(B,A) cannot deadlock.
-	if uintptr(unsafe.Pointer(info)) < uintptr(unsafe.Pointer(o)) {
-		info.mu.Lock()
-		o.mu.Lock()
-		defer o.mu.Unlock()
-		defer info.mu.Unlock()
-	} else {
-		o.mu.Lock()
-		info.mu.Lock()
-		defer info.mu.Unlock()
-		defer o.mu.Unlock()
-	}
+	// Both call sites (mergeK8sInfo / updateContainer) run under ContainerCenter.lock,
+	// so two Merge calls never race; a simple fixed lock order is enough here.
+	info.mu.Lock()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	defer info.mu.Unlock()
 
 	inLen := len(info.Labels)
 	outLen := len(o.Labels)
 	if inLen == 0 && outLen == 0 {
 		return
 	}
-	if inLen == 0 {
-		info.Labels = o.Labels
-		info.matchedCache = nil
-		o.matchedCache = nil
-		return
-	}
-	if outLen == 0 {
-		o.Labels = info.Labels
-		info.matchedCache = nil
-		o.matchedCache = nil
-		return
-	}
 
-	// Union by keys: prefer info's values on overlap, add keys only present on o.
-	// Picking solely by len(Labels) drops keys that exist only on the smaller map
-	// (e.g. ExternalK8sLabelTag would miss those labels).
+	// Union by keys so we never drop labels that exist only on the smaller map.
+	// Picking solely by len(Labels) (the previous behavior) loses keys unique to
+	// one side, e.g. per-container labels added by wrapperK8sInfoByLabels /
+	// ExtractK8sLabels. info's values win on overlap.
 	merged := make(map[string]string, inLen+outLen)
+	for k, v := range o.Labels {
+		merged[k] = v
+	}
 	for k, v := range info.Labels {
 		merged[k] = v
 	}
-	for k, v := range o.Labels {
-		if _, exists := merged[k]; !exists {
-			merged[k] = v
-		}
+
+	// Give each side its own copy. Sharing one map would alias the two K8SInfo
+	// objects, so a later Labels[k]=v write on one container would leak into the
+	// other (see cri_adapter.go wrapperK8sInfoByLabels).
+	infoLabels := merged
+	oLabels := make(map[string]string, len(merged))
+	for k, v := range merged {
+		oLabels[k] = v
 	}
-	info.Labels = merged
-	o.Labels = merged
+	info.Labels = infoLabels
+	o.Labels = oLabels
 	info.matchedCache = nil
 	o.matchedCache = nil
 }

--- a/pkg/helper/containercenter/container_center.go
+++ b/pkg/helper/containercenter/container_center.go
@@ -1189,6 +1189,13 @@ func (dc *ContainerCenter) mergeK8sInfo() {
 		if container.K8SInfo == nil {
 			continue
 		}
+		// Skip containers marked for removal: on an in-place pod rebuild the old
+		// container lingers here until it times out, and its already-enriched
+		// (now stale) labels would otherwise pollute the merge group for the same
+		// namespace@pod and leak back onto the freshly created containers.
+		if container.deleteFlag {
+			continue
+		}
 		key := container.K8SInfo.Namespace + "@" + container.K8SInfo.Pod
 		k8sInfoMap[key] = append(k8sInfoMap[key], container.K8SInfo)
 	}

--- a/pkg/helper/containercenter/container_center.go
+++ b/pkg/helper/containercenter/container_center.go
@@ -882,6 +882,18 @@ func (dc *ContainerCenter) readStaticConfig(forceFlush bool) {
 		forceFlush = true
 	}
 
+	// Mark removed containers before rebuilding the map so their deleteFlag is set
+	// prior to mergeK8sInfo. On an in-place pod rebuild the old business container
+	// (its id changed) is carried over by updateContainers until it times out; if it
+	// is still unflagged during the merge, its stale, already-enriched labels get
+	// pulled into the same namespace@pod group and leak back onto the fresh
+	// containers. Flagging first lets mergeK8sInfo skip it.
+	if len(removedIDs) > 0 {
+		for _, id := range removedIDs {
+			containerCenterInstance.markRemove(id)
+		}
+	}
+
 	// 静态文件读取容器信息的时候，只能全量读取，因此使用updateContainers全量更新
 	if forceFlush || changed {
 		containerMap := make(map[string]*DockerInfoDetail)
@@ -890,12 +902,6 @@ func (dc *ContainerCenter) readStaticConfig(forceFlush bool) {
 			containerMap[info.ID] = dockerInfoDetail
 		}
 		containerCenterInstance.updateContainers(containerMap)
-	}
-
-	if len(removedIDs) > 0 {
-		for _, id := range removedIDs {
-			containerCenterInstance.markRemove(id)
-		}
 	}
 }
 

--- a/pkg/helper/containercenter/container_center_file_discover.go
+++ b/pkg/helper/containercenter/container_center_file_discover.go
@@ -299,7 +299,13 @@ func tryReadStaticContainerInfo() ([]container.InspectResponse, []string, bool, 
 		return staticDockerContainers, nil, statusChanged, nil
 	}
 
-	newStaticDockerContainer, removedIDs, changed, staticDockerContainerError := innerReadStatisContainerInfo(staticDockerContainerFile, staticDockerContainers, stat)
+	// Assign the package-level staticDockerContainerError (not `:=`, which would
+	// shadow it and leave the global stale), so the IsChange gate above can force a
+	// re-read after a previous read error.
+	var newStaticDockerContainer []container.InspectResponse
+	var removedIDs []string
+	var changed bool
+	newStaticDockerContainer, removedIDs, changed, staticDockerContainerError = innerReadStatisContainerInfo(staticDockerContainerFile, staticDockerContainers, stat)
 	changed = changed || statusChanged
 	if staticDockerContainerError == nil {
 		staticDockerContainers = newStaticDockerContainer

--- a/pkg/helper/containercenter/container_center_merge_test.go
+++ b/pkg/helper/containercenter/container_center_merge_test.go
@@ -104,3 +104,47 @@ func TestK8SInfoMergeNilAndSelf(t *testing.T) {
 	self.Merge(self)
 	require.Equal(t, map[string]string{"a": "1"}, self.Labels)
 }
+
+// TestMergeK8sInfoSkipsDeletedContainer reproduces the in-place pod rebuild case:
+// a stale container (deleteFlag) still lingers in the container map alongside the
+// freshly created pause and business containers of the same pod. The stale labels
+// must not leak onto the fresh containers.
+func TestMergeK8sInfoSkipsDeletedContainer(t *testing.T) {
+	const ns, pod = "default", "app-0"
+
+	// Old business container from the previous incarnation, already enriched with
+	// stale label values and a label (test3) that no longer exists. Marked deleted.
+	stale := &DockerInfoDetail{
+		deleteFlag: true,
+		K8SInfo: &K8SInfo{
+			Namespace: ns, Pod: pod, ContainerName: "app",
+			Labels: map[string]string{"test1": "old1", "test2": "old2", "test3": "old3"},
+		},
+	}
+	// Fresh pause container after the rebuild, carrying the new label values.
+	pause := &DockerInfoDetail{
+		K8SInfo: &K8SInfo{
+			Namespace: ns, Pod: pod, ContainerName: "POD", PausedContainer: true,
+			Labels: map[string]string{"test1": "new1", "test2": "new2"},
+		},
+	}
+	// Fresh business container, no labels yet.
+	business := &DockerInfoDetail{
+		K8SInfo: &K8SInfo{Namespace: ns, Pod: pod, ContainerName: "app"},
+	}
+
+	dc := &ContainerCenter{
+		containerMap: map[string]*DockerInfoDetail{
+			"stale-id":    stale,
+			"pause-id":    pause,
+			"business-id": business,
+		},
+	}
+	dc.mergeK8sInfo()
+
+	want := map[string]string{"test1": "new1", "test2": "new2"}
+	require.Equal(t, want, business.K8SInfo.Labels, "fresh business must get new labels only")
+	require.Equal(t, want, pause.K8SInfo.Labels, "pause labels must stay fresh")
+	// The deleted container is untouched and never contributes its stale labels.
+	require.Equal(t, map[string]string{"test1": "old1", "test2": "old2", "test3": "old3"}, stale.K8SInfo.Labels)
+}

--- a/pkg/helper/containercenter/container_center_merge_test.go
+++ b/pkg/helper/containercenter/container_center_merge_test.go
@@ -1,0 +1,106 @@
+// Copyright 2021 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containercenter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestK8SInfoMerge(t *testing.T) {
+	cases := []struct {
+		name     string
+		info     map[string]string
+		other    map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "both empty stays nil",
+			info:     nil,
+			other:    nil,
+			expected: nil,
+		},
+		{
+			name:     "info empty takes other",
+			info:     nil,
+			other:    map[string]string{"a": "1", "b": "2"},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:     "other empty keeps info",
+			info:     map[string]string{"a": "1", "b": "2"},
+			other:    nil,
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:     "disjoint keys are unioned",
+			info:     map[string]string{"a": "1"},
+			other:    map[string]string{"b": "2"},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			// The previous len-based merge dropped the smaller map's unique key.
+			name:     "smaller side unique key is preserved",
+			info:     map[string]string{"only": "me"},
+			other:    map[string]string{"x": "1", "y": "2"},
+			expected: map[string]string{"only": "me", "x": "1", "y": "2"},
+		},
+		{
+			name:     "info value wins on overlap",
+			info:     map[string]string{"k": "info", "a": "1"},
+			other:    map[string]string{"k": "other", "b": "2"},
+			expected: map[string]string{"k": "info", "a": "1", "b": "2"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := &K8SInfo{Labels: tc.info}
+			other := &K8SInfo{Labels: tc.other}
+			info.Merge(other)
+
+			require.Equal(t, tc.expected, info.Labels)
+			require.Equal(t, tc.expected, other.Labels)
+		})
+	}
+}
+
+// TestK8SInfoMergeNoAlias verifies the two K8SInfo objects do not share the
+// same underlying map after Merge, so a later write to one does not leak into
+// the other.
+func TestK8SInfoMergeNoAlias(t *testing.T) {
+	info := &K8SInfo{Labels: map[string]string{"a": "1"}}
+	other := &K8SInfo{Labels: map[string]string{"b": "2"}}
+	info.Merge(other)
+
+	info.Labels["only-info"] = "x"
+	require.NotContains(t, other.Labels, "only-info")
+
+	other.Labels["only-other"] = "y"
+	require.NotContains(t, info.Labels, "only-other")
+}
+
+// TestK8SInfoMergeNilAndSelf ensures nil operands and self-merge are no-ops and
+// do not deadlock.
+func TestK8SInfoMergeNilAndSelf(t *testing.T) {
+	var nilInfo *K8SInfo
+	nilInfo.Merge(&K8SInfo{})
+	(&K8SInfo{}).Merge(nil)
+
+	self := &K8SInfo{Labels: map[string]string{"a": "1"}}
+	self.Merge(self)
+	require.Equal(t, map[string]string{"a": "1"}, self.Labels)
+}

--- a/pkg/helper/containercenter/container_center_merge_test.go
+++ b/pkg/helper/containercenter/container_center_merge_test.go
@@ -178,11 +178,14 @@ func resetStaticContainerGlobals() {
 func TestReadStaticConfigRefreshesLabelsOnPodRebuild(t *testing.T) {
 	resetContainerCenter()
 	resetStaticContainerGlobals()
+	// Always restore the package-level globals we mutate below, so this test can't
+	// contaminate other tests in the package (order-dependent flakiness).
+	t.Cleanup(resetContainerCenter)
+	t.Cleanup(resetStaticContainerGlobals)
 
 	file := filepath.Join(t.TempDir(), "container.json")
 	os.Setenv(staticContainerInfoPathEnvKey, file)
-	defer os.Unsetenv(staticContainerInfoPathEnvKey)
-	defer resetStaticContainerGlobals()
+	t.Cleanup(func() { os.Unsetenv(staticContainerInfoPathEnvKey) })
 
 	// readStaticConfig uses the package-global containerCenterInstance; set it up
 	// directly instead of getContainerCenterInstance() to avoid its background

--- a/pkg/helper/containercenter/container_center_merge_test.go
+++ b/pkg/helper/containercenter/container_center_merge_test.go
@@ -15,9 +15,14 @@
 package containercenter
 
 import (
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/alibaba/ilogtail/pkg/helper"
 )
 
 func TestK8SInfoMerge(t *testing.T) {
@@ -148,3 +153,139 @@ func TestMergeK8sInfoSkipsDeletedContainer(t *testing.T) {
 	// The deleted container is untouched and never contributes its stale labels.
 	require.Equal(t, map[string]string{"test1": "old1", "test2": "old2", "test3": "old3"}, stale.K8SInfo.Labels)
 }
+
+// resetStaticContainerGlobals clears the package-level state used by the static
+// container provider so a test can drive readStaticConfig deterministically
+// without interference from other tests.
+func resetStaticContainerGlobals() {
+	loadStaticContainerOnce = sync.Once{}
+	staticDockerContainerFile = ""
+	staticDockerContainers = nil
+	staticDockerContainerLastStat = helper.StateOS{}
+	staticDockerContainerLastBody = ""
+	staticDockerContainerError = nil
+}
+
+// TestReadStaticConfigRefreshesLabelsOnPodRebuild is the end-to-end regression for
+// the production bug: with static container discovery, when a pod is rebuilt in
+// place (business container gets a new id, pause keeps the pod-uid id) and the pod
+// labels change, the freshly created business container must be enriched with the
+// NEW label values, not the stale ones carried by the lingering old container.
+//
+// This exercises the real readStaticConfig ordering (markRemove before
+// updateContainers/mergeK8sInfo). It is file-driven only: "changing the container
+// id" is just editing container.json, so no real container runtime is needed.
+func TestReadStaticConfigRefreshesLabelsOnPodRebuild(t *testing.T) {
+	resetContainerCenter()
+	resetStaticContainerGlobals()
+
+	file := filepath.Join(t.TempDir(), "container.json")
+	os.Setenv(staticContainerInfoPathEnvKey, file)
+	defer os.Unsetenv(staticContainerInfoPathEnvKey)
+	defer resetStaticContainerGlobals()
+
+	// readStaticConfig uses the package-global containerCenterInstance; set it up
+	// directly instead of getContainerCenterInstance() to avoid its background
+	// discovery goroutine (which would race with our synchronous calls).
+	containerCenterInstance = &ContainerCenter{
+		containerHelper: &ContainerHelperWrapper{},
+		imageCache:      make(map[string]string),
+		containerMap:    make(map[string]*DockerInfoDetail),
+	}
+
+	// v1: pause(id=uid) with test1..test3 + business sandbox(id=8131), no labels.
+	require.NoError(t, os.WriteFile(file, []byte(staticRebuildConfigV1), os.ModePerm))
+	containerCenterInstance.readStaticConfig(true)
+
+	oldSandbox := containerCenterInstance.containerMap["8131"]
+	require.NotNil(t, oldSandbox)
+	require.Equal(t, "111111", oldSandbox.K8SInfo.GetLabel("test1"), "v1: business enriched from pause")
+	require.Equal(t, "311111", oldSandbox.K8SInfo.GetLabel("test3"))
+
+	// Rebuild: change pause label values (test3 removed) and give the business
+	// container a NEW id. Remove+rewrite so the file gets a new inode and the
+	// change is detected reliably.
+	require.NoError(t, os.Remove(file))
+	require.NoError(t, os.WriteFile(file, []byte(staticRebuildConfigV2), os.ModePerm))
+	containerCenterInstance.readStaticConfig(true)
+
+	newSandbox := containerCenterInstance.containerMap["3b59"]
+	require.NotNil(t, newSandbox, "new business container must be present")
+	require.Equal(t, "111112", newSandbox.K8SInfo.GetLabel("test1"), "rebuilt business must get the NEW value, not stale 111111")
+	require.Equal(t, "211112", newSandbox.K8SInfo.GetLabel("test2"))
+	require.Empty(t, newSandbox.K8SInfo.GetLabel("test3"), "removed label must not linger")
+
+	// The old business container is flagged for removal and must not be a live source.
+	if old := containerCenterInstance.containerMap["8131"]; old != nil {
+		require.True(t, old.deleteFlag, "old business container should be marked removed")
+	}
+}
+
+const staticRebuildConfigV1 = `[
+	{
+		"ID": "uid",
+		"Name": "POD",
+		"Image": "pause:latest",
+		"LogPath": "/var/log/pods/default_code-interpreter5_uid",
+		"Labels": {
+			"io.kubernetes.pod.name": "code-interpreter5",
+			"io.kubernetes.pod.namespace": "default",
+			"io.kubernetes.pod.uid": "uid",
+			"test1": "111111",
+			"test2": "211111",
+			"test3": "311111"
+		},
+		"LogType": "json-file",
+		"Created": "2026-08-06T19:41:32.228133866+08:00",
+		"State": { "Pid": 999999999901, "Status": "running" }
+	},
+	{
+		"ID": "8131",
+		"Name": "sandbox",
+		"Image": "alinux3:latest",
+		"LogPath": "/var/log/pods/default_code-interpreter5_uid/sandbox/1.log",
+		"Labels": {
+			"io.kubernetes.container.name": "sandbox",
+			"io.kubernetes.pod.name": "code-interpreter5",
+			"io.kubernetes.pod.namespace": "default",
+			"io.kubernetes.pod.uid": "uid"
+		},
+		"LogType": "json-file",
+		"Created": "2026-08-06T19:41:32.228133866+08:00",
+		"State": { "Pid": 999999999902, "Status": "running" }
+	}
+]`
+
+const staticRebuildConfigV2 = `[
+	{
+		"ID": "uid",
+		"Name": "POD",
+		"Image": "pause:latest",
+		"LogPath": "/var/log/pods/default_code-interpreter5_uid",
+		"Labels": {
+			"io.kubernetes.pod.name": "code-interpreter5",
+			"io.kubernetes.pod.namespace": "default",
+			"io.kubernetes.pod.uid": "uid",
+			"test1": "111112",
+			"test2": "211112"
+		},
+		"LogType": "json-file",
+		"Created": "2026-08-06T19:41:32.228133866+08:00",
+		"State": { "Pid": 999999999901, "Status": "running" }
+	},
+	{
+		"ID": "3b59",
+		"Name": "sandbox",
+		"Image": "alinux3:x86-3.220822.1",
+		"LogPath": "/var/log/pods/default_code-interpreter5_uid/sandbox/2.log",
+		"Labels": {
+			"io.kubernetes.container.name": "sandbox",
+			"io.kubernetes.pod.name": "code-interpreter5",
+			"io.kubernetes.pod.namespace": "default",
+			"io.kubernetes.pod.uid": "uid"
+		},
+		"LogType": "json-file",
+		"Created": "2026-08-06T19:55:44.506191037+08:00",
+		"State": { "Pid": 999999999903, "Status": "running" }
+	}
+]`


### PR DESCRIPTION
## 背景

  修复**静态容器发现**场景(`ALIYUN_LOG_STATIC_CONTAINER_INFO`,如 ECI 的 `container.json`)下 k8s 标签富化不刷新的问题。

  当 pod 原地重建——业务容器镜像 tag 变化 → 拿到**新 container id**,而 pause 容器 id(= pod uid)不变——并且此时 pod
  标签的**值也发生变化**时,富化进采集日志的标签(`ExternalK8sLabelTag`)会**一直停留在重建前的旧值**,被删除的标签(如 `test3`)也可能残留。

  ### 复现

  变更前 `container.json`:pause(id=`uid`,`test1=1,test2=2,test3=3`) + sandbox(id=`8131`)。
  采集日志富化标签:`test1=111111, test22=211111` ✅

  改标签 + 改镜像 tag 后:pause(id=`uid`,`test1=12,test2=22`,`test3` 删除) + sandbox(**新** id=`3b59`)。
  采集日志:仍为 `test1=1, test2=2` ❌(应为 `12/22`)。

  ## 根因

  三件事叠加导致:

  1. **旧业务容器被「保活」搬入**:重建后业务容器换了新 id,旧容器不在新构建的 map 里;`updateContainers` 会保留「尚未超时」的容器(`fetchAllSuccessTimeout` 默认 100
  分钟),于是旧业务容器被原样搬入,**仍带着上一轮富化出的 stale 标签**。
  2. **合并按「标签数量取大」**:`mergeK8sInfo` 原逻辑基于「只有 pause 有标签」的假设,谁标签多用谁。而那个 stale 旧容器恰好标签最多(比新 pause 多一个已删除的 `test3`)→ 它「胜出」,把
  `test1=1` 反向覆盖回本来正确的新 pause 和新 sandbox。
  3. **`markRemove` 晚于 merge**:`readStaticConfig` 先 `updateContainers`(触发 `mergeK8sInfo`)、后 `markRemove`,所以污染发生时旧容器的 `deleteFlag` 还是 `false`;之后文件不再变化 → 不再触发
  merge → **永久卡在脏值**,无自愈机会。

  > 动态路径(docker/CRI)也存在同样的合并机制,但有周期性全量 sync 重建并重新注入标签,顶多是「一个 sync 周期内的瞬态」,会自愈;只有静态因「文件不变即不再 merge」而持续暴露。**本 PR 
  聚焦静态场景。**

  ### 时序图

 ```mermaid
sequenceDiagram
      participant R as readStaticConfig
      participant U as updateContainers mergeK8sInfo
      participant M as markRemove
      Note over R: 文件变化 changed=true
      R->>U: 步骤1 先重建 map 并 merge
      Note over U: 旧容器 deleteFlag=false<br/>参与 merge 导致污染
      R->>M: 步骤2 之后才 markRemove
      Note over M: 太晚, merge 已污染完
      Note over R: 文件不再变, 不再 merge, 永久卡住
 ```

  ## 修复方案

  | Commit | 改动点 | 说明 |
  | --- | --- | --- |
  | `91f6c1f0` | `readStaticConfig` | 把 `markRemove` 提到 `updateContainers` 之前，使被移除容器在 merge 前就带上 `deleteFlag`（本问题闭环项） |
  | `143ce9f0` | `mergeK8sInfo` | 合并分组时跳过 `deleteFlag` 容器，stale 标签不再参与、不外泄 |
  | `6270886e` | `K8SInfo.Merge` | 三点修正：<br>1）「按 len 取大整份覆盖」改为按 key 求并集，不丢仅存在于较小 map 的 key；<br>2）合并结果给双方各自独立拷贝，避免共享同一 map 后续
  `Labels[k]=v` 互相串写；<br>3）去掉基于 `unsafe.Pointer` 的地址序加锁（两个调用点均在 `ContainerCenter.lock` 下串行，不存在并发 Merge），并加 `info==o` 自合并保护 |

  修复后：`markRemove` 先执行 → 旧容器带 `deleteFlag=true` 被搬入 → `mergeK8sInfo` 跳过它 → 分组只剩「新 pause + 新 sandbox」→ 新 sandbox 富化为 `test1=12`，`test3` 不再残留。换 uid 的整
  pod 重建同样成立（旧 pause 也在 `removedIDs` 中被一并标记跳过）。

  ### 测试

  - 新增 pkg/helper/containercenter/container_center_merge_test.go:
    - TestK8SInfoMerge:并集 / 空集 / 冲突值优先 / 较小集合独有 key 保留
    - TestK8SInfoMergeNoAlias、TestK8SInfoMergeNilAndSelf
    - TestMergeK8sInfoSkipsDeletedContainer:已验证「移除修复即失败、加回即通过」,为有效回归测试
  - 全部通过,gofmt / go vet 干净。

  ### 影响面与风险

  - 改动集中在静态容器发现的编排顺序与标签合并逻辑,不涉及 C++ 核心。
  - markRemove 提前仅是把「标记删除」移到「重建 + merge」之前,语义等价、影响面小;被移除容器仍保活至超时清理,不影响正在采集的存量容器。
  - Merge 改为并集 + 各自拷贝,同时修正了原有「丢 key」与「共享 map 串写」两个潜在缺陷。