### PR TITLE
fix(netping): improve ICMP RTT precision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -298,7 +298,7 @@ replace (
 	github.com/alibaba/ilogtail/pkg => ./pkg
 	github.com/aliyun/alibaba-cloud-sdk-go/services/sls_inner => ./external/github.com/aliyun/alibaba-cloud-sdk-go/services/sls_inner
 	github.com/elastic/beats/v7 => ./external/github.com/elastic/beats/v7
-	github.com/go-ping/ping => github.com/EvanLjp/ping v1.2.2
+	github.com/go-ping/ping => github.com/iLogtail/ping v1.2.2
 	github.com/jeromer/syslogparser => ./external/github.com/jeromer/syslogparser
 	github.com/mindprince/gonvml => github.com/iLogtail/gonvml v1.0.0
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.6.0
 	github.com/elastic/go-lumber v0.1.0
 	github.com/go-mysql-org/go-mysql v1.8.0
-	github.com/go-ping/ping v0.0.0-20211130115550-779d1e919534
+	github.com/go-ping/ping v1.2.2
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/gogo/protobuf v1.3.2
@@ -298,6 +298,7 @@ replace (
 	github.com/alibaba/ilogtail/pkg => ./pkg
 	github.com/aliyun/alibaba-cloud-sdk-go/services/sls_inner => ./external/github.com/aliyun/alibaba-cloud-sdk-go/services/sls_inner
 	github.com/elastic/beats/v7 => ./external/github.com/elastic/beats/v7
+	github.com/go-ping/ping => github.com/EvanLjp/ping v1.2.2
 	github.com/jeromer/syslogparser => ./external/github.com/jeromer/syslogparser
 	github.com/mindprince/gonvml => github.com/iLogtail/gonvml v1.0.0
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ github.com/ClickHouse/clickhouse-go/v2 v2.6.0/go.mod h1:SvXuWqDsiHJE3VAn2+3+nz9W
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.0 h1:+K/VEwIAaPcHiMtQvpLD4lqW7f0Gk3xdYZmI1hD+CXo=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/EvanLjp/ping v1.2.2 h1:tkdGddUDao9Wr4kwfBG7NKQFXVi8YLiaze1+l9Pys8E=
-github.com/EvanLjp/ping v1.2.2/go.mod h1:KtEzKdvHQJvKV0rMU5JIwoeNkKAPKJGa4rZXaZpWLo0=
 github.com/IBM/sarama v1.42.2 h1:VoY4hVIZ+WQJ8G9KNY/SQlWguBQXQ9uvFPOnrcu8hEw=
 github.com/IBM/sarama v1.42.2/go.mod h1:FLPGUGwYqEs62hq2bVG6Io2+5n+pS6s/WOXVKWSLFtE=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -915,6 +913,8 @@ github.com/iLogtail/jfr-parser v0.6.0 h1:dNaQ0Ng2BLE5uxrhUQwtx1q7O9LIQFpMthl3SV3
 github.com/iLogtail/jfr-parser v0.6.0/go.mod h1:ZMcbJjfDkOwElEK8CvUJbpetztRWRXszCmf5WU0erV8=
 github.com/iLogtail/metrics v1.23.0-ilogtail h1:WHhiXtMy5+HWiPpDwO7a0zkMjPd7IPa5euF07LH5h6g=
 github.com/iLogtail/metrics v1.23.0-ilogtail/go.mod h1:rAr/llLpEnAdTehiNlUxKgnjcOuROSzpw0GvjpEbvFc=
+github.com/iLogtail/ping v1.2.2 h1:r42n1/6Q56/pwB1vBpBlVsvscdScjfFsZ+oVd1hRc1o=
+github.com/iLogtail/ping v1.2.2/go.mod h1:KtEzKdvHQJvKV0rMU5JIwoeNkKAPKJGa4rZXaZpWLo0=
 github.com/iLogtail/pyroscope-lib v0.35.2-ilogtail h1:n+om7Idv1ftoVOiqmL4CRWGeoj1v8TTQa7V809XiHT4=
 github.com/iLogtail/pyroscope-lib v0.35.2-ilogtail/go.mod h1:IpElNUA9ousagl2w05BZbzGxmd8cOERYA2vZ+DoznlQ=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/ClickHouse/clickhouse-go/v2 v2.6.0/go.mod h1:SvXuWqDsiHJE3VAn2+3+nz9W
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.0 h1:+K/VEwIAaPcHiMtQvpLD4lqW7f0Gk3xdYZmI1hD+CXo=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/EvanLjp/ping v1.2.2 h1:tkdGddUDao9Wr4kwfBG7NKQFXVi8YLiaze1+l9Pys8E=
+github.com/EvanLjp/ping v1.2.2/go.mod h1:KtEzKdvHQJvKV0rMU5JIwoeNkKAPKJGa4rZXaZpWLo0=
 github.com/IBM/sarama v1.42.2 h1:VoY4hVIZ+WQJ8G9KNY/SQlWguBQXQ9uvFPOnrcu8hEw=
 github.com/IBM/sarama v1.42.2/go.mod h1:FLPGUGwYqEs62hq2bVG6Io2+5n+pS6s/WOXVKWSLFtE=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -623,8 +625,6 @@ github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-openapi/validate v0.21.0/go.mod h1:rjnrwK57VJ7A8xqfpAOEKRH8yQSGUriMu5/zuPSQ1hg=
-github.com/go-ping/ping v0.0.0-20211130115550-779d1e919534 h1:dhy9OQKGBh4zVXbjwbxxHjRxMJtLXj3zfgpBYQaR4Q4=
-github.com/go-ping/ping v0.0.0-20211130115550-779d1e919534/go.mod h1:xIFjORFzTxqIV/tDVGO4eDy/bLuSyawEeojSm3GfRGk=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=

--- a/licenses/LICENSE_OF_ILOGTAIL_DEPENDENCIES.md
+++ b/licenses/LICENSE_OF_ILOGTAIL_DEPENDENCIES.md
@@ -221,7 +221,6 @@ When distributed in a binary form, iLogtail may contain portions of the followin
 - [go.uber.org/multierr](https://pkg.go.dev/go.uber.org/multierr?tab=licenses)
 - [go.uber.org/zap](https://pkg.go.dev/go.uber.org/zap?tab=licenses)
 - [gopkg.in/natefinch/lumberjack.v2](https://pkg.go.dev/gopkg.in/natefinch/lumberjack.v2?tab=licenses)
-- [github.com/go-ping/ping](https://pkg.go.dev/github.com/go-ping/ping?tab=licenses)
 - [github.com/dlclark/regexp2](https://pkg.go.dev/github.com/dlclark/regexp2?tab=licenses)
 - [github.com/pelletier/go-toml](https://pkg.go.dev/github.com/pelletier/go-toml?tab=licenses)
 - [gopkg.in/yaml.v3](https://pkg.go.dev/gopkg.in/yaml.v3?tab=licenses)
@@ -277,6 +276,7 @@ When distributed in a binary form, iLogtail may contain portions of the followin
 
 ## iLogtail used or modified source code from these projects
 
+- [github.com/iLogtail/ping fork from github.com/go-ping/ping](https://github.com/iLogtail/ping) based on MIT
 - [github.com/iLogtail/jfr-parser fork from github.com/pyroscope-io/jfr-parser](http://github.com/iLogtail/jfr-parser) based on Apache-2.0
 - [github.com/iLogtail/pyroscope-lib fork from github.com/pyroscope-io/pyroscope](http://github.com/iLogtail/pyroscope-lib) based on Apache-2.0
 - [github.com/iLogtail/gonvml fork from github.com/mindprince/gonvml](https://github.com/iLogtail/gonvml) based on Apache-2.0

--- a/licenses/LICENSE_OF_ILOGTAIL_DEPENDENCIES.md
+++ b/licenses/LICENSE_OF_ILOGTAIL_DEPENDENCIES.md
@@ -277,6 +277,7 @@ When distributed in a binary form, iLogtail may contain portions of the followin
 
 ## iLogtail used or modified source code from these projects
 
+- [github.com/EvanLjp/ping fork from github.com/go-ping/ping](https://github.com/EvanLjp/ping) based on MIT
 - [github.com/iLogtail/jfr-parser fork from github.com/pyroscope-io/jfr-parser](http://github.com/iLogtail/jfr-parser) based on Apache-2.0
 - [github.com/iLogtail/pyroscope-lib fork from github.com/pyroscope-io/pyroscope](http://github.com/iLogtail/pyroscope-lib) based on Apache-2.0
 - [github.com/iLogtail/gonvml fork from github.com/mindprince/gonvml](https://github.com/iLogtail/gonvml) based on Apache-2.0

--- a/licenses/LICENSE_OF_ILOGTAIL_DEPENDENCIES.md
+++ b/licenses/LICENSE_OF_ILOGTAIL_DEPENDENCIES.md
@@ -277,7 +277,6 @@ When distributed in a binary form, iLogtail may contain portions of the followin
 
 ## iLogtail used or modified source code from these projects
 
-- [github.com/EvanLjp/ping fork from github.com/go-ping/ping](https://github.com/EvanLjp/ping) based on MIT
 - [github.com/iLogtail/jfr-parser fork from github.com/pyroscope-io/jfr-parser](http://github.com/iLogtail/jfr-parser) based on Apache-2.0
 - [github.com/iLogtail/pyroscope-lib fork from github.com/pyroscope-io/pyroscope](http://github.com/iLogtail/pyroscope-lib) based on Apache-2.0
 - [github.com/iLogtail/gonvml fork from github.com/mindprince/gonvml](https://github.com/iLogtail/gonvml) based on Apache-2.0

--- a/plugins/input/netping/netping.go
+++ b/plugins/input/netping/netping.go
@@ -48,7 +48,21 @@ const (
 	DefaultTimeoutSeconds  = 5     // default timeout is 5s
 	MinTimeoutSeconds      = 1     // min timeout seconds
 	MaxTimeoutSeconds      = 30    // max timeout seconds
+
+	icmpPayloadSize  = 56
+	icmpSpreadWindow = time.Second
 )
+
+func durationToMilliseconds(duration time.Duration) float64 {
+	return float64(duration) / float64(time.Millisecond)
+}
+
+func icmpStartDelay(index, total int) time.Duration {
+	if index <= 0 || total <= 1 {
+		return 0
+	}
+	return time.Duration(index) * icmpSpreadWindow / time.Duration(total)
+}
 
 type Result struct {
 	Valid   bool // if the result is meaningful for count
@@ -296,7 +310,8 @@ func (m *NetPing) Collect(collector pipeline.Collector) error {
 
 	counter := 0
 	for i := range m.ICMPConfigs {
-		go m.doICMPing(&m.ICMPConfigs[i])
+		delay := icmpStartDelay(i, len(m.ICMPConfigs))
+		go m.doICMPingAfter(&m.ICMPConfigs[i], delay)
 		counter++
 	}
 
@@ -394,6 +409,25 @@ func (m *NetPing) getRealTarget(target string) string {
 	return realTarget
 }
 
+func (m *NetPing) doICMPingAfter(config *ICMPConfig, delay time.Duration) {
+	if delay > 0 {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		<-timer.C
+	}
+	m.doICMPing(config)
+}
+
+func configureICMPPinger(pinger *goping.Pinger, config *ICMPConfig, timeout time.Duration, privileged bool) {
+	pinger.Timeout = timeout
+	pinger.Source = config.Src
+	pinger.Size = icmpPayloadSize
+	pinger.Count = config.Count
+	if privileged {
+		pinger.SetPrivileged(true)
+	}
+}
+
 func (m *NetPing) doICMPing(config *ICMPConfig) {
 	// prepare labels
 	var label helper.MetricLabels
@@ -418,12 +452,7 @@ func (m *NetPing) doICMPing(config *ICMPConfig) {
 		}
 		return
 	}
-	pinger.Timeout = m.timeout
-
-	if m.icmpPrivileged {
-		pinger.SetPrivileged(true)
-	}
-	pinger.Count = config.Count
+	configureICMPPinger(pinger, config, m.timeout, m.icmpPrivileged)
 	err = pinger.Run() // Blocks until finished or timeout.
 	if err != nil {
 		logger.Warning(m.context.GetRuntimeContext(), selfmonitor.FailToRunPing, err.Error())
@@ -451,11 +480,11 @@ func (m *NetPing) doICMPing(config *ICMPConfig) {
 		Total:       pinger.Count,
 		Success:     stats.PacketsRecv,
 		Failed:      pinger.Count - stats.PacketsRecv,
-		MinRTTMs:    float64(stats.MinRtt / time.Millisecond),
-		MaxRTTMs:    float64(stats.MaxRtt / time.Millisecond),
-		AvgRTTMs:    float64(stats.AvgRtt / time.Millisecond),
-		TotalRTTMs:  float64(totalRtt / time.Millisecond),
-		StdDevRTTMs: float64(stats.StdDevRtt / time.Millisecond),
+		MinRTTMs:    durationToMilliseconds(stats.MinRtt),
+		MaxRTTMs:    durationToMilliseconds(stats.MaxRtt),
+		AvgRTTMs:    durationToMilliseconds(stats.AvgRtt),
+		TotalRTTMs:  durationToMilliseconds(totalRtt),
+		StdDevRTTMs: durationToMilliseconds(stats.StdDevRtt),
 	}
 }
 

--- a/plugins/input/netping/netping_test.go
+++ b/plugins/input/netping/netping_test.go
@@ -18,7 +18,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
+	goping "github.com/go-ping/ping"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alibaba/ilogtail/pkg/pipeline"
@@ -26,6 +28,43 @@ import (
 	"github.com/alibaba/ilogtail/plugins/test"
 	"github.com/alibaba/ilogtail/plugins/test/mock"
 )
+
+func TestDurationToMillisecondsPreservesSubMillisecondPrecision(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		want     float64
+	}{
+		{name: "microseconds", duration: 169 * time.Microsecond, want: 0.169},
+		{name: "nanoseconds", duration: 270500 * time.Nanosecond, want: 0.2705},
+		{name: "milliseconds", duration: 20 * time.Millisecond, want: 20},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.InDelta(t, testCase.want, durationToMilliseconds(testCase.duration), 1e-9)
+		})
+	}
+}
+
+func TestICMPStartDelaySpreadsTargetsAcrossOneSecond(t *testing.T) {
+	const targets = 318
+	assert.Zero(t, icmpStartDelay(0, targets))
+	assert.Equal(t, time.Second/targets, icmpStartDelay(1, targets))
+	assert.Equal(t, time.Duration(targets-1)*time.Second/targets, icmpStartDelay(targets-1, targets))
+	assert.Less(t, icmpStartDelay(targets-1, targets), time.Second)
+}
+
+func TestConfigureICMPPinger(t *testing.T) {
+	pinger := goping.New("127.0.0.1")
+	config := &ICMPConfig{Src: "127.0.0.2", Count: 3}
+	configureICMPPinger(pinger, config, 7*time.Second, true)
+
+	assert.Equal(t, config.Src, pinger.Source)
+	assert.Equal(t, icmpPayloadSize, pinger.Size)
+	assert.Equal(t, config.Count, pinger.Count)
+	assert.Equal(t, 7*time.Second, pinger.Timeout)
+	assert.True(t, pinger.Privileged())
+}
 
 func TestInitEmpty(t *testing.T) {
 


### PR DESCRIPTION
## What changed

- replace `github.com/go-ping/ping` with the project fork `github.com/EvanLjp/ping v1.2.2` while keeping the existing import path
- measure RTT from immediately before `WriteTo` to immediately after `ReadFrom`
- carry the receive timestamp through go-ping's internal channel so callback scheduling is excluded
- preserve fractional milliseconds in NetPing metrics
- bind the configured source IP and use a 56-byte ICMP payload
- spread ICMP target startup uniformly across one second
- document the fork license and add deterministic unit tests

Fork changes: https://github.com/EvanLjp/ping/compare/v1.2.0...v1.2.2

## Why

The previous go-ping implementation read the receive time in `processPacket`, after the packet crossed an internal channel. Under hundreds of concurrent pingers, goroutine/channel scheduling delay could inflate a sub-millisecond RTT to 20+ ms. NetPing also converted durations with integer division, losing sub-millisecond precision.

The fork stores monotonic `time.Time` values by tracker UUID and ICMP sequence. Send/receive failures, successful replies, run completion, and sequence rollover clean or bound the tracking state. Only the current and previous UUID generations are retained.

## Behavior and compatibility

- existing metric names, labels, and NetPing configuration remain unchanged
- `ping_rtt_*_ms` values remain milliseconds, now as floating-point values
- TCP, HTTP, and DNS behavior is unchanged
- Linux, macOS, and Windows use the same pure-Go timing path
- remaining unavoidable interval: kernel packet arrival to the Go `ReadFrom` goroutine being scheduled

## Validation

- `go test ./plugins/input/netping -count=50 -run '^(TestDurationToMillisecondsPreservesSubMillisecondPrecision|TestICMPStartDelaySpreadsTargetsAcrossOneSecond|TestConfigureICMPPinger)$'`
- `go test -race ./plugins/input/netping -count=20 -run '^(TestDurationToMillisecondsPreservesSubMillisecondPrecision|TestICMPStartDelaySpreadsTargetsAcrossOneSecond|TestConfigureICMPPinger)$'`
- `go test ./plugins/input/netping -run '^$'`
- `go vet ./plugins/input/netping`
- `go mod verify`
- ping fork targeted tests repeated 20 times and race tests repeated 20-50 times
- ping fork `go vet ./...`
- ping fork Linux and Windows cross-builds
- 300-pinger A/B simulation: forced 20 ms handler/channel delay averaged 20.202 ms before and 0.661 ms after (about 96.7% reduction)
- packet-processing benchmark remains at 200 B/op and 5 allocs/op

## Test environment limitations

- network-dependent upstream ping tests that resolve public hostnames cannot run in the sandbox because external DNS is unavailable
- `make check-license` could not install the missing `addlicense` tool because the package proxy is unavailable; the existing go-ping license entry is retained and the fork attribution is added explicitly
