### PR TITLE
feat(flusher): add flusher_otlp_http for OTLP/HTTP export

### DIFF
--- a/docs/cn/SUMMARY.md
+++ b/docs/cn/SUMMARY.md
@@ -138,6 +138,7 @@
     * [KafkaV2](plugins/flusher/extended/flusher-kafka-v2.md)
     * [Loki](plugins/flusher/extended/flusher-loki.md)
     * [OTLP日志](plugins/flusher/extended/flusher-otlp.md)
+    * [OTLP/HTTP](plugins/flusher/extended/flusher-otlp-http.md)
     * [Prometheus](plugins/flusher/extended/flusher-prometheus.md)
     * [Pulsar](plugins/flusher/extended/flusher-pulsar.md)
     * [标准输出/文件](plugins/flusher/extended/flusher-stdout.md)

--- a/docs/cn/plugins/flusher/extended/flusher-otlp-http.md
+++ b/docs/cn/plugins/flusher/extended/flusher-otlp-http.md
@@ -1,0 +1,144 @@
+# OTLP/HTTP
+
+## 简介
+
+`flusher_otlp_http` `flusher` 插件可以实现将采集到的数据，经过处理后，通过 **OTLP/HTTP** 协议发送到支持 `OpenTelemetry Protocol` 的后端。协议行为对齐 OpenTelemetry Collector 的 `otlphttpexporter`：以 HTTP POST 提交 protobuf 或 JSON 编码的 OTLP `ExportRequest`。
+
+与走 gRPC 的 [`flusher_otlp`](flusher-otlp.md) 相比，本插件适用于后端只开放 HTTP 端口（通常是 `4318`）、或链路上存在只支持 HTTP/1.1 的网关、负载均衡的场景。
+
+> **当前版本仅支持 Logs 数据。** Metrics / Traces 将在后续版本支持；v2 采集配置下遇到 Metric / Span 事件时会被丢弃，不会导致采集配置报错。
+
+## 事件能力
+
+列含义见 [概览 · 事件能力列说明](../../overview.md#事件能力列说明)。
+
+| v1 接口 | v2 接口 | Log | Metric | Span |
+| --- | --- | --- | --- | --- |
+| ✓ | ✓ | v1&v2 | — | — |
+
+## 版本
+
+[Alpha](../../stability-level.md)
+
+## 配置参数
+
+| 参数 | 类型 | 是否必选 | 说明 |
+| --- | --- | --- | --- |
+| Type | string | 是 | 插件类型，固定为 `flusher_otlp_http` |
+| Version | string | 否 | otlp 协议版本，默认为 `v1` |
+| Endpoint | string | 否 | 基础地址，如 `http://192.168.xx.xx:4318`。各信号的路径会自动追加，Logs 为 `/v1/logs`。当 `Logs.Endpoint` 已配置时可省略 |
+| Logs | Struct | 否 | Logs 信号的独立配置 |
+| Logs.Endpoint | string | 否 | Logs 的完整 URL。**配置后完全覆盖 `Endpoint`，且不再追加 `/v1/logs`**，需自行写完整路径 |
+| Logs.Headers | Map | 否 | Logs 专属 HTTP Headers，与 `Headers` 合并，同名键以此处为准 |
+| Encoding | string | 否 | 请求体编码，可选 `proto`、`json`，默认为 `proto`。对应 `Content-Type` 分别为 `application/x-protobuf`、`application/json` |
+| Compression | string | 否 | 请求体压缩，可选 `gzip`、`none`，默认为 `gzip`。压缩时会自动带上 `Content-Encoding: gzip` |
+| Headers | Map | 否 | 追加到每个请求的自定义 HTTP Headers |
+| Timeout | string | 否 | 单次请求的超时时间，默认 `30s` |
+| Retry.Enable | bool | 否 | 是否开启重试，默认为 `true` |
+| Retry.MaxRetryTimes | int | 否 | 最大重试次数，默认为 `3`（即单批数据最多请求 4 次） |
+| Retry.InitialDelay | string | 否 | 首次重试的时间间隔，默认为 `1s`，之后以 2 的倍数递增 |
+| Retry.MaxDelay | string | 否 | 重试间隔的上限，默认为 `30s` |
+| MaxConnsPerHost | int | 否 | 单个 Host 的最大连接数，大于 `http.DefaultTransport` 的默认值时生效 |
+| MaxIdleConnsPerHost | int | 否 | 单个 Host 的最大空闲连接数，大于默认值时生效 |
+| IdleConnTimeout | string | 否 | HTTP 连接保持空闲的最长时间，大于默认值（`90s`）时生效 |
+| WriteBufferSize | int | 否 | HTTP 连接的写缓冲区大小，单位为字节 |
+| Authenticator | Struct | 否 | 认证扩展的类型与配置，需实现 `extensions.ClientAuthenticator`，如 `ext_basicauth` |
+| RequestInterceptors | Struct 数组 | 否 | 请求拦截器扩展链，需实现 `extensions.RequestInterceptor` |
+
+`Content-Type` 与 `Content-Encoding` 由 `Encoding`、`Compression` 决定，即使在 `Headers` 中配置了同名项也不会生效，以避免请求头与实际请求体不一致。`User-Agent` 可以通过 `Headers` 覆盖。
+
+## 重试策略
+
+按 OTLP/HTTP 规范，仅以下响应会被重试：
+
+| 情况 | 是否重试 | 说明 |
+| --- | --- | --- |
+| 连接失败、超时、连接重置 | 是 | 按指数退避重试 |
+| `429 Too Many Requests` | 是 | 解析 `Retry-After` |
+| `502 Bad Gateway` | 是 | 按指数退避重试 |
+| `503 Service Unavailable` | 是 | 解析 `Retry-After` |
+| `504 Gateway Timeout` | 是 | 按指数退避重试 |
+| 其他状态码（含 `400`、`401`、`403`、`413`、**`500`**） | 否 | 视为永久失败，数据丢弃并告警 |
+
+`429`、`503` 响应中的 `Retry-After` 支持整数秒（如 `Retry-After: 5`）和 HTTP 日期（RFC 1123）两种格式，解析结果会作为本次退避时间的下界，即实际等待时间为 `max(指数退避, Retry-After)`。
+
+响应码为 `2xx` 但响应体中带有 `partial_success` 时，会记录告警日志并将本批数据视为发送成功，不会重发（重发会导致已接收的数据重复）。
+
+## 样例
+
+### v1 Pipeline
+
+采集 `/home/test-log/` 路径下的所有文件名匹配 `*.log` 规则的文件，并将采集结果发送到 `Opentelemetry` 后端的 `http://192.168.xx.xx:4318/v1/logs`。
+
+```yaml
+enable: true
+inputs:
+  - Type: input_file
+    FilePaths:
+      - /home/test-log/*.log
+flushers:
+  - Type: flusher_otlp_http
+    Endpoint: http://192.168.xx.xx:4318
+    Headers:
+      X-AppKey: 8bc8f787-b0b2-4f26-89c6-d3950a090fef
+    Retry:
+      MaxRetryTimes: 3
+```
+
+### v2 Pipeline
+
+监听 4316 端口的 `Opentelemetry` gRPC 请求，将采集结果以 JSON 编码、不压缩的方式发送到 `http://192.168.xx.xx:4318/v1/logs`。
+
+```yaml
+enable: true
+global:
+  StructureType: v2
+inputs:
+  - Type: service_otlp
+    Protocals:
+      GRPC:
+        Endpoint: 0.0.0.0:4316
+flushers:
+  - Type: flusher_otlp_http
+    Endpoint: http://192.168.xx.xx:4318
+    Encoding: json
+    Compression: none
+```
+
+### 自定义 Logs 路径
+
+当后端的日志接收路径不是标准的 `/v1/logs` 时，用 `Logs.Endpoint` 指定完整 URL。
+
+```yaml
+enable: true
+inputs:
+  - Type: input_file
+    FilePaths:
+      - /home/test-log/*.log
+flushers:
+  - Type: flusher_otlp_http
+    Logs:
+      Endpoint: http://192.168.xx.xx:8080/api/otlp/logs
+      Headers:
+        X-Tenant: tenant-a
+    Timeout: 10s
+```
+
+### 配合认证扩展
+
+```yaml
+enable: true
+inputs:
+  - Type: input_file
+    FilePaths:
+      - /home/test-log/*.log
+flushers:
+  - Type: flusher_otlp_http
+    Endpoint: http://192.168.xx.xx:4318
+    Authenticator:
+      Type: ext_basicauth
+extensions:
+  - Type: ext_basicauth
+    Username: user
+    Password: password
+```

--- a/docs/cn/plugins/flusher/extended/flusher-otlp-http.md
+++ b/docs/cn/plugins/flusher/extended/flusher-otlp-http.md
@@ -6,7 +6,7 @@
 
 与走 gRPC 的 [`flusher_otlp`](flusher-otlp.md) 相比，本插件适用于后端只开放 HTTP 端口（通常是 `4318`）、或链路上存在只支持 HTTP/1.1 的网关、负载均衡的场景。
 
-> **当前版本仅支持 Logs 数据。** Metrics / Traces 将在后续版本支持；v2 采集配置下遇到 Metric / Span 事件时会被丢弃，不会导致采集配置报错。
+> **Logs / Metrics / Traces 三种信号均支持。** v1 采集配置（`protocol.LogGroup`）只承载日志，Metric、Span 数据需要使用 v2 采集配置。
 
 ## 事件能力
 
@@ -14,7 +14,7 @@
 
 | v1 接口 | v2 接口 | Log | Metric | Span |
 | --- | --- | --- | --- | --- |
-| ✓ | ✓ | v1&v2 | — | — |
+| ✓ | ✓ | v1&v2 | v2 | v2 |
 
 ## 版本
 
@@ -26,26 +26,36 @@
 | --- | --- | --- | --- |
 | Type | string | 是 | 插件类型，固定为 `flusher_otlp_http` |
 | Version | string | 否 | otlp 协议版本，默认为 `v1` |
-| Endpoint | string | 否 | 基础地址，如 `http://192.168.xx.xx:4318`。各信号的路径会自动追加，Logs 为 `/v1/logs`。当 `Logs.Endpoint` 已配置时可省略 |
+| Endpoint | string | 否 | 基础地址，如 `http://192.168.xx.xx:4318`。各信号的路径会自动追加：Logs 为 `/v1/logs`、Metrics 为 `/v1/metrics`、Traces 为 `/v1/traces`，即只配置本项即可同时启用三种信号。当每个用到的信号都配置了自己的 `Endpoint` 时可省略 |
 | Logs | Struct | 否 | Logs 信号的独立配置 |
 | Logs.Endpoint | string | 否 | Logs 的完整 URL。**配置后完全覆盖 `Endpoint`，且不再追加 `/v1/logs`**，需自行写完整路径 |
 | Logs.Headers | Map | 否 | Logs 专属 HTTP Headers，与 `Headers` 合并，同名键以此处为准 |
+| Metrics | Struct | 否 | Metrics 信号的独立配置，字段同 `Logs`，覆盖后不再追加 `/v1/metrics` |
+| Traces | Struct | 否 | Traces 信号的独立配置，字段同 `Logs`，覆盖后不再追加 `/v1/traces` |
 | Encoding | string | 否 | 请求体编码，可选 `proto`、`json`，默认为 `proto`。对应 `Content-Type` 分别为 `application/x-protobuf`、`application/json` |
 | Compression | string | 否 | 请求体压缩，可选 `gzip`、`none`，默认为 `gzip`。压缩时会自动带上 `Content-Encoding: gzip` |
 | Headers | Map | 否 | 追加到每个请求的自定义 HTTP Headers |
-| Timeout | string | 否 | 单次请求的超时时间，默认 `30s` |
+| Timeout | int | 否 | 单次请求的超时时间，单位为**纳秒**，默认 `30000000000`（30s） |
 | Retry.Enable | bool | 否 | 是否开启重试，默认为 `true` |
 | Retry.MaxRetryTimes | int | 否 | 最大重试次数，默认为 `3`（即单批数据最多请求 4 次） |
-| Retry.InitialDelay | string | 否 | 首次重试的时间间隔，默认为 `1s`，之后以 2 的倍数递增 |
-| Retry.MaxDelay | string | 否 | 重试间隔的上限，默认为 `30s` |
+| Retry.InitialDelay | int | 否 | 首次重试的时间间隔，单位为**纳秒**，默认 `1000000000`（1s），之后以 2 的倍数递增 |
+| Retry.MaxDelay | int | 否 | 重试间隔的上限，单位为**纳秒**，默认 `30000000000`（30s）。`Retry-After` 也不会突破该上限 |
 | MaxConnsPerHost | int | 否 | 单个 Host 的最大连接数，大于 `http.DefaultTransport` 的默认值时生效 |
 | MaxIdleConnsPerHost | int | 否 | 单个 Host 的最大空闲连接数，大于默认值时生效 |
-| IdleConnTimeout | string | 否 | HTTP 连接保持空闲的最长时间，大于默认值（`90s`）时生效 |
+| IdleConnTimeout | int | 否 | HTTP 连接保持空闲的最长时间，单位为**纳秒**，大于默认值（`90s`，即 `90000000000`）时生效 |
 | WriteBufferSize | int | 否 | HTTP 连接的写缓冲区大小，单位为字节 |
 | Authenticator | Struct | 否 | 认证扩展的类型与配置，需实现 `extensions.ClientAuthenticator`，如 `ext_basicauth` |
 | RequestInterceptors | Struct 数组 | 否 | 请求拦截器扩展链，需实现 `extensions.RequestInterceptor` |
 
 `Content-Type` 与 `Content-Encoding` 由 `Encoding`、`Compression` 决定，即使在 `Headers` 中配置了同名项也不会生效，以避免请求头与实际请求体不一致。`User-Agent` 可以通过 `Headers` 覆盖。
+
+## 信号处理
+
+- 每个非空信号发送一个独立请求，按 Logs、Metrics、Traces 的顺序依次发送。由于同一批数据通常只包含一种事件类型，实际大多只会产生一个请求。
+- 空信号不会发送，即一批只有日志的数据不会额外产生空的 metrics、traces 请求。
+- 若某个信号既没有 `Endpoint` 也没有自己的 `Endpoint`，该信号视为未开启，其数据会被丢弃并告警。
+- 多个信号同时发送时，只要有一个失败就会返回错误，但其余信号仍会尝试发送，不会因为一个信号异常而阻塞其他信号。
+- 返回的错误只用于上报与告警，**采集框架不会自动重投**这批数据（见 `pluginmanager/plugin_runner_v1.go`、`plugin_runner_v2.go`：flusher 返回的错误仅记录日志）。重试完全由本插件的 `Retry` 配置在插件内部完成。
 
 ## 重试策略
 
@@ -60,9 +70,9 @@
 | `504 Gateway Timeout` | 是 | 按指数退避重试 |
 | 其他状态码（含 `400`、`401`、`403`、`413`、**`500`**） | 否 | 视为永久失败，数据丢弃并告警 |
 
-`429`、`503` 响应中的 `Retry-After` 支持整数秒（如 `Retry-After: 5`）和 HTTP 日期（RFC 1123）两种格式，解析结果会作为本次退避时间的下界，即实际等待时间为 `max(指数退避, Retry-After)`。
+`429`、`503` 响应中的 `Retry-After` 支持整数秒（如 `Retry-After: 5`）和 HTTP 日期（RFC 1123）两种格式，解析结果会作为本次退避时间的下界，即实际等待时间为 `min(max(指数退避, Retry-After), Retry.MaxDelay)`。`Retry-After` 属于外部输入，因此不会突破 `Retry.MaxDelay`，避免服务端返回超长值导致发送线程被长时间占用；插件停止时正在进行的退避等待会被立即中断。
 
-响应码为 `2xx` 但响应体中带有 `partial_success` 时，会记录告警日志并将本批数据视为发送成功，不会重发（重发会导致已接收的数据重复）。
+响应码为 `2xx` 但响应体中带有 `partial_success` 时，会记录告警日志并将本批数据视为发送成功，不会重发（重发会导致已接收的数据重复）。被拒绝的条数按信号区分：Logs 为 `rejected_log_records`、Metrics 为 `rejected_data_points`、Traces 为 `rejected_spans`。
 
 ## 样例
 
@@ -87,7 +97,7 @@ flushers:
 
 ### v2 Pipeline
 
-监听 4316 端口的 `Opentelemetry` gRPC 请求，将采集结果以 JSON 编码、不压缩的方式发送到 `http://192.168.xx.xx:4318/v1/logs`。
+监听 4316 端口的 `Opentelemetry` gRPC 请求，将采集结果以 JSON 编码、不压缩的方式发送到 `http://192.168.xx.xx:4318`，Logs、Metrics、Traces 分别写入 `/v1/logs`、`/v1/metrics`、`/v1/traces`。
 
 ```yaml
 enable: true
@@ -105,24 +115,31 @@ flushers:
     Compression: none
 ```
 
-### 自定义 Logs 路径
+### 自定义各信号的路径
 
-当后端的日志接收路径不是标准的 `/v1/logs` 时，用 `Logs.Endpoint` 指定完整 URL。
+当后端的接收路径不是标准的 `/v1/logs`、`/v1/metrics`、`/v1/traces`，或不同信号需要发往不同后端时，用各信号的 `Endpoint` 指定完整 URL。
 
 ```yaml
 enable: true
+global:
+  StructureType: v2
 inputs:
-  - Type: input_file
-    FilePaths:
-      - /home/test-log/*.log
+  - Type: service_otlp
+    Protocals:
+      GRPC:
+        Endpoint: 0.0.0.0:4316
 flushers:
   - Type: flusher_otlp_http
     Logs:
       Endpoint: http://192.168.xx.xx:8080/api/otlp/logs
       Headers:
         X-Tenant: tenant-a
-    Timeout: 10s
+    Metrics:
+      Endpoint: http://192.168.xx.yy:8080/api/otlp/metrics
+    Timeout: 10000000000
 ```
+
+上例中未配置 `Endpoint` 与 `Traces`，因此 Traces 信号未开启，Span 数据会被丢弃。
 
 ### 配合认证扩展
 

--- a/docs/cn/plugins/flusher/flushers.md
+++ b/docs/cn/plugins/flusher/flushers.md
@@ -45,6 +45,7 @@ LoongCollector 提供两类输出插件：
 | `flusher_kafka_v2`<br>[Kafka V2](extended/flusher-kafka-v2.md) | 社区<br>[shalousun](https://github.com/shalousun) | 输出到 Kafka，优先推荐。 |
 | `flusher_loki`<br>[Loki](extended/flusher-loki.md) | 社区<br>[abingcbc](https://github.com/abingcbc) | 推送到 Grafana Loki。 |
 | `flusher_otlp_log`<br>[OTLP 日志](extended/flusher-otlp.md) | 社区<br>[liuhaoyang](https://github.com/liuhaoyang) | 兼容 OpenTelemetry Logs 的后端。 |
+| `flusher_otlp_http`<br>[OTLP/HTTP](extended/flusher-otlp-http.md) | 社区 | 通过 OTLP/HTTP 协议写入 OpenTelemetry 兼容后端。 |
 | `flusher_prometheus`<br>[Prometheus](extended/flusher-prometheus.md) | 社区 | Remote Write 写入 Prometheus 兼容时序库。 |
 | `flusher_pulsar`<br>[Pulsar](extended/flusher-pulsar.md) | 社区<br>[shalousun](https://github.com/shalousun) | 写入 Apache Pulsar。 |
 | `flusher_stdout`<br>[标准输出/文件](extended/flusher-stdout.md) | SLS 官方 | 标准输出或文件，便于本地调试与排障。 |

--- a/docs/cn/plugins/flusher/flushers.md
+++ b/docs/cn/plugins/flusher/flushers.md
@@ -45,7 +45,7 @@ LoongCollector 提供两类输出插件：
 | `flusher_kafka_v2`<br>[Kafka V2](extended/flusher-kafka-v2.md) | 社区<br>[shalousun](https://github.com/shalousun) | 输出到 Kafka，优先推荐。 |
 | `flusher_loki`<br>[Loki](extended/flusher-loki.md) | 社区<br>[abingcbc](https://github.com/abingcbc) | 推送到 Grafana Loki。 |
 | `flusher_otlp_log`<br>[OTLP 日志](extended/flusher-otlp.md) | 社区<br>[liuhaoyang](https://github.com/liuhaoyang) | 兼容 OpenTelemetry Logs 的后端。 |
-| `flusher_otlp_http`<br>[OTLP/HTTP](extended/flusher-otlp-http.md) | 社区 | 通过 OTLP/HTTP 协议写入 OpenTelemetry 兼容后端。 |
+| `flusher_otlp_http`<br>[OTLP/HTTP](extended/flusher-otlp-http.md) | 社区<br>[shalk](https://github.com/shalk) | 通过 OTLP/HTTP 协议写入 OpenTelemetry 兼容后端，支持 Logs、Metrics、Traces。 |
 | `flusher_prometheus`<br>[Prometheus](extended/flusher-prometheus.md) | 社区 | Remote Write 写入 Prometheus 兼容时序库。 |
 | `flusher_pulsar`<br>[Pulsar](extended/flusher-pulsar.md) | 社区<br>[shalousun](https://github.com/shalousun) | 写入 Apache Pulsar。 |
 | `flusher_stdout`<br>[标准输出/文件](extended/flusher-stdout.md) | SLS 官方 | 标准输出或文件，便于本地调试与排障。 |

--- a/docs/cn/plugins/overview.md
+++ b/docs/cn/plugins/overview.md
@@ -175,7 +175,7 @@
 | `flusher_kafka_v2`<br>[Kafka V2](flusher/extended/flusher-kafka-v2.md) | 社区<br>[shalousun](https://github.com/shalousun) | ✓ | ✓ | v1&v2 | 透传未知 | 透传未知 | 将采集到的数据输出到 Kafka。 |
 | `flusher_loki`<br>[Loki](flusher/extended/flusher-loki.md) | 社区<br>[abingcbc](https://github.com/abingcbc) | ✓ | ✓ | v1&v2 | 透传未知 | 透传未知 | 将采集到的数据输出到 Loki。 |
 | `flusher_otlp_log`<br>[OTLP 日志](flusher/extended/flusher-otlp.md) | 社区<br>[liuhaoyang](https://github.com/liuhaoyang) | ✓ | ✓ | v1&v2 | 透传未知 | 透传未知 | 将采集到的数据支持`OpenTelemetry log protocol`的后端。 |
-| `flusher_otlp_http`<br>[OTLP/HTTP](flusher/extended/flusher-otlp-http.md) | 社区 | ✓ | ✓ | v1&v2 | — | — | 将采集到的数据通过 OTLP/HTTP 协议输出到 OpenTelemetry 兼容后端，当前仅支持 Logs。 |
+| `flusher_otlp_http`<br>[OTLP/HTTP](flusher/extended/flusher-otlp-http.md) | 社区<br>[shalk](https://github.com/shalk) | ✓ | ✓ | v1&v2 | v2 | v2 | 将采集到的数据通过 OTLP/HTTP 协议输出到 OpenTelemetry 兼容后端，支持 Logs、Metrics、Traces。 |
 | `flusher_prometheus`<br>[Prometheus](flusher/extended/flusher-prometheus.md) | 社区<br> | — | ✓ | — | v2 | — | 将采集到的数据，经过处理后，通过 http 格式发送到指定的 Prometheus RemoteWrite 地址。 |
 | `flusher_pulsar`<br>[Pulsar](flusher/extended/flusher-pulsar.md) | 社区<br>[shalousun](https://github.com/shalousun) | ✓ | ✓ | v1&v2 | 透传未知 | 透传未知 | 将采集到的数据输出到 Pulsar。 |
 | `flusher_stdout`<br>[标准输出/文件](flusher/extended/flusher-stdout.md) | SLS 官方 | ✓ | ✓ | v1&v2 | v2 | v2 | 将采集到的数据输出到标准输出或文件。 |

--- a/docs/cn/plugins/overview.md
+++ b/docs/cn/plugins/overview.md
@@ -175,6 +175,7 @@
 | `flusher_kafka_v2`<br>[Kafka V2](flusher/extended/flusher-kafka-v2.md) | 社区<br>[shalousun](https://github.com/shalousun) | ✓ | ✓ | v1&v2 | 透传未知 | 透传未知 | 将采集到的数据输出到 Kafka。 |
 | `flusher_loki`<br>[Loki](flusher/extended/flusher-loki.md) | 社区<br>[abingcbc](https://github.com/abingcbc) | ✓ | ✓ | v1&v2 | 透传未知 | 透传未知 | 将采集到的数据输出到 Loki。 |
 | `flusher_otlp_log`<br>[OTLP 日志](flusher/extended/flusher-otlp.md) | 社区<br>[liuhaoyang](https://github.com/liuhaoyang) | ✓ | ✓ | v1&v2 | 透传未知 | 透传未知 | 将采集到的数据支持`OpenTelemetry log protocol`的后端。 |
+| `flusher_otlp_http`<br>[OTLP/HTTP](flusher/extended/flusher-otlp-http.md) | 社区 | ✓ | ✓ | v1&v2 | — | — | 将采集到的数据通过 OTLP/HTTP 协议输出到 OpenTelemetry 兼容后端，当前仅支持 Logs。 |
 | `flusher_prometheus`<br>[Prometheus](flusher/extended/flusher-prometheus.md) | 社区<br> | — | ✓ | — | v2 | — | 将采集到的数据，经过处理后，通过 http 格式发送到指定的 Prometheus RemoteWrite 地址。 |
 | `flusher_pulsar`<br>[Pulsar](flusher/extended/flusher-pulsar.md) | 社区<br>[shalousun](https://github.com/shalousun) | ✓ | ✓ | v1&v2 | 透传未知 | 透传未知 | 将采集到的数据输出到 Pulsar。 |
 | `flusher_stdout`<br>[标准输出/文件](flusher/extended/flusher-stdout.md) | SLS 官方 | ✓ | ✓ | v1&v2 | v2 | v2 | 将采集到的数据输出到标准输出或文件。 |

--- a/plugins/flusher/opentelemetry/flusher_otlp.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp.go
@@ -20,8 +20,11 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -182,11 +185,49 @@ func (f *FlusherOTLP) Stop() error {
 }
 
 func (f *FlusherOTLP) convertPipelinesGroupeEventsToRequest(pipelinegroupeEventSlice []*models.PipelineGroupEvents) (plogotlp.ExportRequest, pmetricotlp.ExportRequest, ptraceotlp.ExportRequest) {
-	return otlpConvertPipelineEventsToRequests(f.converter, pipelinegroupeEventSlice, f.context.GetRuntimeContext())
+	logs := plog.NewLogs()
+	metrics := pmetric.NewMetrics()
+	traces := ptrace.NewTraces()
+
+	for _, ps := range pipelinegroupeEventSlice {
+		resourceLog, resourceMetric, resourceTrace, err := converter.ConvertPipelineEventToOtlpEvent(f.converter, ps)
+		if err != nil {
+			logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherInitAlarm, "init gRPC client options fail, error", err)
+		}
+		if resourceLog.ScopeLogs().Len() > 0 {
+			newLog := logs.ResourceLogs().AppendEmpty()
+			resourceLog.MoveTo(newLog)
+		}
+
+		if resourceMetric.ScopeMetrics().Len() > 0 {
+			newMetric := metrics.ResourceMetrics().AppendEmpty()
+			resourceMetric.MoveTo(newMetric)
+		}
+
+		if resourceTrace.ScopeSpans().Len() > 0 {
+			newTrace := traces.ResourceSpans().AppendEmpty()
+			resourceTrace.MoveTo(newTrace)
+		}
+	}
+
+	return plogotlp.NewExportRequestFromLogs(logs),
+		pmetricotlp.NewExportRequestFromMetrics(metrics),
+		ptraceotlp.NewExportRequestFromTraces(traces)
 }
 
 func (f *FlusherOTLP) convertLogGroupToRequest(logGroupList []*protocol.LogGroup) plogotlp.ExportRequest {
-	return otlpConvertLogGroupToRequest(f.converter, logGroupList)
+	logs := plog.NewLogs()
+	for _, logGroup := range logGroupList {
+		c, _ := f.converter.Do(logGroup)
+		if log, ok := c.(plog.ResourceLogs); ok {
+			if log.ScopeLogs().Len() > 0 {
+				newLog := logs.ResourceLogs().AppendEmpty()
+				log.MoveTo(newLog)
+			}
+		}
+	}
+
+	return plogotlp.NewExportRequestFromLogs(logs)
 }
 
 func (f *FlusherOTLP) flushRequests(log plogotlp.ExportRequest, metric pmetricotlp.ExportRequest, trace ptraceotlp.ExportRequest) error {

--- a/plugins/flusher/opentelemetry/flusher_otlp.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp.go
@@ -20,11 +20,8 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
-	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -185,49 +182,11 @@ func (f *FlusherOTLP) Stop() error {
 }
 
 func (f *FlusherOTLP) convertPipelinesGroupeEventsToRequest(pipelinegroupeEventSlice []*models.PipelineGroupEvents) (plogotlp.ExportRequest, pmetricotlp.ExportRequest, ptraceotlp.ExportRequest) {
-	logs := plog.NewLogs()
-	metrics := pmetric.NewMetrics()
-	traces := ptrace.NewTraces()
-
-	for _, ps := range pipelinegroupeEventSlice {
-		resourceLog, resourceMetric, resourceTrace, err := converter.ConvertPipelineEventToOtlpEvent(f.converter, ps)
-		if err != nil {
-			logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherInitAlarm, "init gRPC client options fail, error", err)
-		}
-		if resourceLog.ScopeLogs().Len() > 0 {
-			newLog := logs.ResourceLogs().AppendEmpty()
-			resourceLog.MoveTo(newLog)
-		}
-
-		if resourceMetric.ScopeMetrics().Len() > 0 {
-			newMetric := metrics.ResourceMetrics().AppendEmpty()
-			resourceMetric.MoveTo(newMetric)
-		}
-
-		if resourceTrace.ScopeSpans().Len() > 0 {
-			newTrace := traces.ResourceSpans().AppendEmpty()
-			resourceTrace.MoveTo(newTrace)
-		}
-	}
-
-	return plogotlp.NewExportRequestFromLogs(logs),
-		pmetricotlp.NewExportRequestFromMetrics(metrics),
-		ptraceotlp.NewExportRequestFromTraces(traces)
+	return otlpConvertPipelineEventsToRequests(f.converter, pipelinegroupeEventSlice, f.context.GetRuntimeContext())
 }
 
 func (f *FlusherOTLP) convertLogGroupToRequest(logGroupList []*protocol.LogGroup) plogotlp.ExportRequest {
-	logs := plog.NewLogs()
-	for _, logGroup := range logGroupList {
-		c, _ := f.converter.Do(logGroup)
-		if log, ok := c.(plog.ResourceLogs); ok {
-			if log.ScopeLogs().Len() > 0 {
-				newLog := logs.ResourceLogs().AppendEmpty()
-				log.MoveTo(newLog)
-			}
-		}
-	}
-
-	return plogotlp.NewExportRequestFromLogs(logs)
+	return otlpConvertLogGroupToRequest(f.converter, logGroupList)
 }
 
 func (f *FlusherOTLP) flushRequests(log plogotlp.ExportRequest, metric pmetricotlp.ExportRequest, trace ptraceotlp.ExportRequest) error {

--- a/plugins/flusher/opentelemetry/flusher_otlp_http.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp_http.go
@@ -1,0 +1,586 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opentelemetry
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/alibaba/ilogtail/pkg/config"
+	"github.com/alibaba/ilogtail/pkg/logger"
+	"github.com/alibaba/ilogtail/pkg/models"
+	"github.com/alibaba/ilogtail/pkg/pipeline"
+	"github.com/alibaba/ilogtail/pkg/pipeline/extensions"
+	"github.com/alibaba/ilogtail/pkg/protocol"
+	converter "github.com/alibaba/ilogtail/pkg/protocol/converter"
+	"github.com/alibaba/ilogtail/pkg/selfmonitor"
+)
+
+const (
+	otlpHTTPEncodingProto = "proto"
+	otlpHTTPEncodingJSON  = "json"
+
+	otlpHTTPCompressionGzip = "gzip"
+	otlpHTTPCompressionNone = "none"
+
+	otlpHTTPLogsPath = "/v1/logs"
+
+	otlpHTTPProtobufContentType = "application/x-protobuf"
+	otlpHTTPJSONContentType     = "application/json"
+
+	// Upper bound of response body bytes read for error message / partial success decoding.
+	// Aligned with the OpenTelemetry Collector otlphttpexporter.
+	otlpHTTPMaxResponseReadBytes = 64 * 1024
+
+	otlpHTTPDefaultTimeout      = 30 * time.Second
+	otlpHTTPDefaultMaxRetry     = 3
+	otlpHTTPDefaultInitialDelay = time.Second
+	otlpHTTPDefaultMaxDelay     = 30 * time.Second
+)
+
+var (
+	_ pipeline.FlusherV1 = (*FlusherOTLPHTTP)(nil)
+	_ pipeline.FlusherV2 = (*FlusherOTLPHTTP)(nil)
+)
+
+// httpDoer is the minimal http.Client surface used by the flusher, so tests can inject a stub.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// otlpHTTPSignalConfig overrides the destination of a single OTLP signal.
+type otlpHTTPSignalConfig struct {
+	// Endpoint is a complete URL. When set it replaces the base Endpoint entirely,
+	// i.e. no signal path such as /v1/logs is appended to it.
+	Endpoint string `json:"Endpoint"`
+	// Headers are merged on top of the flusher level Headers, this signal wins on conflict.
+	Headers map[string]string `json:"Headers"`
+}
+
+type otlpHTTPRetryConfig struct {
+	Enable        bool          `json:"Enable"`
+	MaxRetryTimes int           `json:"MaxRetryTimes"`
+	InitialDelay  time.Duration `json:"InitialDelay"`
+	MaxDelay      time.Duration `json:"MaxDelay"`
+}
+
+// FlusherOTLPHTTP exports data over the OTLP/HTTP protocol, i.e. an HTTP POST carrying a
+// protobuf or JSON encoded OTLP ExportRequest. Protocol behaviour follows the OpenTelemetry
+// Collector otlphttpexporter.
+//
+// Only the Logs signal is supported for now. Metrics and Traces will be added later; the
+// config layout already leaves room for them.
+type FlusherOTLPHTTP struct {
+	Version Version `json:"Version"`
+	// Endpoint is the base URL, e.g. http://collector:4318. The signal path (/v1/logs) is
+	// appended to it. It may be omitted when every used signal sets its own Endpoint.
+	Endpoint string `json:"Endpoint"`
+	// Logs optionally overrides the URL and headers used for the Logs signal.
+	Logs *otlpHTTPSignalConfig `json:"Logs"`
+
+	// Encoding is the OTLP payload encoding, either proto (default) or json.
+	Encoding string `json:"Encoding"`
+	// Compression is the request body compression, either gzip (default) or none.
+	Compression string `json:"Compression"`
+	// Headers are appended to every request.
+	Headers map[string]string `json:"Headers"`
+	// Timeout of a single request, default is 30s.
+	Timeout time.Duration       `json:"Timeout"`
+	Retry   otlpHTTPRetryConfig `json:"Retry"`
+
+	// http.Transport tuning, semantics follow flusher_http.
+	MaxConnsPerHost     int           `json:"MaxConnsPerHost"`
+	MaxIdleConnsPerHost int           `json:"MaxIdleConnsPerHost"`
+	IdleConnTimeout     time.Duration `json:"IdleConnTimeout"`
+	WriteBufferSize     int           `json:"WriteBufferSize"`
+
+	// Authenticator is the name and options of the extensions.ClientAuthenticator extension to use.
+	Authenticator *extensions.ExtensionConfig `json:"Authenticator"`
+	// RequestInterceptors is a chain of extensions.RequestInterceptor extensions to use.
+	RequestInterceptors []extensions.ExtensionConfig `json:"RequestInterceptors"`
+
+	converter *converter.Converter
+	context   pipeline.Context
+	client    httpDoer
+	logClient *otlpHTTPSignalClient
+}
+
+// otlpHTTPSignalClient is the resolved destination of one signal, immutable after Init.
+type otlpHTTPSignalClient struct {
+	url     string
+	headers map[string]string
+}
+
+func NewFlusherOTLPHTTP() *FlusherOTLPHTTP {
+	return &FlusherOTLPHTTP{
+		Version:     v1,
+		Encoding:    otlpHTTPEncodingProto,
+		Compression: otlpHTTPCompressionGzip,
+		Timeout:     otlpHTTPDefaultTimeout,
+		Retry: otlpHTTPRetryConfig{
+			Enable:        true,
+			MaxRetryTimes: otlpHTTPDefaultMaxRetry,
+			InitialDelay:  otlpHTTPDefaultInitialDelay,
+			MaxDelay:      otlpHTTPDefaultMaxDelay,
+		},
+	}
+}
+
+func (f *FlusherOTLPHTTP) Description() string {
+	return "Open Telemetry HTTP flusher for ilogtail"
+}
+
+func (f *FlusherOTLPHTTP) Init(ctx pipeline.Context) error {
+	f.context = ctx
+	logger.Info(f.context.GetRuntimeContext(), "otlp http flusher init", "initializing")
+
+	f.fillDefaults()
+
+	if err := f.validate(); err != nil {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherInitAlarm, "otlp http flusher check config fail, error", err)
+		return err
+	}
+
+	convert, err := f.getConverter()
+	if err != nil {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherInitAlarm, "init otlp http converter fail, error", err)
+		return err
+	}
+	f.converter = convert
+
+	if f.client, err = f.buildHTTPClient(); err != nil {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherInitAlarm, "init otlp http client fail, error", err)
+		return err
+	}
+
+	if logURL := f.buildSignalURL(f.Logs, otlpHTTPLogsPath); logURL != "" {
+		f.logClient = &otlpHTTPSignalClient{url: logURL, headers: f.buildSignalHeaders(f.Logs)}
+		logger.Info(f.context.GetRuntimeContext(), "otlp http logs flusher endpoint", logURL)
+	}
+
+	if f.logClient == nil {
+		err = fmt.Errorf("invalid_otlp_http_configs")
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherInitAlarm, "init otlp http flusher fail, error", "no endpoint configured")
+		return err
+	}
+
+	logger.Info(f.context.GetRuntimeContext(), "otlp http flusher init", "initialized",
+		"encoding", f.Encoding, "compression", f.Compression, "timeout", f.Timeout)
+	return nil
+}
+
+func (f *FlusherOTLPHTTP) fillDefaults() {
+	if f.Version == "" {
+		f.Version = v1
+	}
+	if f.Encoding == "" {
+		f.Encoding = otlpHTTPEncodingProto
+	}
+	if f.Timeout <= 0 {
+		f.Timeout = otlpHTTPDefaultTimeout
+	}
+	if f.Retry.MaxRetryTimes < 0 {
+		f.Retry.MaxRetryTimes = 0
+	}
+	if f.Retry.InitialDelay <= 0 {
+		f.Retry.InitialDelay = otlpHTTPDefaultInitialDelay
+	}
+	if f.Retry.MaxDelay <= 0 {
+		f.Retry.MaxDelay = otlpHTTPDefaultMaxDelay
+	}
+	if f.Retry.MaxDelay < f.Retry.InitialDelay {
+		f.Retry.MaxDelay = f.Retry.InitialDelay
+	}
+}
+
+func (f *FlusherOTLPHTTP) validate() error {
+	switch f.Encoding {
+	case otlpHTTPEncodingProto, otlpHTTPEncodingJSON:
+	default:
+		return fmt.Errorf("unsupported otlp http encoding: %s, only proto and json are supported", f.Encoding)
+	}
+
+	switch f.Compression {
+	case "", otlpHTTPCompressionNone, otlpHTTPCompressionGzip:
+	default:
+		return fmt.Errorf("unsupported otlp http compression: %s, only gzip is supported", f.Compression)
+	}
+	return nil
+}
+
+func (f *FlusherOTLPHTTP) getConverter() (*converter.Converter, error) {
+	switch f.Version {
+	case v1:
+		return converter.NewConverter(converter.ProtocolOtlpV1, converter.EncodingNone, nil, nil, f.context.GetPipelineScopeConfig())
+	default:
+		return nil, fmt.Errorf("unsupported otlp log protocol version : %s", f.Version)
+	}
+}
+
+// buildSignalURL resolves the destination URL of a signal. A signal level Endpoint is used
+// verbatim, otherwise the signal path is appended to the base Endpoint. An empty result means
+// the signal is not configured. Behaviour matches otlphttpexporter's composeSignalURL.
+func (f *FlusherOTLPHTTP) buildSignalURL(signalCfg *otlpHTTPSignalConfig, signalPath string) string {
+	if signalCfg != nil && signalCfg.Endpoint != "" {
+		return signalCfg.Endpoint
+	}
+	if f.Endpoint != "" {
+		return strings.TrimRight(f.Endpoint, "/") + signalPath
+	}
+	return ""
+}
+
+// buildSignalHeaders merges the flusher level headers with the signal level ones, the latter wins.
+func (f *FlusherOTLPHTTP) buildSignalHeaders(signalCfg *otlpHTTPSignalConfig) map[string]string {
+	headers := make(map[string]string, len(f.Headers)+1)
+	for k, v := range f.Headers {
+		headers[k] = v
+	}
+	if signalCfg != nil {
+		for k, v := range signalCfg.Headers {
+			headers[k] = v
+		}
+	}
+	return headers
+}
+
+func (f *FlusherOTLPHTTP) buildHTTPClient() (httpDoer, error) {
+	transport := http.DefaultTransport
+	if dt, ok := transport.(*http.Transport); ok {
+		dt = dt.Clone()
+		if f.MaxConnsPerHost > dt.MaxConnsPerHost {
+			dt.MaxConnsPerHost = f.MaxConnsPerHost
+		}
+		if f.MaxIdleConnsPerHost > dt.MaxIdleConnsPerHost {
+			dt.MaxIdleConnsPerHost = f.MaxIdleConnsPerHost
+		}
+		if f.IdleConnTimeout > dt.IdleConnTimeout {
+			dt.IdleConnTimeout = f.IdleConnTimeout
+		}
+		if f.WriteBufferSize > 0 {
+			dt.WriteBufferSize = f.WriteBufferSize
+		}
+		transport = dt
+	}
+
+	transport, err := f.initRequestInterceptors(transport)
+	if err != nil {
+		return nil, err
+	}
+
+	if f.Authenticator != nil {
+		var auth pipeline.Extension
+		auth, err = f.context.GetExtension(f.Authenticator.Type, f.Authenticator.Options)
+		if err != nil {
+			return nil, fmt.Errorf("get authenticator extension failed: %w", err)
+		}
+		ca, ok := auth.(extensions.ClientAuthenticator)
+		if !ok {
+			return nil, fmt.Errorf("authenticator(%s) not implement interface extensions.ClientAuthenticator", f.Authenticator.Type)
+		}
+		if transport, err = ca.RoundTripper(transport); err != nil {
+			return nil, fmt.Errorf("build authenticator round tripper failed: %w", err)
+		}
+	}
+
+	return &http.Client{Timeout: f.Timeout, Transport: transport}, nil
+}
+
+func (f *FlusherOTLPHTTP) initRequestInterceptors(transport http.RoundTripper) (http.RoundTripper, error) {
+	for i := len(f.RequestInterceptors) - 1; i >= 0; i-- {
+		setting := f.RequestInterceptors[i]
+		ext, err := f.context.GetExtension(setting.Type, setting.Options)
+		if err != nil {
+			return nil, fmt.Errorf("get request interceptor extension(%s) failed: %w", setting.Type, err)
+		}
+		interceptor, ok := ext.(extensions.RequestInterceptor)
+		if !ok {
+			return nil, fmt.Errorf("interceptor(%s) with type %T not implement interface extensions.RequestInterceptor", setting.Type, ext)
+		}
+		if transport, err = interceptor.RoundTripper(transport); err != nil {
+			return nil, fmt.Errorf("build request interceptor(%s) round tripper failed: %w", setting.Type, err)
+		}
+	}
+	return transport, nil
+}
+
+// SetHTTPDoer replaces the underlying HTTP client, it is only meant for tests.
+func (f *FlusherOTLPHTTP) SetHTTPDoer(doer httpDoer) {
+	f.client = doer
+}
+
+// IsReady is ready to flush
+func (f *FlusherOTLPHTTP) IsReady(projectName string, logstoreName string, logstoreKey int64) bool {
+	ready := f.client != nil && f.logClient != nil
+	if !ready {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherReadyAlarm, "otlp http flusher is not ready", "no available endpoint")
+	}
+	return ready
+}
+
+func (f *FlusherOTLPHTTP) SetUrgent(flag bool) {
+}
+
+// Stop ...
+func (f *FlusherOTLPHTTP) Stop() error {
+	if c, ok := f.client.(*http.Client); ok {
+		c.CloseIdleConnections()
+	}
+	return nil
+}
+
+func (f *FlusherOTLPHTTP) Flush(projectName string, logstoreName string, configName string, logGroupList []*protocol.LogGroup) error {
+	if f.logClient == nil {
+		return nil
+	}
+	return f.flushLogRequest(otlpConvertLogGroupToRequest(f.converter, logGroupList))
+}
+
+// Export data to destination, such as gRPC, console, file, etc.
+// It is expected to return no error at most time because IsReady will be called
+// before it to make sure there is space for next data.
+func (f *FlusherOTLPHTTP) Export(pipelinegroupeEventSlice []*models.PipelineGroupEvents, ctx pipeline.PipelineContext) error {
+	logReq, metricReq, traceReq := otlpConvertPipelineEventsToRequests(f.converter, pipelinegroupeEventSlice, f.context.GetRuntimeContext())
+
+	if metricReq.Metrics().ResourceMetrics().Len() > 0 || traceReq.Traces().ResourceSpans().Len() > 0 {
+		logger.Debug(f.context.GetRuntimeContext(), "otlp http flusher dropped metrics/traces",
+			"only the logs signal is supported for now",
+			"resource_metrics", metricReq.Metrics().ResourceMetrics().Len(),
+			"resource_spans", traceReq.Traces().ResourceSpans().Len())
+	}
+
+	if f.logClient == nil {
+		return nil
+	}
+	return f.flushLogRequest(logReq)
+}
+
+func (f *FlusherOTLPHTTP) flushLogRequest(req plogotlp.ExportRequest) error {
+	data, contentType, err := f.marshalLogRequest(req)
+	if err != nil {
+		// A marshal failure is permanent, retrying cannot help.
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "otlp http flusher marshal logs fail, data dropped, error", err)
+		return err
+	}
+
+	if err = f.sendWithRetry(f.logClient, data, contentType); err != nil {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "send log data to otlp http server fail, error", err,
+			"url", f.logClient.url)
+	}
+	return err
+}
+
+func (f *FlusherOTLPHTTP) marshalLogRequest(req plogotlp.ExportRequest) (data []byte, contentType string, err error) {
+	if f.Encoding == otlpHTTPEncodingJSON {
+		data, err = req.MarshalJSON()
+		return data, otlpHTTPJSONContentType, err
+	}
+	data, err = req.MarshalProto()
+	return data, otlpHTTPProtobufContentType, err
+}
+
+func (f *FlusherOTLPHTTP) compressData(data []byte) (body io.Reader, contentEncoding string, err error) {
+	if f.Compression != otlpHTTPCompressionGzip {
+		return bytes.NewReader(data), "", nil
+	}
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err = gw.Write(data); err != nil {
+		return nil, "", err
+	}
+	if err = gw.Close(); err != nil {
+		return nil, "", err
+	}
+	return &buf, otlpHTTPCompressionGzip, nil
+}
+
+func (f *FlusherOTLPHTTP) sendWithRetry(client *otlpHTTPSignalClient, data []byte, contentType string) error {
+	var err error
+	for attempt := 0; attempt <= f.Retry.MaxRetryTimes; attempt++ {
+		retryable, retryAfter, e := f.sendOnce(client, data, contentType)
+		if e == nil {
+			return nil
+		}
+		err = e
+		if !retryable || !f.Retry.Enable || attempt == f.Retry.MaxRetryTimes {
+			break
+		}
+		<-time.After(f.nextRetryDelay(attempt, retryAfter))
+	}
+	return err
+}
+
+// sendOnce performs a single OTLP/HTTP POST. It reports whether the failure is worth retrying
+// and, for throttled responses, the server suggested delay.
+func (f *FlusherOTLPHTTP) sendOnce(client *otlpHTTPSignalClient, data []byte,
+	contentType string) (retryable bool, retryAfter time.Duration, err error) {
+	body, contentEncoding, err := f.compressData(data)
+	if err != nil {
+		return false, 0, fmt.Errorf("compress otlp payload failed: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, client.url, body)
+	if err != nil {
+		return false, 0, fmt.Errorf("create otlp http request failed: %w", err)
+	}
+
+	// User headers first, then the protocol headers we know are correct for the body we built,
+	// so a stale Content-Type/Content-Encoding in the config cannot corrupt the request.
+	for k, v := range client.headers {
+		req.Header.Set(k, v)
+	}
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", config.UserAgent)
+	}
+	req.Header.Set("Content-Type", contentType)
+	if contentEncoding != "" {
+		req.Header.Set("Content-Encoding", contentEncoding)
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		// Network level failures (connection refused, timeout, reset) are worth retrying.
+		return true, 0, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, otlpHTTPMaxResponseReadBytes))
+	if readErr != nil {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "otlp http flusher read response fail, error", readErr)
+	}
+	// Drain the rest so the connection can be reused.
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode <= 299 {
+		f.checkLogPartialSuccess(respBody)
+		return false, 0, nil
+	}
+
+	err = fmt.Errorf("otlp http server returned %s: %s", resp.Status, f.decodeErrorStatus(respBody))
+
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+		// Throttled, the server may tell us how long to wait.
+		return true, parseRetryAfterDuration(resp.Header.Get("Retry-After")), err
+	case http.StatusBadGateway, http.StatusGatewayTimeout:
+		return true, 0, err
+	default:
+		// Everything else, including 500, is permanent per the OTLP/HTTP specification.
+		return false, 0, err
+	}
+}
+
+func (f *FlusherOTLPHTTP) nextRetryDelay(attempt int, retryAfter time.Duration) time.Duration {
+	delay := f.Retry.MaxDelay
+	if attempt < 32 {
+		if d := f.Retry.InitialDelay << time.Duration(attempt); d > 0 && d < f.Retry.MaxDelay {
+			delay = d
+		}
+	}
+
+	// Apply an about equally distributed jitter in the second half of the interval, such that
+	// the wait time falls into [delay/2, delay].
+	half := int64(delay / 2)
+	if jitter, err := rand.Int(rand.Reader, big.NewInt(half+1)); err == nil {
+		delay = time.Duration(half + jitter.Int64())
+	}
+
+	if retryAfter > delay {
+		return retryAfter
+	}
+	return delay
+}
+
+// decodeErrorStatus renders the error body, which is a protobuf encoded google.rpc.Status for
+// protobuf requests, into a log friendly message.
+func (f *FlusherOTLPHTTP) decodeErrorStatus(body []byte) string {
+	if len(body) == 0 {
+		return "<empty body>"
+	}
+
+	var status spb.Status
+	if err := proto.Unmarshal(body, &status); err == nil && status.GetMessage() != "" {
+		return fmt.Sprintf("code=%d message=%s", status.GetCode(), status.GetMessage())
+	}
+	return string(body)
+}
+
+// checkLogPartialSuccess warns about records the server rejected. A partial success is not an
+// error for the retry machinery, resending the whole batch would duplicate the accepted records.
+func (f *FlusherOTLPHTTP) checkLogPartialSuccess(body []byte) {
+	if len(body) == 0 {
+		return
+	}
+
+	resp := plogotlp.NewExportResponse()
+	var err error
+	if f.Encoding == otlpHTTPEncodingJSON {
+		err = resp.UnmarshalJSON(body)
+	} else {
+		err = resp.UnmarshalProto(body)
+	}
+	if err != nil {
+		logger.Debug(f.context.GetRuntimeContext(), "otlp http flusher cannot decode export response", err)
+		return
+	}
+
+	partial := resp.PartialSuccess()
+	if partial.RejectedLogRecords() != 0 || partial.ErrorMessage() != "" {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "otlp http server partially rejected logs",
+			"rejected_log_records", partial.RejectedLogRecords(), "message", partial.ErrorMessage())
+	}
+}
+
+// parseRetryAfterDuration reads a Retry-After header value, which is either delay seconds or an
+// HTTP date. It returns 0 when the value is absent, unparsable or already in the past.
+func parseRetryAfterDuration(header string) time.Duration {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.ParseInt(header, 10, 64); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+
+	if date, err := http.ParseTime(header); err == nil {
+		if delay := time.Until(date); delay > 0 {
+			return delay
+		}
+	}
+	return 0
+}
+
+func init() {
+	pipeline.Flushers["flusher_otlp_http"] = func() pipeline.Flusher {
+		return NewFlusherOTLPHTTP()
+	}
+}

--- a/plugins/flusher/opentelemetry/flusher_otlp_http.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp_http.go
@@ -161,13 +161,13 @@ type otlpHTTPSignalClient struct {
 	partialSuccess func(body []byte, jsonEncoding bool) (rejected int64, message string, err error)
 }
 
-// otlpRequest is the marshalling surface shared by the logs, metrics and traces export requests.
+// otlpRequest is the marshaling surface shared by the logs, metrics and traces export requests.
 type otlpRequest interface {
 	MarshalProto() ([]byte, error)
 	MarshalJSON() ([]byte, error)
 }
 
-// otlpUnmarshaler is the unmarshalling surface shared by the OTLP export request and response
+// otlpUnmarshaler is the unmarshaling surface shared by the OTLP export request and response
 // wrappers, it lets the encoding be picked once for every signal.
 type otlpUnmarshaler interface {
 	UnmarshalProto(data []byte) error

--- a/plugins/flusher/opentelemetry/flusher_otlp_http.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp_http.go
@@ -24,9 +24,12 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 
@@ -47,7 +50,14 @@ const (
 	otlpHTTPCompressionGzip = "gzip"
 	otlpHTTPCompressionNone = "none"
 
-	otlpHTTPLogsPath = "/v1/logs"
+	otlpHTTPLogsPath    = "/v1/logs"
+	otlpHTTPMetricsPath = "/v1/metrics"
+	otlpHTTPTracesPath  = "/v1/traces"
+
+	// Signal names, only used in log messages.
+	otlpHTTPSignalLogs    = "logs"
+	otlpHTTPSignalMetrics = "metrics"
+	otlpHTTPSignalTraces  = "traces"
 
 	otlpHTTPProtobufContentType = "application/x-protobuf"
 	otlpHTTPJSONContentType     = "application/json"
@@ -89,18 +99,22 @@ type otlpHTTPRetryConfig struct {
 }
 
 // FlusherOTLPHTTP exports data over the OTLP/HTTP protocol, i.e. an HTTP POST carrying a
-// protobuf or JSON encoded OTLP ExportRequest. Protocol behaviour follows the OpenTelemetry
+// protobuf or JSON encoded OTLP ExportRequest. Protocol behavior follows the OpenTelemetry
 // Collector otlphttpexporter.
 //
-// Only the Logs signal is supported for now. Metrics and Traces will be added later; the
-// config layout already leaves room for them.
+// All three signals are supported through the v2 Export entry point. The v1 Flush entry point
+// only carries logs, since protocol.LogGroup has no notion of metrics or traces.
 type FlusherOTLPHTTP struct {
 	Version Version `json:"Version"`
-	// Endpoint is the base URL, e.g. http://collector:4318. The signal path (/v1/logs) is
-	// appended to it. It may be omitted when every used signal sets its own Endpoint.
+	// Endpoint is the base URL, e.g. http://collector:4318. The signal path (/v1/logs,
+	// /v1/metrics, /v1/traces) is appended to it, so a single Endpoint enables every signal.
+	// It may be omitted when every used signal sets its own Endpoint.
 	Endpoint string `json:"Endpoint"`
-	// Logs optionally overrides the URL and headers used for the Logs signal.
-	Logs *otlpHTTPSignalConfig `json:"Logs"`
+	// Logs, Metrics and Traces optionally override the URL and headers of a single signal.
+	// A signal with neither a base Endpoint nor its own Endpoint is disabled, its data is dropped.
+	Logs    *otlpHTTPSignalConfig `json:"Logs"`
+	Metrics *otlpHTTPSignalConfig `json:"Metrics"`
+	Traces  *otlpHTTPSignalConfig `json:"Traces"`
 
 	// Encoding is the OTLP payload encoding, either proto (default) or json.
 	Encoding string `json:"Encoding"`
@@ -123,16 +137,41 @@ type FlusherOTLPHTTP struct {
 	// RequestInterceptors is a chain of extensions.RequestInterceptor extensions to use.
 	RequestInterceptors []extensions.ExtensionConfig `json:"RequestInterceptors"`
 
-	converter *converter.Converter
-	context   pipeline.Context
-	client    httpDoer
-	logClient *otlpHTTPSignalClient
+	converter    *converter.Converter
+	context      pipeline.Context
+	client       httpDoer
+	logClient    *otlpHTTPSignalClient
+	metricClient *otlpHTTPSignalClient
+	traceClient  *otlpHTTPSignalClient
+
+	// stopCh is closed by Stop, it aborts a retry backoff that is currently waiting so that
+	// shutdown is not held hostage by a server suggested Retry-After.
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 // otlpHTTPSignalClient is the resolved destination of one signal, immutable after Init.
 type otlpHTTPSignalClient struct {
+	// signal is logs, metrics or traces, it is only used in log messages.
+	signal  string
 	url     string
 	headers map[string]string
+	// partialSuccess decodes an accepted response body into the number of rejected records and
+	// the server message. The rejected counter is signal specific: log records, data points or spans.
+	partialSuccess func(body []byte, jsonEncoding bool) (rejected int64, message string, err error)
+}
+
+// otlpRequest is the marshalling surface shared by the logs, metrics and traces export requests.
+type otlpRequest interface {
+	MarshalProto() ([]byte, error)
+	MarshalJSON() ([]byte, error)
+}
+
+// otlpUnmarshaler is the unmarshalling surface shared by the OTLP export request and response
+// wrappers, it lets the encoding be picked once for every signal.
+type otlpUnmarshaler interface {
+	UnmarshalProto(data []byte) error
+	UnmarshalJSON(data []byte) error
 }
 
 func NewFlusherOTLPHTTP() *FlusherOTLPHTTP {
@@ -147,6 +186,7 @@ func NewFlusherOTLPHTTP() *FlusherOTLPHTTP {
 			InitialDelay:  otlpHTTPDefaultInitialDelay,
 			MaxDelay:      otlpHTTPDefaultMaxDelay,
 		},
+		stopCh: make(chan struct{}),
 	}
 }
 
@@ -157,6 +197,11 @@ func (f *FlusherOTLPHTTP) Description() string {
 func (f *FlusherOTLPHTTP) Init(ctx pipeline.Context) error {
 	f.context = ctx
 	logger.Info(f.context.GetRuntimeContext(), "otlp http flusher init", "initializing")
+
+	if f.stopCh == nil {
+		// The flusher may have been built by the config loader rather than NewFlusherOTLPHTTP.
+		f.stopCh = make(chan struct{})
+	}
 
 	f.fillDefaults()
 
@@ -177,12 +222,11 @@ func (f *FlusherOTLPHTTP) Init(ctx pipeline.Context) error {
 		return err
 	}
 
-	if logURL := f.buildSignalURL(f.Logs, otlpHTTPLogsPath); logURL != "" {
-		f.logClient = &otlpHTTPSignalClient{url: logURL, headers: f.buildSignalHeaders(f.Logs)}
-		logger.Info(f.context.GetRuntimeContext(), "otlp http logs flusher endpoint", logURL)
-	}
+	f.logClient = f.buildSignalClient(otlpHTTPSignalLogs, f.Logs, otlpHTTPLogsPath, decodeLogsPartialSuccess)
+	f.metricClient = f.buildSignalClient(otlpHTTPSignalMetrics, f.Metrics, otlpHTTPMetricsPath, decodeMetricsPartialSuccess)
+	f.traceClient = f.buildSignalClient(otlpHTTPSignalTraces, f.Traces, otlpHTTPTracesPath, decodeTracesPartialSuccess)
 
-	if f.logClient == nil {
+	if f.logClient == nil && f.metricClient == nil && f.traceClient == nil {
 		err = fmt.Errorf("invalid_otlp_http_configs")
 		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherInitAlarm, "init otlp http flusher fail, error", "no endpoint configured")
 		return err
@@ -199,6 +243,9 @@ func (f *FlusherOTLPHTTP) fillDefaults() {
 	}
 	if f.Encoding == "" {
 		f.Encoding = otlpHTTPEncodingProto
+	}
+	if f.Compression == "" {
+		f.Compression = otlpHTTPCompressionGzip
 	}
 	if f.Timeout <= 0 {
 		f.Timeout = otlpHTTPDefaultTimeout
@@ -225,9 +272,9 @@ func (f *FlusherOTLPHTTP) validate() error {
 	}
 
 	switch f.Compression {
-	case "", otlpHTTPCompressionNone, otlpHTTPCompressionGzip:
+	case otlpHTTPCompressionNone, otlpHTTPCompressionGzip:
 	default:
-		return fmt.Errorf("unsupported otlp http compression: %s, only gzip is supported", f.Compression)
+		return fmt.Errorf("unsupported otlp http compression: %s, only gzip and none are supported", f.Compression)
 	}
 	return nil
 }
@@ -241,9 +288,27 @@ func (f *FlusherOTLPHTTP) getConverter() (*converter.Converter, error) {
 	}
 }
 
+// buildSignalClient resolves one signal into a client, or nil when the signal has no destination
+// and is therefore disabled.
+func (f *FlusherOTLPHTTP) buildSignalClient(signal string, signalCfg *otlpHTTPSignalConfig, signalPath string,
+	partialSuccess func(body []byte, jsonEncoding bool) (int64, string, error)) *otlpHTTPSignalClient {
+	url := f.buildSignalURL(signalCfg, signalPath)
+	if url == "" {
+		return nil
+	}
+
+	logger.Info(f.context.GetRuntimeContext(), "otlp http flusher endpoint", url, "signal", signal)
+	return &otlpHTTPSignalClient{
+		signal:         signal,
+		url:            url,
+		headers:        f.buildSignalHeaders(signalCfg),
+		partialSuccess: partialSuccess,
+	}
+}
+
 // buildSignalURL resolves the destination URL of a signal. A signal level Endpoint is used
 // verbatim, otherwise the signal path is appended to the base Endpoint. An empty result means
-// the signal is not configured. Behaviour matches otlphttpexporter's composeSignalURL.
+// the signal is not configured. Behavior matches otlphttpexporter's composeSignalURL.
 func (f *FlusherOTLPHTTP) buildSignalURL(signalCfg *otlpHTTPSignalConfig, signalPath string) string {
 	if signalCfg != nil && signalCfg.Endpoint != "" {
 		return signalCfg.Endpoint
@@ -335,7 +400,7 @@ func (f *FlusherOTLPHTTP) SetHTTPDoer(doer httpDoer) {
 
 // IsReady is ready to flush
 func (f *FlusherOTLPHTTP) IsReady(projectName string, logstoreName string, logstoreKey int64) bool {
-	ready := f.client != nil && f.logClient != nil
+	ready := f.client != nil && (f.logClient != nil || f.metricClient != nil || f.traceClient != nil)
 	if !ready {
 		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherReadyAlarm, "otlp http flusher is not ready", "no available endpoint")
 	}
@@ -347,6 +412,12 @@ func (f *FlusherOTLPHTTP) SetUrgent(flag bool) {
 
 // Stop ...
 func (f *FlusherOTLPHTTP) Stop() error {
+	// Wake up a retry backoff that is currently waiting, so that shutdown is not blocked by it.
+	f.stopOnce.Do(func() {
+		if f.stopCh != nil {
+			close(f.stopCh)
+		}
+	})
 	if c, ok := f.client.(*http.Client); ok {
 		c.CloseIdleConnections()
 	}
@@ -355,46 +426,63 @@ func (f *FlusherOTLPHTTP) Stop() error {
 
 func (f *FlusherOTLPHTTP) Flush(projectName string, logstoreName string, configName string, logGroupList []*protocol.LogGroup) error {
 	if f.logClient == nil {
+		// The logs signal is disabled, so there is nothing to convert the log groups into.
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "otlp http flusher dropped data",
+			"no endpoint configured for this signal", "signal", otlpHTTPSignalLogs)
 		return nil
 	}
-	return f.flushLogRequest(otlpConvertLogGroupToRequest(f.converter, logGroupList))
+	// v1 log groups only carry logs.
+	req := otlpConvertLogGroupToRequest(f.converter, logGroupList)
+	return f.exportSignal(f.logClient, req, otlpHTTPSignalLogs, req.Logs().LogRecordCount())
 }
 
 // Export data to destination, such as gRPC, console, file, etc.
 // It is expected to return no error at most time because IsReady will be called
 // before it to make sure there is space for next data.
-func (f *FlusherOTLPHTTP) Export(pipelinegroupeEventSlice []*models.PipelineGroupEvents, ctx pipeline.PipelineContext) error {
-	logReq, metricReq, traceReq := otlpConvertPipelineEventsToRequests(f.converter, pipelinegroupeEventSlice, f.context.GetRuntimeContext())
+func (f *FlusherOTLPHTTP) Export(groupEventsSlice []*models.PipelineGroupEvents, ctx pipeline.PipelineContext) error {
+	logReq, metricReq, traceReq := otlpConvertPipelineEventsToRequests(f.context.GetRuntimeContext(), f.converter, groupEventsSlice)
 
-	if metricReq.Metrics().ResourceMetrics().Len() > 0 || traceReq.Traces().ResourceSpans().Len() > 0 {
-		logger.Debug(f.context.GetRuntimeContext(), "otlp http flusher dropped metrics/traces",
-			"only the logs signal is supported for now",
-			"resource_metrics", metricReq.Metrics().ResourceMetrics().Len(),
-			"resource_spans", traceReq.Traces().ResourceSpans().Len())
+	// One request per non empty signal, sent one after another. A batch normally carries a single
+	// event type, so in practice this is a single request. The first failure is reported, the
+	// remaining signals are still attempted so that one broken signal cannot block the others.
+	err := f.exportSignal(f.logClient, logReq, otlpHTTPSignalLogs, logReq.Logs().LogRecordCount())
+	if e := f.exportSignal(f.metricClient, metricReq, otlpHTTPSignalMetrics, metricReq.Metrics().DataPointCount()); e != nil && err == nil {
+		err = e
 	}
-
-	if f.logClient == nil {
-		return nil
-	}
-	return f.flushLogRequest(logReq)
-}
-
-func (f *FlusherOTLPHTTP) flushLogRequest(req plogotlp.ExportRequest) error {
-	data, contentType, err := f.marshalLogRequest(req)
-	if err != nil {
-		// A marshal failure is permanent, retrying cannot help.
-		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "otlp http flusher marshal logs fail, data dropped, error", err)
-		return err
-	}
-
-	if err = f.sendWithRetry(f.logClient, data, contentType); err != nil {
-		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "send log data to otlp http server fail, error", err,
-			"url", f.logClient.url)
+	if e := f.exportSignal(f.traceClient, traceReq, otlpHTTPSignalTraces, traceReq.Traces().SpanCount()); e != nil && err == nil {
+		err = e
 	}
 	return err
 }
 
-func (f *FlusherOTLPHTTP) marshalLogRequest(req plogotlp.ExportRequest) (data []byte, contentType string, err error) {
+// exportSignal sends one signal, unless it carries no data or has no configured destination.
+func (f *FlusherOTLPHTTP) exportSignal(client *otlpHTTPSignalClient, req otlpRequest, signal string, count int) error {
+	if count == 0 {
+		// Nothing to send, an empty OTLP request would only waste a round trip.
+		return nil
+	}
+	if client == nil {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "otlp http flusher dropped data",
+			"no endpoint configured for this signal", "signal", signal, "count", count)
+		return nil
+	}
+
+	data, contentType, err := f.marshalRequest(req)
+	if err != nil {
+		// A marshal failure is permanent, retrying cannot help.
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "otlp http flusher marshal request fail, data dropped, error", err,
+			"signal", client.signal)
+		return err
+	}
+
+	if err = f.sendWithRetry(client, data, contentType); err != nil {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "send data to otlp http server fail, error", err,
+			"signal", client.signal, "url", client.url)
+	}
+	return err
+}
+
+func (f *FlusherOTLPHTTP) marshalRequest(req otlpRequest) (data []byte, contentType string, err error) {
 	if f.Encoding == otlpHTTPEncodingJSON {
 		data, err = req.MarshalJSON()
 		return data, otlpHTTPJSONContentType, err
@@ -430,9 +518,26 @@ func (f *FlusherOTLPHTTP) sendWithRetry(client *otlpHTTPSignalClient, data []byt
 		if !retryable || !f.Retry.Enable || attempt == f.Retry.MaxRetryTimes {
 			break
 		}
-		<-time.After(f.nextRetryDelay(attempt, retryAfter))
+		if !f.waitBeforeRetry(f.nextRetryDelay(attempt, retryAfter)) {
+			// Stopping, give up instead of holding the flush goroutine hostage.
+			break
+		}
 	}
 	return err
+}
+
+// waitBeforeRetry sleeps for delay, unless Stop is called first. It reports whether the wait
+// completed, i.e. whether another attempt should be made.
+func (f *FlusherOTLPHTTP) waitBeforeRetry(delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-f.stopCh:
+		// A nil stopCh never fires, which is exactly the pre-Init behavior.
+		return false
+	}
 }
 
 // sendOnce performs a single OTLP/HTTP POST. It reports whether the failure is worth retrying
@@ -460,6 +565,10 @@ func (f *FlusherOTLPHTTP) sendOnce(client *otlpHTTPSignalClient, data []byte,
 	req.Header.Set("Content-Type", contentType)
 	if contentEncoding != "" {
 		req.Header.Set("Content-Encoding", contentEncoding)
+	} else {
+		// The body is not compressed, so a Content-Encoding coming from the config must go, it
+		// would make the server decode a body that was never encoded.
+		req.Header.Del("Content-Encoding")
 	}
 
 	resp, err := f.client.Do(req)
@@ -477,7 +586,7 @@ func (f *FlusherOTLPHTTP) sendOnce(client *otlpHTTPSignalClient, data []byte,
 	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode <= 299 {
-		f.checkLogPartialSuccess(respBody)
+		f.checkPartialSuccess(client, respBody)
 		return false, 0, nil
 	}
 
@@ -510,7 +619,12 @@ func (f *FlusherOTLPHTTP) nextRetryDelay(attempt int, retryAfter time.Duration) 
 		delay = time.Duration(half + jitter.Int64())
 	}
 
+	// A server suggested Retry-After raises the delay, but never above MaxDelay: it is external
+	// input, and honoring an arbitrarily large value would park the flush goroutine for that long.
 	if retryAfter > delay {
+		if retryAfter > f.Retry.MaxDelay {
+			return f.Retry.MaxDelay
+		}
 		return retryAfter
 	}
 	return delay
@@ -530,30 +644,57 @@ func (f *FlusherOTLPHTTP) decodeErrorStatus(body []byte) string {
 	return string(body)
 }
 
-// checkLogPartialSuccess warns about records the server rejected. A partial success is not an
+// checkPartialSuccess warns about records the server rejected. A partial success is not an
 // error for the retry machinery, resending the whole batch would duplicate the accepted records.
-func (f *FlusherOTLPHTTP) checkLogPartialSuccess(body []byte) {
+func (f *FlusherOTLPHTTP) checkPartialSuccess(client *otlpHTTPSignalClient, body []byte) {
 	if len(body) == 0 {
 		return
 	}
 
-	resp := plogotlp.NewExportResponse()
-	var err error
-	if f.Encoding == otlpHTTPEncodingJSON {
-		err = resp.UnmarshalJSON(body)
-	} else {
-		err = resp.UnmarshalProto(body)
-	}
+	rejected, message, err := client.partialSuccess(body, f.Encoding == otlpHTTPEncodingJSON)
 	if err != nil {
 		logger.Debug(f.context.GetRuntimeContext(), "otlp http flusher cannot decode export response", err)
 		return
 	}
 
-	partial := resp.PartialSuccess()
-	if partial.RejectedLogRecords() != 0 || partial.ErrorMessage() != "" {
-		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "otlp http server partially rejected logs",
-			"rejected_log_records", partial.RejectedLogRecords(), "message", partial.ErrorMessage())
+	if rejected != 0 || message != "" {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherFlushAlarm, "otlp http server partially rejected data",
+			"signal", client.signal, "rejected", rejected, "message", message)
 	}
+}
+
+func decodeLogsPartialSuccess(body []byte, jsonEncoding bool) (int64, string, error) {
+	resp := plogotlp.NewExportResponse()
+	if err := unmarshalOTLP(resp, body, jsonEncoding); err != nil {
+		return 0, "", err
+	}
+	partial := resp.PartialSuccess()
+	return partial.RejectedLogRecords(), partial.ErrorMessage(), nil
+}
+
+func decodeMetricsPartialSuccess(body []byte, jsonEncoding bool) (int64, string, error) {
+	resp := pmetricotlp.NewExportResponse()
+	if err := unmarshalOTLP(resp, body, jsonEncoding); err != nil {
+		return 0, "", err
+	}
+	partial := resp.PartialSuccess()
+	return partial.RejectedDataPoints(), partial.ErrorMessage(), nil
+}
+
+func decodeTracesPartialSuccess(body []byte, jsonEncoding bool) (int64, string, error) {
+	resp := ptraceotlp.NewExportResponse()
+	if err := unmarshalOTLP(resp, body, jsonEncoding); err != nil {
+		return 0, "", err
+	}
+	partial := resp.PartialSuccess()
+	return partial.RejectedSpans(), partial.ErrorMessage(), nil
+}
+
+func unmarshalOTLP(msg otlpUnmarshaler, body []byte, jsonEncoding bool) error {
+	if jsonEncoding {
+		return msg.UnmarshalJSON(body)
+	}
+	return msg.UnmarshalProto(body)
 }
 
 // parseRetryAfterDuration reads a Retry-After header value, which is either delay seconds or an

--- a/plugins/flusher/opentelemetry/flusher_otlp_http_test.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp_http_test.go
@@ -27,10 +27,13 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/alibaba/ilogtail/pkg/helper"
+	"github.com/alibaba/ilogtail/pkg/models"
 	"github.com/alibaba/ilogtail/pkg/pipeline"
 	"github.com/alibaba/ilogtail/plugins/test/mock"
 )
@@ -103,8 +106,8 @@ func (s *otlpHTTPTestServer) callCount() int { return int(atomic.LoadInt32(&s.ca
 
 func (s *otlpHTTPTestServer) close() { s.server.Close() }
 
-// decodeLogRequest turns a captured request body back into an OTLP logs export request.
-func decodeLogRequest(t *testing.T, req capturedRequest, encoding string) plogotlp.ExportRequest {
+// decodeRequestBody decompresses a captured request body when it was gzip encoded.
+func decodeRequestBody(t *testing.T, req capturedRequest) []byte {
 	t.Helper()
 	raw := req.body
 	if req.contentEncoding == otlpHTTPCompressionGzip {
@@ -114,15 +117,30 @@ func decodeLogRequest(t *testing.T, req capturedRequest, encoding string) plogot
 		convey.So(err, convey.ShouldBeNil)
 		convey.So(gr.Close(), convey.ShouldBeNil)
 	}
+	return raw
+}
 
+// decodeLogRequest turns a captured request body back into an OTLP logs export request.
+func decodeLogRequest(t *testing.T, req capturedRequest, encoding string) plogotlp.ExportRequest {
+	t.Helper()
 	out := plogotlp.NewExportRequest()
-	var err error
-	if encoding == otlpHTTPEncodingJSON {
-		err = out.UnmarshalJSON(raw)
-	} else {
-		err = out.UnmarshalProto(raw)
-	}
-	convey.So(err, convey.ShouldBeNil)
+	convey.So(unmarshalOTLP(out, decodeRequestBody(t, req), encoding == otlpHTTPEncodingJSON), convey.ShouldBeNil)
+	return out
+}
+
+// decodeMetricRequest turns a captured request body back into an OTLP metrics export request.
+func decodeMetricRequest(t *testing.T, req capturedRequest, encoding string) pmetricotlp.ExportRequest {
+	t.Helper()
+	out := pmetricotlp.NewExportRequest()
+	convey.So(unmarshalOTLP(out, decodeRequestBody(t, req), encoding == otlpHTTPEncodingJSON), convey.ShouldBeNil)
+	return out
+}
+
+// decodeTraceRequest turns a captured request body back into an OTLP traces export request.
+func decodeTraceRequest(t *testing.T, req capturedRequest, encoding string) ptraceotlp.ExportRequest {
+	t.Helper()
+	out := ptraceotlp.NewExportRequest()
+	convey.So(unmarshalOTLP(out, decodeRequestBody(t, req), encoding == otlpHTTPEncodingJSON), convey.ShouldBeNil)
 	return out
 }
 
@@ -151,12 +169,14 @@ func Test_FlusherOTLPHTTP_Init(t *testing.T) {
 			convey.So(err.Error(), convey.ShouldEqual, "invalid_otlp_http_configs")
 		})
 
-		convey.Convey("When only the base endpoint is set, the signal path should be appended", func() {
+		convey.Convey("When only the base endpoint is set, every signal path should be appended", func() {
 			f := NewFlusherOTLPHTTP()
 			f.Endpoint = "http://127.0.0.1:4318"
 			convey.So(f.Init(logCtx), convey.ShouldBeNil)
 			convey.So(f.logClient, convey.ShouldNotBeNil)
 			convey.So(f.logClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/logs")
+			convey.So(f.metricClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/metrics")
+			convey.So(f.traceClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/traces")
 			convey.So(f.IsReady("p", "l", 1), convey.ShouldBeTrue)
 			convey.So(f.Stop(), convey.ShouldBeNil)
 		})
@@ -166,6 +186,7 @@ func Test_FlusherOTLPHTTP_Init(t *testing.T) {
 			f.Endpoint = "http://127.0.0.1:4318/"
 			convey.So(f.Init(logCtx), convey.ShouldBeNil)
 			convey.So(f.logClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/logs")
+			convey.So(f.metricClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/metrics")
 		})
 
 		convey.Convey("When the Logs endpoint is set, it should be used verbatim", func() {
@@ -174,13 +195,33 @@ func Test_FlusherOTLPHTTP_Init(t *testing.T) {
 			f.Logs = &otlpHTTPSignalConfig{Endpoint: "http://otherhost:8080/custom/logs"}
 			convey.So(f.Init(logCtx), convey.ShouldBeNil)
 			convey.So(f.logClient.url, convey.ShouldEqual, "http://otherhost:8080/custom/logs")
+			// The other signals keep following the base endpoint.
+			convey.So(f.metricClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/metrics")
 		})
 
-		convey.Convey("When only the Logs endpoint is set, Init should succeed", func() {
+		convey.Convey("When only the Logs endpoint is set, the other signals stay disabled", func() {
 			f := NewFlusherOTLPHTTP()
 			f.Logs = &otlpHTTPSignalConfig{Endpoint: "http://127.0.0.1:4318/v1/logs"}
 			convey.So(f.Init(logCtx), convey.ShouldBeNil)
 			convey.So(f.logClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/logs")
+			convey.So(f.metricClient, convey.ShouldBeNil)
+			convey.So(f.traceClient, convey.ShouldBeNil)
+		})
+
+		convey.Convey("When only the Metrics endpoint is set, Init should succeed", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Metrics = &otlpHTTPSignalConfig{Endpoint: "http://127.0.0.1:4318/v1/metrics"}
+			convey.So(f.Init(logCtx), convey.ShouldBeNil)
+			convey.So(f.logClient, convey.ShouldBeNil)
+			convey.So(f.metricClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/metrics")
+			convey.So(f.IsReady("p", "l", 1), convey.ShouldBeTrue)
+		})
+
+		convey.Convey("When only the Traces endpoint is set, Init should succeed", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Traces = &otlpHTTPSignalConfig{Endpoint: "http://127.0.0.1:4318/v1/traces"}
+			convey.So(f.Init(logCtx), convey.ShouldBeNil)
+			convey.So(f.traceClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/traces")
 		})
 
 		convey.Convey("Defaults should be filled in", func() {
@@ -215,11 +256,12 @@ func Test_FlusherOTLPHTTP_Init(t *testing.T) {
 			convey.So(f.Init(logCtx), convey.ShouldBeError)
 		})
 
-		convey.Convey("An empty compression means no compression", func() {
+		convey.Convey("An empty compression falls back to the gzip default", func() {
 			f := NewFlusherOTLPHTTP()
 			f.Endpoint = "http://127.0.0.1:4318"
 			f.Compression = ""
 			convey.So(f.Init(logCtx), convey.ShouldBeNil)
+			convey.So(f.Compression, convey.ShouldEqual, otlpHTTPCompressionGzip)
 		})
 	})
 }
@@ -371,15 +413,37 @@ func Test_FlusherOTLPHTTP_Flush_HeadersCannotCorruptContentType(t *testing.T) {
 	})
 }
 
+func Test_FlusherOTLPHTTP_Flush_HeadersCannotSetContentEncodingWhenUncompressed(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("With compression disabled a Content-Encoding from the config must be dropped", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Endpoint = server.server.URL
+				f.Compression = otlpHTTPCompressionNone
+				f.Headers = map[string]string{"Content-Encoding": otlpHTTPCompressionGzip}
+			})
+
+			convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeNil)
+
+			req := <-server.requests
+			// The body is not compressed, so the header must not claim it is.
+			convey.So(req.contentEncoding, convey.ShouldBeEmpty)
+			convey.So(decodeLogRequest(t, req, otlpHTTPEncodingProto).Logs().LogRecordCount(), convey.ShouldBeGreaterThan, 0)
+		})
+	})
+}
+
 func Test_FlusherOTLPHTTP_Flush_Empty(t *testing.T) {
 	convey.Convey("Given an OTLP/HTTP server", t, func() {
 		server := newOTLPHTTPTestServer(http.StatusOK)
 		defer server.close()
 
-		convey.Convey("Flushing an empty log group list still succeeds", func() {
+		convey.Convey("Flushing an empty log group list sends nothing", func() {
 			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
 			convey.So(f.Flush("p", "l", "c", nil), convey.ShouldBeNil)
-			convey.So(server.callCount(), convey.ShouldEqual, 1)
+			convey.So(server.callCount(), convey.ShouldEqual, 0)
 		})
 	})
 }
@@ -399,34 +463,176 @@ func Test_FlusherOTLPHTTP_Export_Logs(t *testing.T) {
 			convey.So(req.path, convey.ShouldEqual, otlpHTTPLogsPath)
 
 			got := decodeLogRequest(t, req, otlpHTTPEncodingProto)
-			expected, _, _ := otlpConvertPipelineEventsToRequests(f.converter, slice, f.context.GetRuntimeContext())
+			expected, _, _ := otlpConvertPipelineEventsToRequests(f.context.GetRuntimeContext(), f.converter, slice)
 			convey.So(got.Logs().ResourceLogs().Len(), convey.ShouldEqual, expected.Logs().ResourceLogs().Len())
 			convey.So(got.Logs().LogRecordCount(), convey.ShouldEqual, expected.Logs().LogRecordCount())
 		})
 	})
 }
 
-func Test_FlusherOTLPHTTP_Export_MetricsAndTracesAreDropped(t *testing.T) {
+func Test_FlusherOTLPHTTP_Export_Metrics(t *testing.T) {
 	convey.Convey("Given an OTLP/HTTP server", t, func() {
 		server := newOTLPHTTPTestServer(http.StatusOK)
 		defer server.close()
 
-		convey.Convey("Exporting metrics should not fail and should not carry metric data", func() {
+		convey.Convey("When exporting v2 metric events", func() {
 			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
-			convey.So(f.Export(makeTestPipelineGroupEventsMetricSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
 
-			// The logs request is still sent, but it is empty.
+			slice := makeTestPipelineGroupEventsMetricSlice()
+			convey.So(f.Export(slice, helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+
+			// Only the metrics request is sent, the empty logs and traces ones are skipped.
+			convey.So(server.callCount(), convey.ShouldEqual, 1)
 			req := <-server.requests
-			convey.So(req.path, convey.ShouldEqual, otlpHTTPLogsPath)
-			convey.So(decodeLogRequest(t, req, otlpHTTPEncodingProto).Logs().LogRecordCount(), convey.ShouldEqual, 0)
+			convey.So(req.path, convey.ShouldEqual, otlpHTTPMetricsPath)
+			convey.So(req.contentType, convey.ShouldEqual, otlpHTTPProtobufContentType)
+
+			got := decodeMetricRequest(t, req, otlpHTTPEncodingProto)
+			_, expected, _ := otlpConvertPipelineEventsToRequests(f.context.GetRuntimeContext(), f.converter, slice)
+			convey.So(got.Metrics().ResourceMetrics().Len(), convey.ShouldEqual, expected.Metrics().ResourceMetrics().Len())
+			convey.So(got.Metrics().DataPointCount(), convey.ShouldEqual, expected.Metrics().DataPointCount())
+			convey.So(got.Metrics().DataPointCount(), convey.ShouldBeGreaterThan, 0)
+			convey.So(got.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name(),
+				convey.ShouldEqual,
+				expected.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
 		})
 
-		convey.Convey("Exporting traces should not fail", func() {
-			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
-			convey.So(f.Export(makeTestPipelineGroupEventsTraceSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+		convey.Convey("When exporting metric events with json encoding", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Endpoint = server.server.URL
+				f.Encoding = otlpHTTPEncodingJSON
+			})
+
+			convey.So(f.Export(makeTestPipelineGroupEventsMetricSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
 
 			req := <-server.requests
-			convey.So(decodeLogRequest(t, req, otlpHTTPEncodingProto).Logs().LogRecordCount(), convey.ShouldEqual, 0)
+			convey.So(req.path, convey.ShouldEqual, otlpHTTPMetricsPath)
+			convey.So(req.contentType, convey.ShouldEqual, otlpHTTPJSONContentType)
+			convey.So(decodeMetricRequest(t, req, otlpHTTPEncodingJSON).Metrics().DataPointCount(), convey.ShouldBeGreaterThan, 0)
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Export_Traces(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("When exporting v2 span events", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+
+			slice := makeTestPipelineGroupEventsTraceSlice()
+			convey.So(f.Export(slice, helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+
+			convey.So(server.callCount(), convey.ShouldEqual, 1)
+			req := <-server.requests
+			convey.So(req.path, convey.ShouldEqual, otlpHTTPTracesPath)
+
+			got := decodeTraceRequest(t, req, otlpHTTPEncodingProto)
+			_, _, expected := otlpConvertPipelineEventsToRequests(f.context.GetRuntimeContext(), f.converter, slice)
+			convey.So(got.Traces().ResourceSpans().Len(), convey.ShouldEqual, expected.Traces().ResourceSpans().Len())
+			convey.So(got.Traces().SpanCount(), convey.ShouldEqual, expected.Traces().SpanCount())
+			convey.So(got.Traces().SpanCount(), convey.ShouldBeGreaterThan, 0)
+			convey.So(got.Traces().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name(),
+				convey.ShouldEqual,
+				expected.Traces().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Export_AllSignals(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("A batch carrying all three signals produces one request per signal", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+
+			var slice []*models.PipelineGroupEvents
+			slice = append(slice, makeTestPipelineGroupEventsLogSlice()...)
+			slice = append(slice, makeTestPipelineGroupEventsMetricSlice()...)
+			slice = append(slice, makeTestPipelineGroupEventsTraceSlice()...)
+			convey.So(f.Export(slice, helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+
+			convey.So(server.callCount(), convey.ShouldEqual, 3)
+			byPath := map[string]capturedRequest{}
+			for i := 0; i < 3; i++ {
+				req := <-server.requests
+				byPath[req.path] = req
+			}
+
+			convey.So(decodeLogRequest(t, byPath[otlpHTTPLogsPath], otlpHTTPEncodingProto).Logs().LogRecordCount(), convey.ShouldBeGreaterThan, 0)
+			convey.So(decodeMetricRequest(t, byPath[otlpHTTPMetricsPath], otlpHTTPEncodingProto).Metrics().DataPointCount(), convey.ShouldBeGreaterThan, 0)
+			convey.So(decodeTraceRequest(t, byPath[otlpHTTPTracesPath], otlpHTTPEncodingProto).Traces().SpanCount(), convey.ShouldBeGreaterThan, 0)
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Export_SignalRouting(t *testing.T) {
+	convey.Convey("Given two OTLP/HTTP servers", t, func() {
+		logServer := newOTLPHTTPTestServer(http.StatusOK)
+		defer logServer.close()
+		metricServer := newOTLPHTTPTestServer(http.StatusOK)
+		defer metricServer.close()
+
+		convey.Convey("Each signal goes to its own endpoint with its own headers", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Headers = map[string]string{"X-Base": "base"}
+				f.Logs = &otlpHTTPSignalConfig{Endpoint: logServer.server.URL + "/custom/logs"}
+				f.Metrics = &otlpHTTPSignalConfig{
+					Endpoint: metricServer.server.URL + "/custom/metrics",
+					Headers:  map[string]string{"X-Signal": "metrics"},
+				}
+			})
+
+			convey.So(f.Export(makeTestPipelineGroupEventsLogSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+			logReq := <-logServer.requests
+			convey.So(logReq.path, convey.ShouldEqual, "/custom/logs")
+			convey.So(logReq.header.Get("X-Base"), convey.ShouldEqual, "base")
+			convey.So(logReq.header.Get("X-Signal"), convey.ShouldBeEmpty)
+
+			convey.So(f.Export(makeTestPipelineGroupEventsMetricSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+			metricReq := <-metricServer.requests
+			convey.So(metricReq.path, convey.ShouldEqual, "/custom/metrics")
+			convey.So(metricReq.header.Get("X-Base"), convey.ShouldEqual, "base")
+			convey.So(metricReq.header.Get("X-Signal"), convey.ShouldEqual, "metrics")
+
+			convey.So(logServer.callCount(), convey.ShouldEqual, 1)
+			convey.So(metricServer.callCount(), convey.ShouldEqual, 1)
+		})
+
+		convey.Convey("A signal without an endpoint is dropped without failing the export", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Logs = &otlpHTTPSignalConfig{Endpoint: logServer.server.URL + "/custom/logs"}
+			})
+
+			// Traces have no destination, the data is dropped.
+			convey.So(f.Export(makeTestPipelineGroupEventsTraceSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+			convey.So(logServer.callCount(), convey.ShouldEqual, 0)
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Export_PartialFailureIsReported(t *testing.T) {
+	convey.Convey("Given a healthy logs server and a failing metrics server", t, func() {
+		logServer := newOTLPHTTPTestServer(http.StatusOK)
+		defer logServer.close()
+		metricServer := newOTLPHTTPTestServer(http.StatusBadRequest)
+		defer metricServer.close()
+
+		convey.Convey("The failure is returned but the healthy signal is still sent", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Logs = &otlpHTTPSignalConfig{Endpoint: logServer.server.URL + "/v1/logs"}
+				f.Metrics = &otlpHTTPSignalConfig{Endpoint: metricServer.server.URL + "/v1/metrics"}
+			})
+
+			var slice []*models.PipelineGroupEvents
+			slice = append(slice, makeTestPipelineGroupEventsLogSlice()...)
+			slice = append(slice, makeTestPipelineGroupEventsMetricSlice()...)
+			convey.So(f.Export(slice, helper.NewNoopPipelineContext()), convey.ShouldBeError)
+
+			convey.So(logServer.callCount(), convey.ShouldEqual, 1)
+			convey.So(metricServer.callCount(), convey.ShouldEqual, 1)
 		})
 	})
 }
@@ -449,7 +655,7 @@ func Test_FlusherOTLPHTTP_Retry_Retryable(t *testing.T) {
 		for _, c := range cases {
 			convey.Convey(c.name, func() {
 				server := newOTLPHTTPTestServer(c.statuses...)
-				// Keep the Retry-After honoured but short so the test stays fast.
+				// Keep the Retry-After honored but short so the test stays fast.
 				server.retryAfter = c.retryAfter
 				defer server.close()
 
@@ -504,6 +710,45 @@ func Test_FlusherOTLPHTTP_Retry_Exhausted(t *testing.T) {
 		convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeError)
 		// One initial attempt plus two retries.
 		convey.So(server.callCount(), convey.ShouldEqual, 3)
+	})
+}
+
+func Test_FlusherOTLPHTTP_Stop_AbortsRetryBackoff(t *testing.T) {
+	convey.Convey("Stop should abort a retry backoff instead of holding the flush goroutine", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusServiceUnavailable)
+		// A hostile Retry-After: without a cap and without an interruptible wait this would
+		// park the flush goroutine for a day.
+		server.retryAfter = "86400"
+		defer server.close()
+
+		f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+			f.Endpoint = server.server.URL
+			f.Retry.InitialDelay = 10 * time.Second
+			f.Retry.MaxDelay = 30 * time.Second
+		})
+
+		done := make(chan error, 1)
+		start := time.Now()
+		go func() {
+			done <- f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList())
+		}()
+
+		// Let the first attempt fail and the backoff start, then stop the flusher.
+		time.Sleep(200 * time.Millisecond)
+		convey.So(f.Stop(), convey.ShouldBeNil)
+
+		select {
+		case err := <-done:
+			convey.So(err, convey.ShouldBeError)
+			convey.So(time.Since(start), convey.ShouldBeLessThan, 3*time.Second)
+			// Only the first attempt was made, the retry was abandoned.
+			convey.So(server.callCount(), convey.ShouldEqual, 1)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Flush did not return after Stop, the retry backoff is not interruptible")
+		}
+
+		// Stop must stay idempotent, a second call must not panic on the closed channel.
+		convey.So(f.Stop(), convey.ShouldBeNil)
 	})
 }
 
@@ -589,6 +834,58 @@ func Test_FlusherOTLPHTTP_PartialSuccess_JSON(t *testing.T) {
 	})
 }
 
+func Test_FlusherOTLPHTTP_PartialSuccess_MetricsAndTraces(t *testing.T) {
+	convey.Convey("Partial success is decoded with the counter of the sent signal", t, func() {
+		convey.Convey("Rejected data points are reported for metrics", func() {
+			resp := pmetricotlp.NewExportResponse()
+			resp.PartialSuccess().SetRejectedDataPoints(7)
+			resp.PartialSuccess().SetErrorMessage("7 data points rejected")
+			body, err := resp.MarshalProto()
+			convey.So(err, convey.ShouldBeNil)
+
+			rejected, message, err := decodeMetricsPartialSuccess(body, false)
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(rejected, convey.ShouldEqual, int64(7))
+			convey.So(message, convey.ShouldEqual, "7 data points rejected")
+
+			server := newOTLPHTTPTestServer(http.StatusOK)
+			server.respBody = body
+			defer server.close()
+
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+			convey.So(f.Export(makeTestPipelineGroupEventsMetricSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+			convey.So(server.callCount(), convey.ShouldEqual, 1)
+		})
+
+		convey.Convey("Rejected spans are reported for traces", func() {
+			resp := ptraceotlp.NewExportResponse()
+			resp.PartialSuccess().SetRejectedSpans(3)
+			body, err := resp.MarshalJSON()
+			convey.So(err, convey.ShouldBeNil)
+
+			rejected, _, err := decodeTracesPartialSuccess(body, true)
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(rejected, convey.ShouldEqual, int64(3))
+
+			server := newOTLPHTTPTestServer(http.StatusOK)
+			server.respBody = body
+			defer server.close()
+
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Endpoint = server.server.URL
+				f.Encoding = otlpHTTPEncodingJSON
+			})
+			convey.So(f.Export(makeTestPipelineGroupEventsTraceSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+			convey.So(server.callCount(), convey.ShouldEqual, 1)
+		})
+
+		convey.Convey("An undecodable body is ignored", func() {
+			_, _, err := decodeLogsPartialSuccess([]byte("not otlp at all"), true)
+			convey.So(err, convey.ShouldBeError)
+		})
+	})
+}
+
 func Test_FlusherOTLPHTTP_Stop_And_NotReady(t *testing.T) {
 	convey.Convey("Given an uninitialized flusher", t, func() {
 		convey.Convey("Stop should be safe", func() {
@@ -670,8 +967,10 @@ func Test_FlusherOTLPHTTP_NextRetryDelay(t *testing.T) {
 			convey.So(f.nextRetryDelay(20, 0), convey.ShouldBeLessThanOrEqualTo, 4*time.Second)
 		})
 
-		convey.Convey("A larger Retry-After wins", func() {
-			convey.So(f.nextRetryDelay(0, 10*time.Second), convey.ShouldEqual, 10*time.Second)
+		convey.Convey("A larger Retry-After wins but is capped at MaxDelay", func() {
+			convey.So(f.nextRetryDelay(0, 3*time.Second), convey.ShouldEqual, 3*time.Second)
+			// Retry-After is external input, it must not push the wait beyond MaxDelay.
+			convey.So(f.nextRetryDelay(0, 24*time.Hour), convey.ShouldEqual, 4*time.Second)
 		})
 
 		convey.Convey("A smaller Retry-After is ignored", func() {

--- a/plugins/flusher/opentelemetry/flusher_otlp_http_test.go
+++ b/plugins/flusher/opentelemetry/flusher_otlp_http_test.go
@@ -1,0 +1,701 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opentelemetry
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/goconvey/convey"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/alibaba/ilogtail/pkg/helper"
+	"github.com/alibaba/ilogtail/pkg/pipeline"
+	"github.com/alibaba/ilogtail/plugins/test/mock"
+)
+
+// capturedRequest is what the test OTLP/HTTP server recorded for one request.
+type capturedRequest struct {
+	path            string
+	contentType     string
+	contentEncoding string
+	userAgent       string
+	header          http.Header
+	body            []byte
+}
+
+// otlpHTTPTestServer is a minimal OTLP/HTTP receiver used by the tests below. It records every
+// request and replies with the responses queued in statuses (the last one repeats forever).
+type otlpHTTPTestServer struct {
+	server   *httptest.Server
+	requests chan capturedRequest
+	calls    int32
+
+	statuses    []int
+	retryAfter  string
+	respBody    []byte
+	handlerHook func(w http.ResponseWriter, r *http.Request) bool
+}
+
+func newOTLPHTTPTestServer(statuses ...int) *otlpHTTPTestServer {
+	if len(statuses) == 0 {
+		statuses = []int{http.StatusOK}
+	}
+	s := &otlpHTTPTestServer{
+		requests: make(chan capturedRequest, 64),
+		statuses: statuses,
+	}
+	s.server = httptest.NewServer(http.HandlerFunc(s.handle))
+	return s
+}
+
+func (s *otlpHTTPTestServer) handle(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	s.requests <- capturedRequest{
+		path:            r.URL.Path,
+		contentType:     r.Header.Get("Content-Type"),
+		contentEncoding: r.Header.Get("Content-Encoding"),
+		userAgent:       r.Header.Get("User-Agent"),
+		header:          r.Header.Clone(),
+		body:            body,
+	}
+	n := int(atomic.AddInt32(&s.calls, 1))
+
+	if s.handlerHook != nil && s.handlerHook(w, r) {
+		return
+	}
+
+	status := s.statuses[len(s.statuses)-1]
+	if n <= len(s.statuses) {
+		status = s.statuses[n-1]
+	}
+	if s.retryAfter != "" && (status == http.StatusTooManyRequests || status == http.StatusServiceUnavailable) {
+		w.Header().Set("Retry-After", s.retryAfter)
+	}
+	w.WriteHeader(status)
+	if len(s.respBody) > 0 {
+		_, _ = w.Write(s.respBody)
+	}
+}
+
+func (s *otlpHTTPTestServer) callCount() int { return int(atomic.LoadInt32(&s.calls)) }
+
+func (s *otlpHTTPTestServer) close() { s.server.Close() }
+
+// decodeLogRequest turns a captured request body back into an OTLP logs export request.
+func decodeLogRequest(t *testing.T, req capturedRequest, encoding string) plogotlp.ExportRequest {
+	t.Helper()
+	raw := req.body
+	if req.contentEncoding == otlpHTTPCompressionGzip {
+		gr, err := gzip.NewReader(bytes.NewReader(raw))
+		convey.So(err, convey.ShouldBeNil)
+		raw, err = io.ReadAll(gr)
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(gr.Close(), convey.ShouldBeNil)
+	}
+
+	out := plogotlp.NewExportRequest()
+	var err error
+	if encoding == otlpHTTPEncodingJSON {
+		err = out.UnmarshalJSON(raw)
+	} else {
+		err = out.UnmarshalProto(raw)
+	}
+	convey.So(err, convey.ShouldBeNil)
+	return out
+}
+
+// newTestFlusherOTLPHTTP builds an initialized flusher pointing at the given base endpoint.
+func newTestFlusherOTLPHTTP(t *testing.T, mutate func(f *FlusherOTLPHTTP)) *FlusherOTLPHTTP {
+	t.Helper()
+	f := NewFlusherOTLPHTTP()
+	f.Retry.InitialDelay = 10 * time.Millisecond
+	f.Retry.MaxDelay = 20 * time.Millisecond
+	if mutate != nil {
+		mutate(f)
+	}
+	err := f.Init(mock.NewEmptyContext("p", "l", "c"))
+	convey.So(err, convey.ShouldBeNil)
+	return f
+}
+
+func Test_FlusherOTLPHTTP_Init(t *testing.T) {
+	convey.Convey("Given a FlusherOTLPHTTP", t, func() {
+		logCtx := mock.NewEmptyContext("p", "l", "c")
+
+		convey.Convey("When no endpoint is configured, Init should fail", func() {
+			f := NewFlusherOTLPHTTP()
+			err := f.Init(logCtx)
+			convey.So(err, convey.ShouldBeError)
+			convey.So(err.Error(), convey.ShouldEqual, "invalid_otlp_http_configs")
+		})
+
+		convey.Convey("When only the base endpoint is set, the signal path should be appended", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Endpoint = "http://127.0.0.1:4318"
+			convey.So(f.Init(logCtx), convey.ShouldBeNil)
+			convey.So(f.logClient, convey.ShouldNotBeNil)
+			convey.So(f.logClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/logs")
+			convey.So(f.IsReady("p", "l", 1), convey.ShouldBeTrue)
+			convey.So(f.Stop(), convey.ShouldBeNil)
+		})
+
+		convey.Convey("When the base endpoint has a trailing slash, no double slash should appear", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Endpoint = "http://127.0.0.1:4318/"
+			convey.So(f.Init(logCtx), convey.ShouldBeNil)
+			convey.So(f.logClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/logs")
+		})
+
+		convey.Convey("When the Logs endpoint is set, it should be used verbatim", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Endpoint = "http://127.0.0.1:4318"
+			f.Logs = &otlpHTTPSignalConfig{Endpoint: "http://otherhost:8080/custom/logs"}
+			convey.So(f.Init(logCtx), convey.ShouldBeNil)
+			convey.So(f.logClient.url, convey.ShouldEqual, "http://otherhost:8080/custom/logs")
+		})
+
+		convey.Convey("When only the Logs endpoint is set, Init should succeed", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Logs = &otlpHTTPSignalConfig{Endpoint: "http://127.0.0.1:4318/v1/logs"}
+			convey.So(f.Init(logCtx), convey.ShouldBeNil)
+			convey.So(f.logClient.url, convey.ShouldEqual, "http://127.0.0.1:4318/v1/logs")
+		})
+
+		convey.Convey("Defaults should be filled in", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Endpoint = "http://127.0.0.1:4318"
+			convey.So(f.Init(logCtx), convey.ShouldBeNil)
+			convey.So(f.Version, convey.ShouldEqual, v1)
+			convey.So(f.Encoding, convey.ShouldEqual, otlpHTTPEncodingProto)
+			convey.So(f.Compression, convey.ShouldEqual, otlpHTTPCompressionGzip)
+			convey.So(f.Timeout, convey.ShouldEqual, otlpHTTPDefaultTimeout)
+			convey.So(f.Retry.MaxRetryTimes, convey.ShouldEqual, otlpHTTPDefaultMaxRetry)
+		})
+
+		convey.Convey("An unsupported encoding should fail Init", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Endpoint = "http://127.0.0.1:4318"
+			f.Encoding = "yaml"
+			convey.So(f.Init(logCtx), convey.ShouldBeError)
+		})
+
+		convey.Convey("An unsupported compression should fail Init", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Endpoint = "http://127.0.0.1:4318"
+			f.Compression = "snappy"
+			convey.So(f.Init(logCtx), convey.ShouldBeError)
+		})
+
+		convey.Convey("An unsupported version should fail Init", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Endpoint = "http://127.0.0.1:4318"
+			f.Version = "v9"
+			convey.So(f.Init(logCtx), convey.ShouldBeError)
+		})
+
+		convey.Convey("An empty compression means no compression", func() {
+			f := NewFlusherOTLPHTTP()
+			f.Endpoint = "http://127.0.0.1:4318"
+			f.Compression = ""
+			convey.So(f.Init(logCtx), convey.ShouldBeNil)
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_BuildSignalURL(t *testing.T) {
+	convey.Convey("buildSignalURL should follow the otlphttpexporter rules", t, func() {
+		cases := []struct {
+			name     string
+			base     string
+			signal   *otlpHTTPSignalConfig
+			expected string
+		}{
+			{"base only", "http://h:4318", nil, "http://h:4318/v1/logs"},
+			{"base with trailing slashes", "http://h:4318//", nil, "http://h:4318/v1/logs"},
+			{"signal override wins", "http://h:4318", &otlpHTTPSignalConfig{Endpoint: "http://o/l"}, "http://o/l"},
+			{"signal without endpoint falls back", "http://h:4318", &otlpHTTPSignalConfig{}, "http://h:4318/v1/logs"},
+			{"no base and no override", "", nil, ""},
+			{"no base but override", "", &otlpHTTPSignalConfig{Endpoint: "http://o/l"}, "http://o/l"},
+		}
+
+		for _, c := range cases {
+			convey.Convey(c.name, func() {
+				f := &FlusherOTLPHTTP{Endpoint: c.base}
+				convey.So(f.buildSignalURL(c.signal, otlpHTTPLogsPath), convey.ShouldEqual, c.expected)
+			})
+		}
+	})
+}
+
+func Test_FlusherOTLPHTTP_BuildSignalHeaders(t *testing.T) {
+	convey.Convey("buildSignalHeaders should merge with the signal winning", t, func() {
+		f := &FlusherOTLPHTTP{Headers: map[string]string{"X-Base": "1", "X-Both": "base"}}
+
+		convey.Convey("Without a signal config only the base headers are used", func() {
+			convey.So(f.buildSignalHeaders(nil), convey.ShouldResemble, map[string]string{"X-Base": "1", "X-Both": "base"})
+		})
+
+		convey.Convey("With a signal config the signal headers override", func() {
+			got := f.buildSignalHeaders(&otlpHTTPSignalConfig{Headers: map[string]string{"X-Both": "signal", "X-Signal": "2"}})
+			convey.So(got, convey.ShouldResemble, map[string]string{"X-Base": "1", "X-Both": "signal", "X-Signal": "2"})
+			// The base headers must not be mutated.
+			convey.So(f.Headers, convey.ShouldResemble, map[string]string{"X-Base": "1", "X-Both": "base"})
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Flush_Proto(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("When flushing v1 log groups with proto encoding", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Endpoint = server.server.URL
+				f.Headers = map[string]string{"X-AppKey": "test-key"}
+			})
+
+			groupList := makeTestLogGroupList().GetLogGroupList()
+			convey.So(f.Flush("p", "l", "c", groupList), convey.ShouldBeNil)
+
+			req := <-server.requests
+			convey.So(req.path, convey.ShouldEqual, otlpHTTPLogsPath)
+			convey.So(req.contentType, convey.ShouldEqual, otlpHTTPProtobufContentType)
+			convey.So(req.contentEncoding, convey.ShouldEqual, otlpHTTPCompressionGzip)
+			convey.So(req.userAgent, convey.ShouldNotBeEmpty)
+			convey.So(req.header.Get("X-AppKey"), convey.ShouldEqual, "test-key")
+
+			got := decodeLogRequest(t, req, otlpHTTPEncodingProto)
+			expected := otlpConvertLogGroupToRequest(f.converter, groupList)
+			convey.So(got.Logs().ResourceLogs().Len(), convey.ShouldEqual, expected.Logs().ResourceLogs().Len())
+			convey.So(got.Logs().LogRecordCount(), convey.ShouldEqual, expected.Logs().LogRecordCount())
+			convey.So(got.Logs().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().AsString(),
+				convey.ShouldEqual,
+				expected.Logs().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().AsString())
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Flush_JSON(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("When flushing with json encoding", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Endpoint = server.server.URL
+				f.Encoding = otlpHTTPEncodingJSON
+			})
+
+			groupList := makeTestLogGroupList().GetLogGroupList()
+			convey.So(f.Flush("p", "l", "c", groupList), convey.ShouldBeNil)
+
+			req := <-server.requests
+			convey.So(req.contentType, convey.ShouldEqual, otlpHTTPJSONContentType)
+
+			got := decodeLogRequest(t, req, otlpHTTPEncodingJSON)
+			expected := otlpConvertLogGroupToRequest(f.converter, groupList)
+			convey.So(got.Logs().LogRecordCount(), convey.ShouldEqual, expected.Logs().LogRecordCount())
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Flush_NoCompression(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("When compression is disabled, no Content-Encoding should be sent", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Endpoint = server.server.URL
+				f.Compression = otlpHTTPCompressionNone
+			})
+
+			groupList := makeTestLogGroupList().GetLogGroupList()
+			convey.So(f.Flush("p", "l", "c", groupList), convey.ShouldBeNil)
+
+			req := <-server.requests
+			convey.So(req.contentEncoding, convey.ShouldBeEmpty)
+
+			got := decodeLogRequest(t, req, otlpHTTPEncodingProto)
+			convey.So(got.Logs().LogRecordCount(), convey.ShouldBeGreaterThan, 0)
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Flush_HeadersCannotCorruptContentType(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("A stale Content-Type in the config must not override the real encoding", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+				f.Endpoint = server.server.URL
+				f.Headers = map[string]string{
+					"Content-Type":     otlpHTTPJSONContentType,
+					"Content-Encoding": "snappy",
+					"User-Agent":       "custom-agent",
+				}
+			})
+
+			convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeNil)
+
+			req := <-server.requests
+			convey.So(req.contentType, convey.ShouldEqual, otlpHTTPProtobufContentType)
+			convey.So(req.contentEncoding, convey.ShouldEqual, otlpHTTPCompressionGzip)
+			// User-Agent stays overridable.
+			convey.So(req.userAgent, convey.ShouldEqual, "custom-agent")
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Flush_Empty(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("Flushing an empty log group list still succeeds", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+			convey.So(f.Flush("p", "l", "c", nil), convey.ShouldBeNil)
+			convey.So(server.callCount(), convey.ShouldEqual, 1)
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Export_Logs(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("When exporting v2 log events", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+
+			slice := makeTestPipelineGroupEventsLogSlice()
+			convey.So(f.Export(slice, helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+
+			req := <-server.requests
+			convey.So(req.path, convey.ShouldEqual, otlpHTTPLogsPath)
+
+			got := decodeLogRequest(t, req, otlpHTTPEncodingProto)
+			expected, _, _ := otlpConvertPipelineEventsToRequests(f.converter, slice, f.context.GetRuntimeContext())
+			convey.So(got.Logs().ResourceLogs().Len(), convey.ShouldEqual, expected.Logs().ResourceLogs().Len())
+			convey.So(got.Logs().LogRecordCount(), convey.ShouldEqual, expected.Logs().LogRecordCount())
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Export_MetricsAndTracesAreDropped(t *testing.T) {
+	convey.Convey("Given an OTLP/HTTP server", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		defer server.close()
+
+		convey.Convey("Exporting metrics should not fail and should not carry metric data", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+			convey.So(f.Export(makeTestPipelineGroupEventsMetricSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+
+			// The logs request is still sent, but it is empty.
+			req := <-server.requests
+			convey.So(req.path, convey.ShouldEqual, otlpHTTPLogsPath)
+			convey.So(decodeLogRequest(t, req, otlpHTTPEncodingProto).Logs().LogRecordCount(), convey.ShouldEqual, 0)
+		})
+
+		convey.Convey("Exporting traces should not fail", func() {
+			f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+			convey.So(f.Export(makeTestPipelineGroupEventsTraceSlice(), helper.NewNoopPipelineContext()), convey.ShouldBeNil)
+
+			req := <-server.requests
+			convey.So(decodeLogRequest(t, req, otlpHTTPEncodingProto).Logs().LogRecordCount(), convey.ShouldEqual, 0)
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Retry_Retryable(t *testing.T) {
+	convey.Convey("Retryable status codes should be retried until success", t, func() {
+		cases := []struct {
+			name       string
+			statuses   []int
+			retryAfter string
+			wantCalls  int
+		}{
+			{"429 then 200", []int{http.StatusTooManyRequests, http.StatusOK}, "", 2},
+			{"429 with Retry-After then 200", []int{http.StatusTooManyRequests, http.StatusOK}, "1", 2},
+			{"503 twice then 200", []int{http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusOK}, "", 3},
+			{"502 then 200", []int{http.StatusBadGateway, http.StatusOK}, "", 2},
+			{"504 then 200", []int{http.StatusGatewayTimeout, http.StatusOK}, "", 2},
+		}
+
+		for _, c := range cases {
+			convey.Convey(c.name, func() {
+				server := newOTLPHTTPTestServer(c.statuses...)
+				// Keep the Retry-After honoured but short so the test stays fast.
+				server.retryAfter = c.retryAfter
+				defer server.close()
+
+				f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+				convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeNil)
+				convey.So(server.callCount(), convey.ShouldEqual, c.wantCalls)
+			})
+		}
+	})
+}
+
+func Test_FlusherOTLPHTTP_NoRetry_Permanent(t *testing.T) {
+	convey.Convey("Permanent status codes must not be retried", t, func() {
+		// 500 is explicitly NOT retryable per the OTLP/HTTP specification.
+		for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden,
+			http.StatusNotFound, http.StatusRequestEntityTooLarge, http.StatusInternalServerError} {
+			convey.Convey(http.StatusText(status), func() {
+				server := newOTLPHTTPTestServer(status)
+				defer server.close()
+
+				f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+				convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeError)
+				convey.So(server.callCount(), convey.ShouldEqual, 1)
+			})
+		}
+	})
+}
+
+func Test_FlusherOTLPHTTP_Retry_Disabled(t *testing.T) {
+	convey.Convey("With retry disabled a retryable failure is attempted once", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusServiceUnavailable)
+		defer server.close()
+
+		f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+			f.Endpoint = server.server.URL
+			f.Retry.Enable = false
+		})
+		convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeError)
+		convey.So(server.callCount(), convey.ShouldEqual, 1)
+	})
+}
+
+func Test_FlusherOTLPHTTP_Retry_Exhausted(t *testing.T) {
+	convey.Convey("When retries are exhausted the error is returned", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusServiceUnavailable)
+		defer server.close()
+
+		f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+			f.Endpoint = server.server.URL
+			f.Retry.MaxRetryTimes = 2
+		})
+		convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeError)
+		// One initial attempt plus two retries.
+		convey.So(server.callCount(), convey.ShouldEqual, 3)
+	})
+}
+
+func Test_FlusherOTLPHTTP_Retry_NetworkError(t *testing.T) {
+	convey.Convey("A transport level error should be retried", t, func() {
+		f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+			f.Endpoint = "http://127.0.0.1:4318"
+			f.Retry.MaxRetryTimes = 2
+		})
+
+		doer := &countingErrDoer{err: errors.New("connection refused")}
+		f.SetHTTPDoer(doer)
+
+		convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeError)
+		convey.So(doer.calls, convey.ShouldEqual, 3)
+	})
+}
+
+type countingErrDoer struct {
+	err   error
+	calls int
+}
+
+func (d *countingErrDoer) Do(*http.Request) (*http.Response, error) {
+	d.calls++
+	return nil, d.err
+}
+
+func Test_FlusherOTLPHTTP_Timeout(t *testing.T) {
+	convey.Convey("A server slower than Timeout should produce a retryable error", t, func() {
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		server.handlerHook = func(w http.ResponseWriter, r *http.Request) bool {
+			time.Sleep(300 * time.Millisecond)
+			return false
+		}
+		defer server.close()
+
+		f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+			f.Endpoint = server.server.URL
+			f.Timeout = 50 * time.Millisecond
+			f.Retry.MaxRetryTimes = 1
+		})
+
+		convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeError)
+		convey.So(server.callCount(), convey.ShouldEqual, 2)
+	})
+}
+
+func Test_FlusherOTLPHTTP_PartialSuccess(t *testing.T) {
+	convey.Convey("A partial success response is warned about but not treated as an error", t, func() {
+		resp := plogotlp.NewExportResponse()
+		resp.PartialSuccess().SetRejectedLogRecords(5)
+		resp.PartialSuccess().SetErrorMessage("5 records rejected")
+		body, err := resp.MarshalProto()
+		convey.So(err, convey.ShouldBeNil)
+
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		server.respBody = body
+		defer server.close()
+
+		f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) { f.Endpoint = server.server.URL })
+		convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeNil)
+		convey.So(server.callCount(), convey.ShouldEqual, 1)
+	})
+}
+
+func Test_FlusherOTLPHTTP_PartialSuccess_JSON(t *testing.T) {
+	convey.Convey("A json encoded partial success response is handled too", t, func() {
+		resp := plogotlp.NewExportResponse()
+		resp.PartialSuccess().SetRejectedLogRecords(2)
+		body, err := resp.MarshalJSON()
+		convey.So(err, convey.ShouldBeNil)
+
+		server := newOTLPHTTPTestServer(http.StatusOK)
+		server.respBody = body
+		defer server.close()
+
+		f := newTestFlusherOTLPHTTP(t, func(f *FlusherOTLPHTTP) {
+			f.Endpoint = server.server.URL
+			f.Encoding = otlpHTTPEncodingJSON
+		})
+		convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeNil)
+	})
+}
+
+func Test_FlusherOTLPHTTP_Stop_And_NotReady(t *testing.T) {
+	convey.Convey("Given an uninitialized flusher", t, func() {
+		convey.Convey("Stop should be safe", func() {
+			f := NewFlusherOTLPHTTP()
+			convey.So(f.Stop(), convey.ShouldBeNil)
+		})
+
+		convey.Convey("Flush without a log client is a no-op", func() {
+			f := NewFlusherOTLPHTTP()
+			f.context = mock.NewEmptyContext("p", "l", "c")
+			convey.So(f.Flush("p", "l", "c", makeTestLogGroupList().GetLogGroupList()), convey.ShouldBeNil)
+		})
+
+		convey.Convey("IsReady should be false", func() {
+			f := NewFlusherOTLPHTTP()
+			f.context = mock.NewEmptyContext("p", "l", "c")
+			convey.So(f.IsReady("p", "l", 1), convey.ShouldBeFalse)
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_Registered(t *testing.T) {
+	convey.Convey("flusher_otlp_http should be registered", t, func() {
+		creator, ok := pipeline.Flushers["flusher_otlp_http"]
+		convey.So(ok, convey.ShouldBeTrue)
+		f, ok := creator().(*FlusherOTLPHTTP)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(f.Description(), convey.ShouldNotBeEmpty)
+		convey.So(f.Encoding, convey.ShouldEqual, otlpHTTPEncodingProto)
+	})
+}
+
+func Test_ParseRetryAfterDuration(t *testing.T) {
+	convey.Convey("parseRetryAfterDuration", t, func() {
+		convey.Convey("An empty header yields zero", func() {
+			convey.So(parseRetryAfterDuration(""), convey.ShouldEqual, time.Duration(0))
+		})
+		convey.Convey("Integer seconds are parsed", func() {
+			convey.So(parseRetryAfterDuration("3"), convey.ShouldEqual, 3*time.Second)
+			convey.So(parseRetryAfterDuration(" 7 "), convey.ShouldEqual, 7*time.Second)
+		})
+		convey.Convey("Non positive seconds yield zero", func() {
+			convey.So(parseRetryAfterDuration("0"), convey.ShouldEqual, time.Duration(0))
+			convey.So(parseRetryAfterDuration("-5"), convey.ShouldEqual, time.Duration(0))
+		})
+		convey.Convey("A future HTTP date yields a positive delay", func() {
+			header := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
+			got := parseRetryAfterDuration(header)
+			convey.So(got, convey.ShouldBeGreaterThan, time.Duration(0))
+			convey.So(got, convey.ShouldBeLessThanOrEqualTo, 31*time.Second)
+		})
+		convey.Convey("A past HTTP date yields zero", func() {
+			header := time.Now().Add(-time.Minute).UTC().Format(http.TimeFormat)
+			convey.So(parseRetryAfterDuration(header), convey.ShouldEqual, time.Duration(0))
+		})
+		convey.Convey("An unparsable header yields zero", func() {
+			convey.So(parseRetryAfterDuration("later"), convey.ShouldEqual, time.Duration(0))
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_NextRetryDelay(t *testing.T) {
+	convey.Convey("nextRetryDelay", t, func() {
+		f := NewFlusherOTLPHTTP()
+		f.Retry.InitialDelay = time.Second
+		f.Retry.MaxDelay = 4 * time.Second
+
+		convey.Convey("The delay grows and stays within [d/2, d]", func() {
+			d0 := f.nextRetryDelay(0, 0)
+			convey.So(d0, convey.ShouldBeGreaterThanOrEqualTo, 500*time.Millisecond)
+			convey.So(d0, convey.ShouldBeLessThanOrEqualTo, time.Second)
+
+			d2 := f.nextRetryDelay(2, 0)
+			convey.So(d2, convey.ShouldBeGreaterThanOrEqualTo, 2*time.Second)
+			convey.So(d2, convey.ShouldBeLessThanOrEqualTo, 4*time.Second)
+		})
+
+		convey.Convey("The delay is capped at MaxDelay", func() {
+			convey.So(f.nextRetryDelay(20, 0), convey.ShouldBeLessThanOrEqualTo, 4*time.Second)
+		})
+
+		convey.Convey("A larger Retry-After wins", func() {
+			convey.So(f.nextRetryDelay(0, 10*time.Second), convey.ShouldEqual, 10*time.Second)
+		})
+
+		convey.Convey("A smaller Retry-After is ignored", func() {
+			convey.So(f.nextRetryDelay(2, time.Nanosecond), convey.ShouldBeGreaterThanOrEqualTo, 2*time.Second)
+		})
+	})
+}
+
+func Test_FlusherOTLPHTTP_DecodeErrorStatus(t *testing.T) {
+	convey.Convey("decodeErrorStatus", t, func() {
+		f := NewFlusherOTLPHTTP()
+
+		convey.Convey("An empty body is reported as such", func() {
+			convey.So(f.decodeErrorStatus(nil), convey.ShouldEqual, "<empty body>")
+		})
+
+		convey.Convey("A google.rpc.Status body is rendered", func() {
+			body, err := proto.Marshal(&spb.Status{Code: 3, Message: "bad field"})
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(f.decodeErrorStatus(body), convey.ShouldEqual, "code=3 message=bad field")
+		})
+
+		convey.Convey("A non protobuf body falls back to the raw text", func() {
+			convey.So(f.decodeErrorStatus([]byte("plain text error")), convey.ShouldEqual, "plain text error")
+		})
+	})
+}

--- a/plugins/flusher/opentelemetry/otlp_convert.go
+++ b/plugins/flusher/opentelemetry/otlp_convert.go
@@ -32,7 +32,8 @@ import (
 )
 
 // otlpConvertLogGroupToRequest converts v1 log groups into an OTLP logs export request.
-// Shared by the gRPC (flusher_otlp) and HTTP (flusher_otlp_http) flushers.
+// Used by flusher_otlp_http; flusher_otlp keeps its own equivalent method so that the
+// existing gRPC flusher stays untouched.
 func otlpConvertLogGroupToRequest(conv *converter.Converter, logGroupList []*protocol.LogGroup) plogotlp.ExportRequest {
 	logs := plog.NewLogs()
 	for _, logGroup := range logGroupList {
@@ -49,18 +50,19 @@ func otlpConvertLogGroupToRequest(conv *converter.Converter, logGroupList []*pro
 }
 
 // otlpConvertPipelineEventsToRequests converts v2 pipeline group events into OTLP logs/metrics/traces
-// export requests. Shared by the gRPC (flusher_otlp) and HTTP (flusher_otlp_http) flushers.
+// export requests. Used by flusher_otlp_http; flusher_otlp keeps its own equivalent method so that
+// the existing gRPC flusher stays untouched.
 // runtimeCtx is only used for logging.
-func otlpConvertPipelineEventsToRequests(conv *converter.Converter, pipelinegroupeEventSlice []*models.PipelineGroupEvents,
-	runtimeCtx context.Context) (plogotlp.ExportRequest, pmetricotlp.ExportRequest, ptraceotlp.ExportRequest) {
+func otlpConvertPipelineEventsToRequests(runtimeCtx context.Context, conv *converter.Converter,
+	groupEventsSlice []*models.PipelineGroupEvents) (plogotlp.ExportRequest, pmetricotlp.ExportRequest, ptraceotlp.ExportRequest) {
 	logs := plog.NewLogs()
 	metrics := pmetric.NewMetrics()
 	traces := ptrace.NewTraces()
 
-	for _, ps := range pipelinegroupeEventSlice {
+	for _, ps := range groupEventsSlice {
 		resourceLog, resourceMetric, resourceTrace, err := converter.ConvertPipelineEventToOtlpEvent(conv, ps)
 		if err != nil {
-			logger.Warning(runtimeCtx, selfmonitor.FlusherInitAlarm, "convert pipeline events to otlp events fail, error", err)
+			logger.Warning(runtimeCtx, selfmonitor.FlusherFlushAlarm, "convert pipeline events to otlp events fail, error", err)
 		}
 		if resourceLog.ScopeLogs().Len() > 0 {
 			newLog := logs.ResourceLogs().AppendEmpty()

--- a/plugins/flusher/opentelemetry/otlp_convert.go
+++ b/plugins/flusher/opentelemetry/otlp_convert.go
@@ -1,0 +1,84 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opentelemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+
+	"github.com/alibaba/ilogtail/pkg/logger"
+	"github.com/alibaba/ilogtail/pkg/models"
+	"github.com/alibaba/ilogtail/pkg/protocol"
+	converter "github.com/alibaba/ilogtail/pkg/protocol/converter"
+	"github.com/alibaba/ilogtail/pkg/selfmonitor"
+)
+
+// otlpConvertLogGroupToRequest converts v1 log groups into an OTLP logs export request.
+// Shared by the gRPC (flusher_otlp) and HTTP (flusher_otlp_http) flushers.
+func otlpConvertLogGroupToRequest(conv *converter.Converter, logGroupList []*protocol.LogGroup) plogotlp.ExportRequest {
+	logs := plog.NewLogs()
+	for _, logGroup := range logGroupList {
+		c, _ := conv.Do(logGroup)
+		if log, ok := c.(plog.ResourceLogs); ok {
+			if log.ScopeLogs().Len() > 0 {
+				newLog := logs.ResourceLogs().AppendEmpty()
+				log.MoveTo(newLog)
+			}
+		}
+	}
+
+	return plogotlp.NewExportRequestFromLogs(logs)
+}
+
+// otlpConvertPipelineEventsToRequests converts v2 pipeline group events into OTLP logs/metrics/traces
+// export requests. Shared by the gRPC (flusher_otlp) and HTTP (flusher_otlp_http) flushers.
+// runtimeCtx is only used for logging.
+func otlpConvertPipelineEventsToRequests(conv *converter.Converter, pipelinegroupeEventSlice []*models.PipelineGroupEvents,
+	runtimeCtx context.Context) (plogotlp.ExportRequest, pmetricotlp.ExportRequest, ptraceotlp.ExportRequest) {
+	logs := plog.NewLogs()
+	metrics := pmetric.NewMetrics()
+	traces := ptrace.NewTraces()
+
+	for _, ps := range pipelinegroupeEventSlice {
+		resourceLog, resourceMetric, resourceTrace, err := converter.ConvertPipelineEventToOtlpEvent(conv, ps)
+		if err != nil {
+			logger.Warning(runtimeCtx, selfmonitor.FlusherInitAlarm, "convert pipeline events to otlp events fail, error", err)
+		}
+		if resourceLog.ScopeLogs().Len() > 0 {
+			newLog := logs.ResourceLogs().AppendEmpty()
+			resourceLog.MoveTo(newLog)
+		}
+
+		if resourceMetric.ScopeMetrics().Len() > 0 {
+			newMetric := metrics.ResourceMetrics().AppendEmpty()
+			resourceMetric.MoveTo(newMetric)
+		}
+
+		if resourceTrace.ScopeSpans().Len() > 0 {
+			newTrace := traces.ResourceSpans().AppendEmpty()
+			resourceTrace.MoveTo(newTrace)
+		}
+	}
+
+	return plogotlp.NewExportRequestFromLogs(logs),
+		pmetricotlp.NewExportRequestFromMetrics(metrics),
+		ptraceotlp.NewExportRequestFromTraces(traces)
+}


### PR DESCRIPTION
## Summary

- The existing `flusher_otlp` only speaks OTLP/gRPC, so backends that expose only the HTTP port (`4318`), or that sit behind an HTTP/1.1-only gateway or load balancer, cannot be reached. This adds `flusher_otlp_http`, whose protocol behavior follows the OpenTelemetry Collector [`otlphttpexporter`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter).
- **All three signals are supported through the v2 `Export` entry point.** A single base `Endpoint` enables Logs, Metrics and Traces by appending `/v1/logs`, `/v1/metrics`, `/v1/traces`; each signal can also override the full URL and its headers. The v1 `Flush` entry point only carries logs, since `protocol.LogGroup` has no notion of metrics or traces. A signal with no destination is disabled and its data is dropped with an alarm.
- The pdata conversion helpers used by this flusher live in `otlp_convert.go` as package-level functions. **`flusher_otlp.go` is deliberately left byte-for-byte identical to `main`** — sharing the helpers would mean editing the existing gRPC flusher, so the two currently keep equivalent copies (~40 lines). The duplication is called out in the comments on both helpers; de-duplicating is a follow-up that can be done without touching this plugin.
- Lives in the existing `plugins/flusher/opentelemetry` package, so `plugins.yml` needs no change.

### Config

`Endpoint: http://collector:4318` auto-appends the signal paths; `Logs.Endpoint` / `Metrics.Endpoint` / `Traces.Endpoint` override the full URL. `Encoding` is `proto` (default) or `json`; `Compression` is `gzip` (default) or `none`. Timeout, retry, `http.Transport` tuning, `Authenticator` and `RequestInterceptors` follow the `flusher_http` conventions. Note that duration fields (`Timeout`, `Retry.InitialDelay`, `Retry.MaxDelay`, `IdleConnTimeout`) are `time.Duration` and the plugin config is decoded with plain `encoding/json`, so they take **integer nanoseconds** — the docs and samples spell this out. Full reference: `docs/cn/plugins/flusher/extended/flusher-otlp-http.md`.

### Three behaviors worth reviewer attention

1. **Retry classification deliberately differs from `flusher_http`.** Per the OTLP/HTTP specification only `429`, `502`, `503`, `504` (plus transport-level errors) are retried — notably **`500` is permanent**, whereas `flusher_http` retries all 5xx.
2. **`Retry-After` is a lower bound on the backoff, but is capped at `Retry.MaxDelay`.** It is parsed as either integer seconds or an RFC 1123 date, so the effective wait is `min(max(exponential backoff, Retry-After), MaxDelay)`. The cap matters because `Flush`/`Export` run synchronously on the pipeline flush goroutine: honoring an unbounded server-supplied value would let a backend park that goroutine for hours. For the same reason the backoff waits on `select { <-timer.C; <-stopCh }` and `Stop()` closes `stopCh`, so shutdown aborts a pending backoff instead of waiting it out.
3. **`Content-Type` / `Content-Encoding` are derived from `Encoding` / `Compression` and cannot be overridden through `Headers`**, so a stale value in the config can never contradict the body that was actually built — including the uncompressed case, where a `Content-Encoding` coming from the config is deleted rather than left in place. `User-Agent` remains overridable.

A `2xx` response carrying `partial_success` is logged as a warning and treated as sent, since resending the batch would duplicate the accepted records. The rejected counter is signal specific: `rejected_log_records`, `rejected_data_points` or `rejected_spans`.

Errors returned by the flusher are only used for reporting and alarms — the framework does not re-send the batch (`plugin_runner_v1.go` / `plugin_runner_v2.go` just log it), so all retrying happens inside the plugin.

## Test plan

`plugins/flusher/opentelemetry/flusher_otlp_http_test.go` adds 30 tests. They drive a real `httptest.NewServer`, so marshal → gzip → POST → response decode runs end to end rather than against a mock.

- [x] `go build ./plugins/flusher/opentelemetry/...`
- [x] `go vet ./plugins/flusher/opentelemetry/...`
- [x] `gofmt -l plugins/flusher/opentelemetry/` — clean
- [x] `go test ./plugins/flusher/opentelemetry/... -count=1` — new tests plus the pre-existing gRPC tests all pass
- [x] `go test -race ./plugins/flusher/opentelemetry/ -run 'Test_FlusherOTLPHTTP_Stop|Test_FlusherOTLPHTTP_Init|Test_FlusherOTLPHTTP_Flush_Headers|Test_FlusherOTLPHTTP_NextRetryDelay'`
- [x] `python3 scripts/check_docs_cn_relative_links.py`
- [x] `python3 scripts/validate_docs_cn_plugin_samples.py`
- [x] `make lint` — not run locally (the pinned golangci-lint v1.64.8 did not finish in reasonable time on this machine); the three `misspell` findings the previous CI run reported are fixed, relying on CI for the rest
- [x] `make plugin_local` — not run locally; relying on CI

Coverage of the new tests: Init and defaults, endpoint/URL composition (base, trailing slash, per-signal override, neither), header merging, proto and JSON encoding, gzip and no-compression, header-cannot-corrupt-`Content-Type`, header-cannot-set-`Content-Encoding`-when-uncompressed, v1 `Flush` and v2 `Export` for all three signals, signal routing, per-signal partial failure, every retryable and permanent status code, retry disabled, retries exhausted, transport error, timeout, `Stop` aborting a pending backoff, partial success in both encodings and for all three signals, `Retry-After` parsing, backoff jitter bounds and the `MaxDelay` cap, and `google.rpc.Status` error decoding.

### Manual verification

Point the flusher at a Collector with only the HTTP receiver enabled and a `debug` exporter, then run it once per `Encoding` × `Compression` combination:

```yaml
receivers:
  otlp:
    protocols:
      http:
        endpoint: 0.0.0.0:4318
exporters:
  debug:
    verbosity: detailed
service:
  pipelines:
    logs:
      receivers: [otlp]
      exporters: [debug]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
