### PR TITLE
feat(agentsight): collect unified security events

### DIFF
--- a/core/ebpf/Config.cpp
+++ b/core/ebpf/Config.cpp
@@ -690,6 +690,8 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
         mAgentsightHttp.clear();
         mAgentsightEventStreamFormat = true;
         mAgentsightMessageDeltaOnly = true;
+        mAgentsightSecurityAuditEnabled = false;
+        mAgentsightEnforcerSocket = "/run/agentsight/enforcer.sock";
     }
 
     SecurityOption thisSecurityOption;
@@ -749,6 +751,30 @@ bool SecurityOptions::Init(SecurityProbeType probeType,
                 if (innerConfig.isMember("MessageDeltaOnly")) {
                     if (!GetOptionalBoolParam(innerConfig, "MessageDeltaOnly", mAgentsightMessageDeltaOnly, errorMsg)) {
                         warnOptionalParse();
+                    }
+                }
+                if (innerConfig.isMember("SecurityAudit")) {
+                    const auto& securityAudit = innerConfig["SecurityAudit"];
+                    if (!securityAudit.isObject()) {
+                        errorMsg = "ProbeConfig.SecurityAudit must be an object";
+                        warnOptionalParse();
+                        return false;
+                    }
+                    if (securityAudit.isMember("Enabled")
+                        && !GetOptionalBoolParam(securityAudit, "Enabled", mAgentsightSecurityAuditEnabled, errorMsg)) {
+                        warnOptionalParse();
+                        return false;
+                    }
+                    if (securityAudit.isMember("EnforcerSocket")
+                        && !GetOptionalStringParam(
+                            securityAudit, "EnforcerSocket", mAgentsightEnforcerSocket, errorMsg)) {
+                        warnOptionalParse();
+                        return false;
+                    }
+                    if (mAgentsightEnforcerSocket.empty()) {
+                        errorMsg = "ProbeConfig.SecurityAudit.EnforcerSocket must not be empty";
+                        warnOptionalParse();
+                        return false;
                     }
                 }
                 return true;

--- a/core/ebpf/Config.h
+++ b/core/ebpf/Config.h
@@ -71,6 +71,10 @@ public:
     bool mAgentsightEventStreamFormat = true;
     /// When true, omit system instructions, tool definitions, and full input messages (per dedup).
     bool mAgentsightMessageDeltaOnly = true;
+    /// Subscribe to AgentSight's normalized system security audit stream.
+    bool mAgentsightSecurityAuditEnabled = false;
+    /// Local AgentSight enforcer socket used when security audit is enabled.
+    std::string mAgentsightEnforcerSocket = "/run/agentsight/enforcer.sock";
 };
 
 /////////////////////  /////////////////////

--- a/core/ebpf/EBPFAdapter.cpp
+++ b/core/ebpf/EBPFAdapter.cpp
@@ -257,6 +257,10 @@ bool EBPFAdapter::tryLoadAgentSightDylib() {
         tmpLib->LoadMethod("agentsight_config_set_verbose", symErr));
     sym.config_set_log_path = reinterpret_cast<decltype(sym.config_set_log_path)>(
         tmpLib->LoadMethod("agentsight_config_set_log_path", symErr));
+    sym.config_set_enable_security_audit = reinterpret_cast<decltype(sym.config_set_enable_security_audit)>(
+        tmpLib->LoadMethod("agentsight_config_set_enable_security_audit", symErr));
+    sym.config_set_enforcer_socket = reinterpret_cast<decltype(sym.config_set_enforcer_socket)>(
+        tmpLib->LoadMethod("agentsight_config_set_enforcer_socket", symErr));
     sym.config_add_cmdline_rule = reinterpret_cast<decltype(sym.config_add_cmdline_rule)>(
         tmpLib->LoadMethod("agentsight_config_add_cmdline_rule", symErr));
     sym.config_add_https
@@ -270,6 +274,8 @@ bool EBPFAdapter::tryLoadAgentSightDylib() {
     sym.handle_get_eventfd
         = reinterpret_cast<decltype(sym.handle_get_eventfd)>(tmpLib->LoadMethod("agentsight_get_eventfd", symErr));
     sym.handle_read = reinterpret_cast<decltype(sym.handle_read)>(tmpLib->LoadMethod("agentsight_read", symErr));
+    sym.handle_read_v2
+        = reinterpret_cast<decltype(sym.handle_read_v2)>(tmpLib->LoadMethod("agentsight_read_v2", symErr));
 
     const bool ok = sym.last_error && sym.config_new && sym.config_free && sym.config_set_verbose
         && sym.config_set_log_path && sym.handle_new && sym.handle_free && sym.handle_start && sym.handle_stop
@@ -284,6 +290,11 @@ bool EBPFAdapter::tryLoadAgentSightDylib() {
     mAgentSightLib = std::move(tmpLib);
     mAgentSightSymbols = std::make_unique<AgentSightSymbolTable>(sym);
     LOG_INFO(sLogger, ("[EBPFAdapter] AgentSight symbols loaded", STRING_FLAG(ebpf_agentsight_dylib_base_name)));
+    if (!sym.config_set_enable_security_audit || !sym.config_set_enforcer_socket || !sym.handle_read_v2) {
+        LOG_WARNING(
+            sLogger,
+            ("[EBPFAdapter] AgentSight security audit API unavailable", "continuing with legacy LLM collection"));
+    }
     return true;
 }
 

--- a/core/ebpf/EBPFAdapter.h
+++ b/core/ebpf/EBPFAdapter.h
@@ -22,9 +22,9 @@
 #include <memory>
 #include <string>
 
-#include "agentsight.h"
 #include "common/DynamicLibHelper.h"
 #include "ebpf/include/export.h"
+#include "ebpf/plugin/agentsight/AgentSightV2Compat.h"
 
 namespace logtail::ebpf {
 
@@ -36,6 +36,8 @@ struct AgentSightSymbolTable {
     void (*config_free)(AgentsightConfigHandle*) = nullptr;
     void (*config_set_verbose)(AgentsightConfigHandle*, int) = nullptr;
     void (*config_set_log_path)(AgentsightConfigHandle*, const char*) = nullptr;
+    void (*config_set_enable_security_audit)(AgentsightConfigHandle*, int) = nullptr;
+    void (*config_set_enforcer_socket)(AgentsightConfigHandle*, const char*) = nullptr;
     void (*config_add_cmdline_rule)(AgentsightConfigHandle*, const char* const*, const char*, int) = nullptr;
     void (*config_add_https)(AgentsightConfigHandle*, const char*) = nullptr;
     int (*config_add_http)(AgentsightConfigHandle*, const char*) = nullptr;
@@ -45,6 +47,15 @@ struct AgentSightSymbolTable {
     int (*handle_stop)(AgentsightHandle*) = nullptr;
     int (*handle_get_eventfd)(AgentsightHandle*) = nullptr;
     int (*handle_read)(AgentsightHandle*, agentsight_https_callback_fn, void*, agentsight_llm_callback_fn, void*, int)
+        = nullptr;
+    int (*handle_read_v2)(AgentsightHandle*,
+                          agentsight_https_callback_fn,
+                          void*,
+                          agentsight_llm_callback_fn,
+                          void*,
+                          agentsight_event_callback_fn,
+                          void*,
+                          int)
         = nullptr;
 };
 

--- a/core/ebpf/plugin/agentsight/AgentSightV2Compat.h
+++ b/core/ebpf/plugin/agentsight/AgentSightV2Compat.h
@@ -1,0 +1,40 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "agentsight.h"
+
+// LoongCollector can be built with an older AgentSight SDK while loading a
+// newer libagentsight.so at runtime. Remove this fallback after the pinned SDK
+// header defines AGENTSIGHT_HAS_READ_V2.
+#ifndef AGENTSIGHT_HAS_READ_V2
+enum AgentsightEventType : uint32_t {
+    AGENTSIGHT_EVENT_TYPE_HTTPS = 1,
+    AGENTSIGHT_EVENT_TYPE_LLM = 2,
+    AGENTSIGHT_EVENT_TYPE_SECURITY = 3,
+};
+
+struct AgentsightEvent {
+    AgentsightEventType event_type;
+    uint16_t schema_version;
+    uint64_t timestamp_ns;
+    const char* payload_json;
+    uint32_t payload_json_len;
+};
+
+using agentsight_event_callback_fn = void (*)(const AgentsightEvent* data, void* user_data);
+#endif

--- a/core/ebpf/plugin/agentsight/AgentsightEvents.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightEvents.cpp
@@ -76,4 +76,15 @@ AgentsightLlmRecord::AgentsightLlmRecord(std::string pipelineConfigName, const A
     mToolDefinitionsJson = CopyBuffer(d.tools, d.tools_len);
 }
 
+AgentsightSecurityRecord::AgentsightSecurityRecord(std::string pipelineConfigName,
+                                                   uint64_t timestampNs,
+                                                   uint16_t schemaVersion,
+                                                   std::string payloadJson)
+    : CommonEvent(KernelEventType::AGENTSIGHT_SECURITY_RECORD),
+      mPipelineConfigName(std::move(pipelineConfigName)),
+      mTimestampNs(timestampNs),
+      mSchemaVersion(schemaVersion),
+      mPayloadJson(std::move(payloadJson)) {
+}
+
 } // namespace logtail::ebpf

--- a/core/ebpf/plugin/agentsight/AgentsightEvents.h
+++ b/core/ebpf/plugin/agentsight/AgentsightEvents.h
@@ -18,8 +18,8 @@
 
 #include <string>
 
-#include "agentsight.h"
 #include "ebpf/include/export.h"
+#include "ebpf/plugin/agentsight/AgentSightV2Compat.h"
 #include "ebpf/type/CommonDataEvent.h"
 
 namespace logtail::ebpf {
@@ -66,6 +66,23 @@ public:
     std::string mInputMessageDeltaJson;
     std::string mResponseMessagesJson;
     std::string mToolDefinitionsJson;
+};
+
+class AgentsightSecurityRecord : public CommonEvent {
+public:
+    AgentsightSecurityRecord(std::string pipelineConfigName,
+                             uint64_t timestampNs,
+                             uint16_t schemaVersion,
+                             std::string payloadJson);
+
+    PluginType GetPluginType() const override { return PluginType::AGENTSIGHT_OBSERVE; }
+
+    const std::string& GetPipelineConfigName() const { return mPipelineConfigName; }
+
+    std::string mPipelineConfigName;
+    uint64_t mTimestampNs = 0;
+    uint16_t mSchemaVersion = 0;
+    std::string mPayloadJson;
 };
 
 } // namespace logtail::ebpf

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -959,9 +959,9 @@ int AgentsightManager::HandleSecurityEvent(const AgentsightSecurityRecord& rec) 
     auto* log = eventGroup.AddLogEvent(true, mEventPool);
     SetLogTimestampFromNs(log, rec.mTimestampNs);
     log->SetContent("time_unix_nano", std::to_string(rec.mTimestampNs));
-    log->SetContent("event.name", "agentsight.security");
-    log->SetContent("event.kind", "event");
-    log->SetContent("event.category", "security");
+    log->SetContent(StringView("event.name"), StringView("agentsight.security"));
+    log->SetContent(StringView("event.kind"), StringView("event"));
+    log->SetContent(StringView("event.category"), StringView("security"));
     log->SetContent("agentsight.schema_version", std::to_string(rec.mSchemaVersion));
     log->SetContent("event.original", rec.mPayloadJson);
 

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -19,6 +19,8 @@
 #include <utility>
 #include <vector>
 
+#include "json/json.h"
+
 #include "collection_pipeline/queue/ProcessQueueItem.h"
 #include "collection_pipeline/queue/ProcessQueueManager.h"
 #include "common/StringView.h"
@@ -436,6 +438,47 @@ void FillAgentsightModelResponseLog(const AgentsightLlmRecord& rec,
     setStr(StringView("gen_ai.output.messages"), rec.mResponseMessagesJson);
 }
 
+std::string JsonScalarToString(const Json::Value& value) {
+    if (value.isString()) {
+        return value.asString();
+    }
+    if (value.isBool()) {
+        return value.asBool() ? "true" : "false";
+    }
+    if (value.isInt64()) {
+        return std::to_string(value.asInt64());
+    }
+    if (value.isUInt64()) {
+        return std::to_string(value.asUInt64());
+    }
+    if (value.isDouble()) {
+        return std::to_string(value.asDouble());
+    }
+    return {};
+}
+
+void FlattenSecurityJson(const Json::Value& value, const std::string& prefix, logtail::LogEvent* log) {
+    if (!value.isObject()) {
+        const std::string scalar = JsonScalarToString(value);
+        if (!scalar.empty()) {
+            log->SetContent(prefix, scalar);
+        }
+        return;
+    }
+    for (const auto& key : value.getMemberNames()) {
+        const auto& child = value[key];
+        const std::string childKey = prefix.empty() ? key : prefix + "." + key;
+        if (child.isObject()) {
+            FlattenSecurityJson(child, childKey, log);
+        } else {
+            const std::string scalar = JsonScalarToString(child);
+            if (!scalar.empty()) {
+                log->SetContent(childKey, scalar);
+            }
+        }
+    }
+}
+
 } // namespace
 
 AgentsightManager::AgentsightManager(const std::shared_ptr<ProcessCacheManager>& processCacheManager,
@@ -491,6 +534,7 @@ void AgentsightManager::StopAgentSightLocked() {
     }
     mHandle = nullptr;
     mRunning = false;
+    mSecurityAuditEnabled = false;
 }
 
 bool AgentsightManager::RestartAgentSightLocked(const SecurityOptions& opts) {
@@ -515,6 +559,21 @@ bool AgentsightManager::RestartAgentSightLocked(const SecurityOptions& opts) {
     }
 
     ApplyAgentsightRulesToConfig(cfg, sym, opts);
+
+    mSecurityAuditEnabled = false;
+    if (opts.mAgentsightSecurityAuditEnabled) {
+        if (sym->config_set_enable_security_audit && sym->config_set_enforcer_socket && sym->handle_read_v2) {
+            sym->config_set_enable_security_audit(cfg, 1);
+            sym->config_set_enforcer_socket(cfg, opts.mAgentsightEnforcerSocket.c_str());
+            mSecurityAuditEnabled = true;
+        } else {
+            LOG_WARNING(sLogger,
+                        ("AgentSight security audit",
+                         "requested but read_v2/configuration symbols are unavailable; continuing with LLM only"));
+        }
+    } else if (sym->config_set_enable_security_audit) {
+        sym->config_set_enable_security_audit(cfg, 0);
+    }
 
     mHandle = sym->handle_new(cfg);
     if (sym->config_free) {
@@ -551,7 +610,16 @@ int AgentsightManager::DrainReadsLocked() {
     }
     int total = 0;
     for (;;) {
-        const int r = sym->handle_read(mHandle, nullptr, nullptr, &AgentsightManager::OnLlmCallback, this, 0);
+        const int r = mSecurityAuditEnabled && sym->handle_read_v2
+            ? sym->handle_read_v2(mHandle,
+                                  nullptr,
+                                  nullptr,
+                                  &AgentsightManager::OnLlmCallback,
+                                  this,
+                                  &AgentsightManager::OnEventCallback,
+                                  this,
+                                  0)
+            : sym->handle_read(mHandle, nullptr, nullptr, &AgentsightManager::OnLlmCallback, this, 0);
         if (r <= 0) {
             break;
         }
@@ -589,6 +657,32 @@ void AgentsightManager::OnLlmCallback(const AgentsightLLMData* data, void* user_
     } else {
         ADD_COUNTER(self->mLossKernelEventsTotal, 1);
         LOG_WARNING(sLogger, ("AgentSight LLM event enqueue failed", ""));
+    }
+}
+
+void AgentsightManager::OnEventCallback(const AgentsightEvent* data, void* user_data) {
+    static constexpr uint32_t kSecurityEventType = 3;
+    static constexpr uint32_t kMaxSecurityPayloadBytes = 4U * 1024U * 1024U;
+    if (!data || !user_data || static_cast<uint32_t>(data->event_type) != kSecurityEventType) {
+        return;
+    }
+    if (data->schema_version != 1 || !data->payload_json || data->payload_json_len == 0
+        || data->payload_json_len > kMaxSecurityPayloadBytes) {
+        LOG_WARNING(sLogger,
+                    ("AgentSight security event rejected",
+                     "invalid envelope")("schema", data->schema_version)("payload_bytes", data->payload_json_len));
+        return;
+    }
+    auto* self = static_cast<AgentsightManager*>(user_data);
+    auto event = std::make_shared<AgentsightSecurityRecord>(self->mConfigName,
+                                                            data->timestamp_ns,
+                                                            data->schema_version,
+                                                            std::string(data->payload_json, data->payload_json_len));
+    if (self->mCommonEventQueue.try_enqueue(event)) {
+        ADD_COUNTER(self->mPluginInEventsTotal, 1);
+    } else {
+        ADD_COUNTER(self->mLossKernelEventsTotal, 1);
+        LOG_WARNING(sLogger, ("AgentSight security event enqueue failed", ""));
     }
 }
 
@@ -676,6 +770,7 @@ int AgentsightManager::RemoveConfig(const std::string&) {
     mPluginIndex = 0;
     mEventStreamFormat = true;
     mMessageDeltaOnly = true;
+    mSecurityAuditEnabled = false;
     StopAgentSightLocked();
     return 0;
 }
@@ -692,6 +787,7 @@ int AgentsightManager::Destroy() {
     mPluginIndex = 0;
     mEventStreamFormat = true;
     mMessageDeltaOnly = true;
+    mSecurityAuditEnabled = false;
     mInited = false;
     return 0;
 }
@@ -746,7 +842,13 @@ std::unique_ptr<PluginConfig> AgentsightManager::GeneratePluginConfig(const Plug
 }
 
 int AgentsightManager::HandleEvent(const std::shared_ptr<CommonEvent>& event) {
-    if (!event || event->GetKernelEventType() != KernelEventType::AGENTSIGHT_LLM_RECORD) {
+    if (!event) {
+        return 0;
+    }
+    if (event->GetKernelEventType() == KernelEventType::AGENTSIGHT_SECURITY_RECORD) {
+        return HandleSecurityEvent(*static_cast<AgentsightSecurityRecord*>(event.get()));
+    }
+    if (event->GetKernelEventType() != KernelEventType::AGENTSIGHT_LLM_RECORD) {
         return 0;
     }
     auto* rec = static_cast<AgentsightLlmRecord*>(event.get());
@@ -836,6 +938,82 @@ int AgentsightManager::HandleEvent(const std::shared_ptr<CommonEvent>& event) {
         LOG_WARNING(
             sLogger,
             ("Agentsight push queue failed", "")("config", rec->GetPipelineConfigName())("pluginIdx", pluginIndex));
+    }
+    return 0;
+}
+
+int AgentsightManager::HandleSecurityEvent(const AgentsightSecurityRecord& rec) {
+    logtail::QueueKey queueKey;
+    uint32_t pluginIndex;
+    {
+        std::lock_guard<std::mutex> lock(mLibMutex);
+        if (mPipelineCtx == nullptr) {
+            return 0;
+        }
+        queueKey = mQueueKey;
+        pluginIndex = mPluginIndex;
+    }
+
+    auto sourceBuffer = std::make_shared<SourceBuffer>();
+    PipelineEventGroup eventGroup(sourceBuffer);
+    auto* log = eventGroup.AddLogEvent(true, mEventPool);
+    SetLogTimestampFromNs(log, rec.mTimestampNs);
+    log->SetContent("time_unix_nano", std::to_string(rec.mTimestampNs));
+    log->SetContent("event.name", "agentsight.security");
+    log->SetContent("event.kind", "event");
+    log->SetContent("event.category", "security");
+    log->SetContent("agentsight.schema_version", std::to_string(rec.mSchemaVersion));
+    log->SetContent("event.original", rec.mPayloadJson);
+
+    Json::Value root;
+    Json::CharReaderBuilder builder;
+    std::string errors;
+    const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    if (reader->parse(rec.mPayloadJson.data(), rec.mPayloadJson.data() + rec.mPayloadJson.size(), &root, &errors)
+        && root.isObject()) {
+        if (root["event_type"].isString()) {
+            log->SetContent("event.name", "agentsight.security." + root["event_type"].asString());
+            log->SetContent("event.type", root["event_type"].asString());
+        }
+        if (root["event_id"].isString()) {
+            log->SetContent("event.id", root["event_id"].asString());
+        }
+        if (root["observed_at_ns"].isUInt64()) {
+            log->SetContent("observed_time_unix_nano", std::to_string(root["observed_at_ns"].asUInt64()));
+        }
+        const auto& identity = root["identity"];
+        if (identity.isObject()) {
+            if (identity["agent_id"].isString()) {
+                log->SetContent("agent.id", identity["agent_id"].asString());
+            }
+            if (identity["agent_name"].isString()) {
+                log->SetContent("gen_ai.agent.type", identity["agent_name"].asString());
+            }
+            if (identity["session_id"].isString()) {
+                log->SetContent("gen_ai.session.id", identity["session_id"].asString());
+            }
+            if (identity["conversation_id"].isString()) {
+                log->SetContent("gen_ai.turn.id", identity["conversation_id"].asString());
+            }
+            if (identity["pid"].isInt()) {
+                log->SetContent("process.pid", std::to_string(identity["pid"].asInt()));
+            }
+            FlattenSecurityJson(identity, "agentsight.identity", log);
+        }
+        FlattenSecurityJson(root["event"], "security", log);
+    } else {
+        LOG_WARNING(sLogger, ("AgentSight security event JSON parse failed", errors));
+    }
+
+    auto item = std::make_unique<ProcessQueueItem>(std::move(eventGroup), pluginIndex);
+    if (QueueStatus::OK == ProcessQueueManager::GetInstance()->PushQueue(queueKey, std::move(item))) {
+        ADD_COUNTER(mPushLogsTotal, 1);
+        ADD_COUNTER(mPushLogGroupTotal, 1);
+    } else {
+        ADD_COUNTER(mPushLogFailedTotal, 1);
+        LOG_WARNING(sLogger,
+                    ("Agentsight security push queue failed", "")("config", rec.GetPipelineConfigName())("pluginIdx",
+                                                                                                         pluginIndex));
     }
     return 0;
 }

--- a/core/ebpf/plugin/agentsight/AgentsightManager.h
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.h
@@ -20,15 +20,17 @@
 #include <mutex>
 #include <string>
 
-#include "agentsight.h"
 #include "collection_pipeline/queue/QueueKey.h"
 #include "common/LRUCache.h"
 #include "ebpf/EBPFAdapter.h"
 #include "ebpf/plugin/AbstractManager.h"
+#include "ebpf/plugin/agentsight/AgentSightV2Compat.h"
 #include "ebpf/plugin/agentsight/AgentsightMessageUtil.h"
 #include "monitor/metric_models/ReentrantMetricsRecord.h"
 
 namespace logtail::ebpf {
+
+class AgentsightSecurityRecord;
 
 class AgentsightManager : public AbstractManager {
 public:
@@ -94,6 +96,7 @@ protected:
 
 private:
     static void OnLlmCallback(const AgentsightLLMData* data, void* user_data);
+    static void OnEventCallback(const AgentsightEvent* data, void* user_data);
 
     void StopAgentSightLocked();
     bool RestartAgentSightLocked(const SecurityOptions& opts);
@@ -101,6 +104,7 @@ private:
     void LogAgentSightError(const char* what);
     void releaseMetricRefs();
     void clearSessionInputState();
+    int HandleSecurityEvent(const AgentsightSecurityRecord& rec);
 
     static constexpr size_t kMaxSessionInputStates = 4096;
 
@@ -122,6 +126,7 @@ private:
     bool mRunning = false;
     bool mEventStreamFormat = true;
     bool mMessageDeltaOnly = true;
+    bool mSecurityAuditEnabled = false;
 
     CounterPtr mLossKernelEventsTotal;
     CounterPtr mPushLogFailedTotal;

--- a/core/ebpf/type/CommonDataEvent.h
+++ b/core/ebpf/type/CommonDataEvent.h
@@ -40,6 +40,7 @@ enum class KernelEventType {
     FILE_PERMISSION_EVENT_READ,
 
     AGENTSIGHT_LLM_RECORD,
+    AGENTSIGHT_SECURITY_RECORD,
 };
 
 class CommonEvent {

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -18,13 +18,17 @@
 
 #include <memory>
 #include <variant>
+#include <vector>
 
 #include "collection_pipeline/CollectionPipelineContext.h"
+#include "collection_pipeline/queue/ProcessQueueManager.h"
+#include "collection_pipeline/queue/QueueKeyManager.h"
 #include "ebpf/Config.h"
 #include "ebpf/EBPFAdapter.h"
 #include "ebpf/plugin/agentsight/AgentsightEvents.h"
 #include "ebpf/plugin/agentsight/AgentsightManager.h"
 #include "ebpf/type/FileEvent.h"
+#include "models/LogEvent.h"
 #include "unittest/Unittest.h"
 #include "unittest/ebpf/ManagerUnittestBase.h"
 
@@ -298,6 +302,10 @@ public:
     }
 
     void TearDown() override {
+        for (const auto key : mProcessQueueKeys) {
+            ProcessQueueManager::GetInstance()->DeleteQueue(key);
+        }
+        mProcessQueueKeys.clear();
         if (gFakeAgentSightEventFd >= 0) {
             ::close(gFakeAgentSightEventFd);
             gFakeAgentSightEventFd = -1;
@@ -337,6 +345,17 @@ public:
         APSARA_TEST_EQUAL(0, mgr.AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
     }
 
+    void registerConfigWithQueue(AgentsightManager& mgr, const char* configName) {
+        const QueueKey key = QueueKeyManager::GetInstance()->GetKey(configName);
+        CollectionPipelineContext ctx;
+        ctx.SetConfigName(configName);
+        ctx.SetProcessQueueKey(key);
+        APSARA_TEST_TRUE(ProcessQueueManager::GetInstance()->CreateOrUpdateCountBoundedQueue(key, 0, ctx));
+        ProcessQueueManager::GetInstance()->EnablePop(configName);
+        APSARA_TEST_EQUAL(0, mgr.AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
+        mProcessQueueKeys.push_back(key);
+    }
+
     void populateSessionInputCache(AgentsightManager& mgr, const char* configName, const char* const* sessionIds) {
         for (const char* const* it = sessionIds; *it != nullptr; ++it) {
             APSARA_TEST_EQUAL(0, mgr.HandleEvent(makeMinimalLlmRecord(configName, *it)));
@@ -366,9 +385,12 @@ public:
     void TestSessionInputCacheLruEviction();
     void TestSecurityAuditUsesReadV2AndEnqueuesSecurityRecord();
     void TestSecurityAuditFallsBackWhenV2SymbolsAreMissing();
+    void TestSecurityEventProducesSearchableLog();
+    void TestMalformedSecurityEventPreservesEnvelope();
 
 protected:
     std::shared_ptr<AgentSightTestEBPFAdapter> mAgentSightAdapter;
+    std::vector<QueueKey> mProcessQueueKeys;
 };
 
 void AgentsightManagerUnittest::TestGetPluginType() {
@@ -514,6 +536,8 @@ void AgentsightManagerUnittest::TestHandleEventBranches() {
     // No pipeline: mPipelineCtx is null
     auto orphan = std::make_shared<AgentsightLlmRecord>(std::string("orphan"), d0);
     APSARA_TEST_EQUAL(0, mgr->HandleEvent(orphan));
+    auto orphanSecurity = std::make_shared<AgentsightSecurityRecord>("orphan", 1U, 1U, "{}");
+    APSARA_TEST_EQUAL(0, mgr->HandleEvent(orphanSecurity));
 
     CollectionPipelineContext cctx;
     cctx.SetConfigName("p1");
@@ -712,6 +736,76 @@ void AgentsightManagerUnittest::TestSecurityAuditFallsBackWhenV2SymbolsAreMissin
     mgr->Destroy();
 }
 
+void AgentsightManagerUnittest::TestSecurityEventProducesSearchableLog() {
+    static const std::string kConfigName = "security-log-pipeline";
+    static const std::string kPayload
+        = R"({"event_id":"00000000-0000-0000-0000-000000000001","observed_at_ns":8,"identity":{"agent_id":"agent-1","agent_name":"claude","session_id":"session-1","conversation_id":"turn-1","pid":42},"event_type":"policy_decision","event":{"policy_id":"credential-exfiltration","policy_revision":3,"mode":"audit","risk_score":85,"large_counter":9223372036854775808,"blocked":true,"confidence":0.75,"details":{"source":"unit-test"}}})";
+
+    auto mgr = makeManager();
+    registerConfigWithQueue(*mgr, kConfigName.c_str());
+
+    auto record = std::make_shared<AgentsightSecurityRecord>(kConfigName, 7U, 1U, kPayload);
+    APSARA_TEST_EQUAL(0, mgr->HandleEvent(record));
+
+    std::unique_ptr<ProcessQueueItem> item;
+    std::string configName;
+    APSARA_TEST_TRUE(ProcessQueueManager::GetInstance()->PopItem(0, item, configName));
+    APSARA_TEST_EQUAL(kConfigName, configName);
+    APSARA_TEST_EQUAL(1U, item->mEventGroup.GetEvents().size());
+    const auto& log = item->mEventGroup.GetEvents().at(0).Cast<LogEvent>();
+    APSARA_TEST_EQUAL("7", log.GetContent("time_unix_nano").to_string());
+    APSARA_TEST_EQUAL("agentsight.security.policy_decision", log.GetContent("event.name").to_string());
+    APSARA_TEST_EQUAL("event", log.GetContent("event.kind").to_string());
+    APSARA_TEST_EQUAL("security", log.GetContent("event.category").to_string());
+    APSARA_TEST_EQUAL("policy_decision", log.GetContent("event.type").to_string());
+    APSARA_TEST_EQUAL("00000000-0000-0000-0000-000000000001", log.GetContent("event.id").to_string());
+    APSARA_TEST_EQUAL("8", log.GetContent("observed_time_unix_nano").to_string());
+    APSARA_TEST_EQUAL("1", log.GetContent("agentsight.schema_version").to_string());
+    APSARA_TEST_EQUAL("agent-1", log.GetContent("agent.id").to_string());
+    APSARA_TEST_EQUAL("claude", log.GetContent("gen_ai.agent.type").to_string());
+    APSARA_TEST_EQUAL("session-1", log.GetContent("gen_ai.session.id").to_string());
+    APSARA_TEST_EQUAL("turn-1", log.GetContent("gen_ai.turn.id").to_string());
+    APSARA_TEST_EQUAL("42", log.GetContent("process.pid").to_string());
+    APSARA_TEST_EQUAL("agent-1", log.GetContent("agentsight.identity.agent_id").to_string());
+    APSARA_TEST_EQUAL("credential-exfiltration", log.GetContent("security.policy_id").to_string());
+    APSARA_TEST_EQUAL("3", log.GetContent("security.policy_revision").to_string());
+    APSARA_TEST_EQUAL("audit", log.GetContent("security.mode").to_string());
+    APSARA_TEST_EQUAL("85", log.GetContent("security.risk_score").to_string());
+    APSARA_TEST_EQUAL("9223372036854775808", log.GetContent("security.large_counter").to_string());
+    APSARA_TEST_EQUAL("true", log.GetContent("security.blocked").to_string());
+    APSARA_TEST_EQUAL("0.750000", log.GetContent("security.confidence").to_string());
+    APSARA_TEST_EQUAL("unit-test", log.GetContent("security.details.source").to_string());
+    APSARA_TEST_EQUAL(kPayload, log.GetContent("event.original").to_string());
+
+    mgr->Destroy();
+}
+
+void AgentsightManagerUnittest::TestMalformedSecurityEventPreservesEnvelope() {
+    static const std::string kConfigName = "security-malformed-pipeline";
+    static const std::string kPayload = "{not-json";
+
+    auto mgr = makeManager();
+    registerConfigWithQueue(*mgr, kConfigName.c_str());
+
+    auto record = std::make_shared<AgentsightSecurityRecord>(kConfigName, 9U, 2U, kPayload);
+    APSARA_TEST_EQUAL(0, mgr->HandleEvent(record));
+
+    std::unique_ptr<ProcessQueueItem> item;
+    std::string configName;
+    APSARA_TEST_TRUE(ProcessQueueManager::GetInstance()->PopItem(0, item, configName));
+    APSARA_TEST_EQUAL(1U, item->mEventGroup.GetEvents().size());
+    const auto& log = item->mEventGroup.GetEvents().at(0).Cast<LogEvent>();
+    APSARA_TEST_EQUAL("9", log.GetContent("time_unix_nano").to_string());
+    APSARA_TEST_EQUAL("agentsight.security", log.GetContent("event.name").to_string());
+    APSARA_TEST_EQUAL("event", log.GetContent("event.kind").to_string());
+    APSARA_TEST_EQUAL("security", log.GetContent("event.category").to_string());
+    APSARA_TEST_EQUAL("2", log.GetContent("agentsight.schema_version").to_string());
+    APSARA_TEST_EQUAL(kPayload, log.GetContent("event.original").to_string());
+    APSARA_TEST_TRUE(log.GetContent("event.id").empty());
+
+    mgr->Destroy();
+}
+
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestGetPluginType);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateValidation);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateNoSymbols);
@@ -735,5 +829,7 @@ UNIT_TEST_CASE(AgentsightManagerUnittest, TestDestroyClearsSessionInputCache);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestSessionInputCacheLruEviction);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestSecurityAuditUsesReadV2AndEnqueuesSecurityRecord);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestSecurityAuditFallsBackWhenV2SymbolsAreMissing);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestSecurityEventProducesSearchableLog);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestMalformedSecurityEventPreservesEnvelope);
 
 UNIT_TEST_MAIN

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -38,7 +38,7 @@ AgentsightHandle* gFakeHandle = reinterpret_cast<AgentsightHandle*>(0x20U);
 
 struct FakeReadControl {
     int start_ret = 0;
-    /// 0: always 0; 1: return 1 once then 0; 2: call LLM callback once then 0
+    /// 0: always 0; 1: return 1 once then 0; 2: LLM once; 3: security once via read_v2
     int read_mode = 0;
     int read_step = 0;
 } gRead;
@@ -74,6 +74,21 @@ int g_ut_cmdline_allow_calls = 0;
 int g_ut_cmdline_deny_calls = 0;
 int g_ut_https_calls = 0;
 int g_ut_http_calls = 0;
+int g_ut_security_enable_calls = 0;
+int g_ut_security_enabled = 0;
+std::string g_ut_enforcer_socket;
+int g_ut_read_v2_calls = 0;
+
+void fake_config_set_enable_security_audit(AgentsightConfigHandle* cfg, int enabled) {
+    (void)cfg;
+    ++g_ut_security_enable_calls;
+    g_ut_security_enabled = enabled;
+}
+
+void fake_config_set_enforcer_socket(AgentsightConfigHandle* cfg, const char* path) {
+    (void)cfg;
+    g_ut_enforcer_socket = path ? path : "";
+}
 
 void fake_config_add_cmdline_rule(AgentsightConfigHandle* cfg,
                                   const char* const* rule,
@@ -169,6 +184,33 @@ int fake_handle_read(AgentsightHandle* h,
     return 0;
 }
 
+int fake_handle_read_v2(AgentsightHandle* h,
+                        agentsight_https_callback_fn http,
+                        void* http_user_data,
+                        agentsight_llm_callback_fn llm,
+                        void* llm_user_data,
+                        agentsight_event_callback_fn event,
+                        void* event_user_data,
+                        int flags) {
+    ++g_ut_read_v2_calls;
+    if (gRead.read_mode != 3) {
+        return fake_handle_read(h, http, http_user_data, llm, llm_user_data, flags);
+    }
+    static const char payload[]
+        = R"({"event_id":"00000000-0000-0000-0000-000000000001","occurred_at_ns":7,"observed_at_ns":8,"identity":{"agent_id":"agent-1","agent_name":"claude","session_id":"session-1","pid":42},"event_type":"policy_decision","event":{"policy_id":"credential-exfiltration","policy_revision":3,"mode":"audit","risk_score":85,"reason":"test"}})";
+    AgentsightEvent data{};
+    data.event_type = static_cast<AgentsightEventType>(3);
+    data.schema_version = 1;
+    data.timestamp_ns = 7;
+    data.payload_json = payload;
+    data.payload_json_len = sizeof(payload) - 1U;
+    if (event) {
+        event(&data, event_user_data);
+    }
+    gRead.read_mode = 0;
+    return 1;
+}
+
 std::unique_ptr<AgentSightSymbolTable> makeFullSymbolTable() {
     auto t = std::make_unique<AgentSightSymbolTable>();
     t->last_error = fake_last_error;
@@ -176,6 +218,8 @@ std::unique_ptr<AgentSightSymbolTable> makeFullSymbolTable() {
     t->config_free = fake_config_free;
     t->config_set_verbose = fake_config_set_verbose;
     t->config_set_log_path = fake_config_set_log_path;
+    t->config_set_enable_security_audit = fake_config_set_enable_security_audit;
+    t->config_set_enforcer_socket = fake_config_set_enforcer_socket;
     t->config_add_cmdline_rule = fake_config_add_cmdline_rule;
     t->config_add_https = fake_config_add_https;
     t->config_add_http = fake_config_add_http;
@@ -185,6 +229,7 @@ std::unique_ptr<AgentSightSymbolTable> makeFullSymbolTable() {
     t->handle_stop = fake_handle_stop;
     t->handle_get_eventfd = fake_get_eventfd;
     t->handle_read = fake_handle_read;
+    t->handle_read_v2 = fake_handle_read_v2;
     return t;
 }
 
@@ -239,11 +284,17 @@ public:
         g_ut_cmdline_deny_calls = 0;
         g_ut_https_calls = 0;
         g_ut_http_calls = 0;
+        g_ut_security_enable_calls = 0;
+        g_ut_security_enabled = 0;
+        g_ut_enforcer_socket.clear();
+        g_ut_read_v2_calls = 0;
         auto& o = agentsightOptions();
         o.mAgentsightCmdlineWhitelist.clear();
         o.mAgentsightCmdlineBlacklist.clear();
         o.mAgentsightHttps.clear();
         o.mAgentsightHttp.clear();
+        o.mAgentsightSecurityAuditEnabled = false;
+        o.mAgentsightEnforcerSocket = "/run/agentsight/enforcer.sock";
     }
 
     void TearDown() override {
@@ -313,6 +364,8 @@ public:
     void TestRemoveConfigClearsSessionInputCache();
     void TestDestroyClearsSessionInputCache();
     void TestSessionInputCacheLruEviction();
+    void TestSecurityAuditUsesReadV2AndEnqueuesSecurityRecord();
+    void TestSecurityAuditFallsBackWhenV2SymbolsAreMissing();
 
 protected:
     std::shared_ptr<AgentSightTestEBPFAdapter> mAgentSightAdapter;
@@ -620,6 +673,45 @@ void AgentsightManagerUnittest::TestSessionInputCacheLruEviction() {
     mgr->Destroy();
 }
 
+void AgentsightManagerUnittest::TestSecurityAuditUsesReadV2AndEnqueuesSecurityRecord() {
+    auto& options = agentsightOptions();
+    options.mAgentsightSecurityAuditEnabled = true;
+    options.mAgentsightEnforcerSocket = "/tmp/enforcer.sock";
+    auto mgr = makeManager();
+    registerConfig(*mgr, "security-pipeline");
+
+    APSARA_TEST_EQUAL(1, g_ut_security_enabled);
+    APSARA_TEST_EQUAL("/tmp/enforcer.sock", g_ut_enforcer_socket);
+    gRead.read_mode = 3;
+    APSARA_TEST_EQUAL(1, mgr->OnEpollReadable());
+    APSARA_TEST_TRUE(g_ut_read_v2_calls >= 1);
+
+    std::shared_ptr<CommonEvent> event;
+    APSARA_TEST_TRUE(mEventQueue->try_dequeue(event));
+    APSARA_TEST_EQUAL(KernelEventType::AGENTSIGHT_SECURITY_RECORD, event->GetKernelEventType());
+    auto* security = static_cast<AgentsightSecurityRecord*>(event.get());
+    APSARA_TEST_EQUAL(1, security->mSchemaVersion);
+    APSARA_TEST_EQUAL(7, security->mTimestampNs);
+    APSARA_TEST_TRUE(security->mPayloadJson.find("credential-exfiltration") != std::string::npos);
+    mgr->Destroy();
+}
+
+void AgentsightManagerUnittest::TestSecurityAuditFallsBackWhenV2SymbolsAreMissing() {
+    auto symbols = makeFullSymbolTable();
+    symbols->handle_read_v2 = nullptr;
+    mAgentSightAdapter->setAgentSightSymbols(std::move(symbols));
+    auto& options = agentsightOptions();
+    options.mAgentsightSecurityAuditEnabled = true;
+    auto mgr = makeManager();
+    registerConfig(*mgr, "legacy-pipeline");
+
+    APSARA_TEST_EQUAL(0, g_ut_security_enabled);
+    gRead.read_mode = 2;
+    APSARA_TEST_EQUAL(1, mgr->OnEpollReadable());
+    APSARA_TEST_EQUAL(0, g_ut_read_v2_calls);
+    mgr->Destroy();
+}
+
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestGetPluginType);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateValidation);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateNoSymbols);
@@ -641,5 +733,7 @@ UNIT_TEST_CASE(AgentsightManagerUnittest, TestUserBlacklistOnlySkipsBuiltinAllow
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestRemoveConfigClearsSessionInputCache);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestDestroyClearsSessionInputCache);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestSessionInputCacheLruEviction);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestSecurityAuditUsesReadV2AndEnqueuesSecurityRecord);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestSecurityAuditFallsBackWhenV2SymbolsAreMissing);
 
 UNIT_TEST_MAIN

--- a/core/unittest/input/InputAgentSightUnittest.cpp
+++ b/core/unittest/input/InputAgentSightUnittest.cpp
@@ -145,9 +145,7 @@ void InputAgentSightUnittest::TestRejectInvalidSecurityAuditFields() {
         std::string err;
         Json::Value configJson;
         APSARA_TEST_TRUE(ParseJsonTable(
-            R"({"Type":"input_agentsight","ProbeConfig":{"SecurityAudit":{"Enabled":"yes"}}})",
-            configJson,
-            err));
+            R"({"Type":"input_agentsight","ProbeConfig":{"SecurityAudit":{"Enabled":"yes"}}})", configJson, err));
         InputAgentSight input;
         input.SetContext(mContex);
         input.CreateMetricsRecordRef("t", "1");
@@ -157,9 +155,7 @@ void InputAgentSightUnittest::TestRejectInvalidSecurityAuditFields() {
         std::string err;
         Json::Value configJson;
         APSARA_TEST_TRUE(ParseJsonTable(
-            R"({"Type":"input_agentsight","ProbeConfig":{"SecurityAudit":{"EnforcerSocket":""}}})",
-            configJson,
-            err));
+            R"({"Type":"input_agentsight","ProbeConfig":{"SecurityAudit":{"EnforcerSocket":""}}})", configJson, err));
         InputAgentSight input;
         input.SetContext(mContex);
         input.CreateMetricsRecordRef("t", "1");

--- a/core/unittest/input/InputAgentSightUnittest.cpp
+++ b/core/unittest/input/InputAgentSightUnittest.cpp
@@ -29,6 +29,7 @@ public:
     void TestNameAndQueueType();
     void TestInitWithProbeConfig();
     void TestInitWithHttpsAndHttp();
+    void TestInitWithSecurityAudit();
 
 protected:
     void SetUp() override {
@@ -91,9 +92,27 @@ void InputAgentSightUnittest::TestInitWithHttpsAndHttp() {
     APSARA_TEST_EQUAL("model-svc.default.svc", input.mSecurityOptions.mAgentsightHttp[1]);
 }
 
+void InputAgentSightUnittest::TestInitWithSecurityAudit() {
+    std::string err;
+    Json::Value configJson;
+    Json::Value optionalGoPipeline;
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"Type":"input_agentsight","ProbeConfig":{"SecurityAudit":{"Enabled":true,"EnforcerSocket":"/tmp/enforcer.sock"}}})",
+        configJson,
+        err));
+    InputAgentSight input;
+    input.SetContext(mContex);
+    input.CreateMetricsRecordRef("t", "1");
+    APSARA_TEST_TRUE(input.Init(configJson, optionalGoPipeline));
+    input.CommitMetricsRecordRef();
+    APSARA_TEST_TRUE(input.mSecurityOptions.mAgentsightSecurityAuditEnabled);
+    APSARA_TEST_EQUAL("/tmp/enforcer.sock", input.mSecurityOptions.mAgentsightEnforcerSocket);
+}
+
 UNIT_TEST_CASE(InputAgentSightUnittest, TestNameAndQueueType)
 UNIT_TEST_CASE(InputAgentSightUnittest, TestInitWithProbeConfig)
 UNIT_TEST_CASE(InputAgentSightUnittest, TestInitWithHttpsAndHttp)
+UNIT_TEST_CASE(InputAgentSightUnittest, TestInitWithSecurityAudit)
 
 } // namespace logtail
 

--- a/core/unittest/input/InputAgentSightUnittest.cpp
+++ b/core/unittest/input/InputAgentSightUnittest.cpp
@@ -30,6 +30,9 @@ public:
     void TestInitWithProbeConfig();
     void TestInitWithHttpsAndHttp();
     void TestInitWithSecurityAudit();
+    void TestInitWithSecurityAuditDefaultSocket();
+    void TestRejectNonObjectSecurityAudit();
+    void TestRejectInvalidSecurityAuditFields();
 
 protected:
     void SetUp() override {
@@ -109,10 +112,68 @@ void InputAgentSightUnittest::TestInitWithSecurityAudit() {
     APSARA_TEST_EQUAL("/tmp/enforcer.sock", input.mSecurityOptions.mAgentsightEnforcerSocket);
 }
 
+void InputAgentSightUnittest::TestInitWithSecurityAuditDefaultSocket() {
+    std::string err;
+    Json::Value configJson;
+    Json::Value optionalGoPipeline;
+    APSARA_TEST_TRUE(ParseJsonTable(
+        R"({"Type":"input_agentsight","ProbeConfig":{"SecurityAudit":{"Enabled":true}}})", configJson, err));
+    InputAgentSight input;
+    input.SetContext(mContex);
+    input.CreateMetricsRecordRef("t", "1");
+    APSARA_TEST_TRUE(input.Init(configJson, optionalGoPipeline));
+    input.CommitMetricsRecordRef();
+    APSARA_TEST_TRUE(input.mSecurityOptions.mAgentsightSecurityAuditEnabled);
+    APSARA_TEST_EQUAL("/run/agentsight/enforcer.sock", input.mSecurityOptions.mAgentsightEnforcerSocket);
+}
+
+void InputAgentSightUnittest::TestRejectNonObjectSecurityAudit() {
+    std::string err;
+    Json::Value configJson;
+    Json::Value optionalGoPipeline;
+    APSARA_TEST_TRUE(
+        ParseJsonTable(R"({"Type":"input_agentsight","ProbeConfig":{"SecurityAudit":true}})", configJson, err));
+    InputAgentSight input;
+    input.SetContext(mContex);
+    input.CreateMetricsRecordRef("t", "1");
+    APSARA_TEST_FALSE(input.Init(configJson, optionalGoPipeline));
+}
+
+void InputAgentSightUnittest::TestRejectInvalidSecurityAuditFields() {
+    Json::Value optionalGoPipeline;
+    {
+        std::string err;
+        Json::Value configJson;
+        APSARA_TEST_TRUE(ParseJsonTable(
+            R"({"Type":"input_agentsight","ProbeConfig":{"SecurityAudit":{"Enabled":"yes"}}})",
+            configJson,
+            err));
+        InputAgentSight input;
+        input.SetContext(mContex);
+        input.CreateMetricsRecordRef("t", "1");
+        APSARA_TEST_FALSE(input.Init(configJson, optionalGoPipeline));
+    }
+    {
+        std::string err;
+        Json::Value configJson;
+        APSARA_TEST_TRUE(ParseJsonTable(
+            R"({"Type":"input_agentsight","ProbeConfig":{"SecurityAudit":{"EnforcerSocket":""}}})",
+            configJson,
+            err));
+        InputAgentSight input;
+        input.SetContext(mContex);
+        input.CreateMetricsRecordRef("t", "1");
+        APSARA_TEST_FALSE(input.Init(configJson, optionalGoPipeline));
+    }
+}
+
 UNIT_TEST_CASE(InputAgentSightUnittest, TestNameAndQueueType)
 UNIT_TEST_CASE(InputAgentSightUnittest, TestInitWithProbeConfig)
 UNIT_TEST_CASE(InputAgentSightUnittest, TestInitWithHttpsAndHttp)
 UNIT_TEST_CASE(InputAgentSightUnittest, TestInitWithSecurityAudit)
+UNIT_TEST_CASE(InputAgentSightUnittest, TestInitWithSecurityAuditDefaultSocket)
+UNIT_TEST_CASE(InputAgentSightUnittest, TestRejectNonObjectSecurityAudit)
+UNIT_TEST_CASE(InputAgentSightUnittest, TestRejectInvalidSecurityAuditFields)
 
 } // namespace logtail
 

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -34,6 +34,28 @@ dev
 |  ProbeConfig.Http  |  array  |  否  |  `[]`（关闭）  |  HTTP 明文流量的目标列表（字符串数组）。每项可为 `:端口`、`IP`、`IP:端口` 或域名（如 `model-svc.default.svc`、`*.internal.svc`）。**留空时不采集明文 HTTP 流量**。  |
 |  ProbeConfig.EventStreamFormat  |  bool  |  否  |  `true`  |  为 `true` 时，每次 LLM 调用在同一 `PipelineEventGroup` 内输出两条日志（各有 `event.id`）：`event.name=gen_ai.model.request`（请求开始时间戳）与 `gen_ai.model.response`（请求结束时间戳）。为 `false` 时输出单条合并日志，**无** `event.name` / `event.id`。  |
 |  ProbeConfig.MessageDeltaOnly  |  bool  |  否  |  `true`  |  为 `true` 时**不**输出全量 `gen_ai.input.messages`；仍输出 `gen_ai.input.messages_delta`、`gen_ai.system_instructions_hash` / `gen_ai.tool.definitions_hash`（非空时），以及 hash 相对上一轮变化时的 `gen_ai.system_instructions` / `gen_ai.tool.definitions`。为 `false` 时**每次**输出非空的全量 `gen_ai.input.messages`。**不影响** `gen_ai.output.messages`；`messages_delta` 及 session 状态维护**不受**本开关影响。  |
+|  ProbeConfig.SecurityAudit  |  object  |  否  |  /  |  AgentSight 系统安全审计采集配置。使用同一个 AgentSight handle、eventfd 和 `input_agentsight` 输出链路，不创建独立 input。  |
+|  ProbeConfig.SecurityAudit.Enabled  |  bool  |  否  |  `false`  |  是否订阅 AgentSight enforcer 归一化后的文件、网络、污点传播、策略判定和执行状态事件。  |
+|  ProbeConfig.SecurityAudit.EnforcerSocket  |  string  |  否  |  `/run/agentsight/enforcer.sock`  |  AgentSight enforcer 本地 Unix socket。开启审计后 enforcer 暂时不可用不会中断 LLM 采集，订阅线程会持续重连。  |
+
+### 系统安全审计事件
+
+安全审计显式开启后，`input_agentsight` 除 LLM 日志外还会输出 `event.name=agentsight.security.<event_type>` 的单条日志。事件保留完整 JSON 于 `event.original`，并提取以下公共字段便于检索：
+
+- `event.id`、`event.type`、`time_unix_nano`、`observed_time_unix_nano`
+- `agent.id`、`gen_ai.agent.type`、`gen_ai.session.id`、`gen_ai.turn.id`、`process.pid`
+- 事件载荷中的标量字段以 `security.*` 前缀展开，例如 `security.policy_id`、`security.mode`、`security.risk_score`
+
+```yaml
+inputs:
+  - Type: input_agentsight
+    ProbeConfig:
+      SecurityAudit:
+        Enabled: true
+        EnforcerSocket: /run/agentsight/enforcer.sock
+```
+
+该能力只负责采集 enforcer 已生成的安全事实；策略下发、阻断和案件编排不由 LoongCollector 执行。若运行时 AgentSight 动态库尚未提供 `read_v2` 安全审计 ABI，插件会告警并自动退化为原有 LLM 采集。
 
 ### `AgentType` 取值命名规范
 

--- a/docs/superpowers/plans/2026-07-31-agentsight-security-coverage-tests.md
+++ b/docs/superpowers/plans/2026-07-31-agentsight-security-coverage-tests.md
@@ -1,0 +1,134 @@
+# AgentSight Security Coverage Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add behavior-level tests that raise AgentSight security-event diff coverage above the repository's 60% threshold.
+
+**Architecture:** Extend the existing AgentSight manager and input fixtures. Manager tests exercise the real `CommonEvent -> ProcessQueueItem -> LogEvent` path; input tests exercise JSON configuration validation without exposing production helpers.
+
+**Tech Stack:** C++17, GoogleTest-compatible `APSARA_TEST_*` assertions, LoongCollector `ProcessQueueManager`, JSONCPP.
+
+## Global Constraints
+
+- Keep production interfaces and runtime behavior unchanged.
+- Use the existing fake AgentSight FFI table; do not require a live AgentSight library or enforcer.
+- Isolate singleton process-queue state within each test.
+- Assert observable output fields and validation results, not implementation call counts alone.
+
+---
+
+### Task 1: Security-event conversion behavior
+
+**Files:**
+- Modify: `core/unittest/ebpf/AgentsightManagerUnittest.cpp`
+
+**Interfaces:**
+- Consumes: `AgentsightManager::HandleEvent(const std::shared_ptr<CommonEvent>&)`, `AgentsightSecurityRecord`, `ProcessQueueManager::PopItem`.
+- Produces: tests for valid and malformed security JSON conversion.
+
+- [ ] **Step 1: Add queue cleanup and a registered-queue helper**
+
+Include `QueueKeyManager.h` and `ProcessQueueManager.h`. Track created queue keys in the fixture, delete them in `TearDown`, and add a helper that creates/enables a count-bounded queue before registering the manager config.
+
+```cpp
+QueueKey registerConfigWithQueue(AgentsightManager& mgr, const char* configName) {
+    const QueueKey key = QueueKeyManager::GetInstance()->GetKey(configName);
+    CollectionPipelineContext ctx;
+    ctx.SetConfigName(configName);
+    ctx.SetProcessQueueKey(key);
+    APSARA_TEST_TRUE(ProcessQueueManager::GetInstance()->CreateOrUpdateCountBoundedQueue(key, 0, ctx));
+    ProcessQueueManager::GetInstance()->EnablePop(configName);
+    APSARA_TEST_EQUAL(0, mgr.AddOrUpdateConfig(&ctx, 0, nullptr, asVariant()));
+    mProcessQueueKeys.push_back(key);
+    return key;
+}
+```
+
+- [ ] **Step 2: Write the valid-event behavior test**
+
+Create a `policy_decision` payload containing event identifiers, timestamps, full identity fields, nested strings, booleans, signed/unsigned integers, and a double. Send the record through `HandleEvent`, pop the queue item, and assert representative fields.
+
+```cpp
+APSARA_TEST_EQUAL("agentsight.security.policy_decision", log.GetContent("event.name").to_string());
+APSARA_TEST_EQUAL("policy_decision", log.GetContent("event.type").to_string());
+APSARA_TEST_EQUAL("agent-1", log.GetContent("agent.id").to_string());
+APSARA_TEST_EQUAL("85", log.GetContent("security.risk_score").to_string());
+APSARA_TEST_EQUAL("true", log.GetContent("security.blocked").to_string());
+APSARA_TEST_EQUAL(payload, log.GetContent("event.original").to_string());
+```
+
+- [ ] **Step 3: Verify the valid-event test detects a mutation**
+
+Temporarily change one asserted production mapping, such as `event.type`, to a different key. Build/run `agentsight_manager_unittest` and expect the new test to fail on the missing field. Restore the production line immediately and confirm `git diff` contains only test changes.
+
+- [ ] **Step 4: Write the malformed-JSON fallback test**
+
+Send `{not-json` through the same queue path and assert the event is still emitted with `event.name=agentsight.security`, `event.kind=event`, schema version, timestamp, and exact `event.original`, while parsed fields such as `event.id` remain empty.
+
+- [ ] **Step 5: Run targeted manager tests**
+
+Run the repository's Linux unit-test build for `agentsight_manager_unittest`, then execute the binary. Expected: both new tests and all existing manager tests pass.
+
+- [ ] **Step 6: Commit manager tests**
+
+```bash
+git add core/unittest/ebpf/AgentsightManagerUnittest.cpp
+git commit -m "test(agentsight): cover security event conversion"
+```
+
+### Task 2: SecurityAudit configuration validation
+
+**Files:**
+- Modify: `core/unittest/input/InputAgentSightUnittest.cpp`
+
+**Interfaces:**
+- Consumes: `InputAgentSight::Init(const Json::Value&, Json::Value&)`.
+- Produces: tests for default, malformed, and empty-socket `SecurityAudit` configuration.
+
+- [ ] **Step 1: Add the default-socket test**
+
+Initialize with `"SecurityAudit":{"Enabled":true}` and assert initialization succeeds, security audit is enabled, and the socket remains `/run/agentsight/enforcer.sock`.
+
+- [ ] **Step 2: Add invalid configuration tests**
+
+Initialize separate inputs with `"SecurityAudit":true`, `"SecurityAudit":{"Enabled":"yes"}`, and `"SecurityAudit":{"EnforcerSocket":""}`. Assert each initialization fails.
+
+- [ ] **Step 3: Verify a configuration test detects a mutation**
+
+Temporarily change the default socket initialization in `SecurityOptions::Init` to a different path. Run `input_ebpf_agentsight_unittest` and expect the default-socket assertion to fail. Restore the production line immediately.
+
+- [ ] **Step 4: Run targeted input tests**
+
+Build and execute `input_ebpf_agentsight_unittest`. Expected: all existing and new cases pass.
+
+- [ ] **Step 5: Commit configuration tests**
+
+```bash
+git add core/unittest/input/InputAgentSightUnittest.cpp
+git commit -m "test(agentsight): cover security audit validation"
+```
+
+### Task 3: Verification and PR update
+
+**Files:**
+- Verify: all committed files in the branch.
+
+**Interfaces:**
+- Consumes: the two test commits.
+- Produces: updated PR #2670 with passing coverage-oriented tests.
+
+- [ ] **Step 1: Run local static verification**
+
+Run `git diff --check`, clang-format dry-run for both modified C++ test files, `make check-license`, and the security-check push scan.
+
+- [ ] **Step 2: Inspect the final diff**
+
+Confirm only the two test files and the approved design/plan documents were added after the prior fix. Preserve unrelated untracked files.
+
+- [ ] **Step 3: Publish the branch**
+
+Update `codex/agentsight-unified-events` on the fork and verify the remote tree SHA equals the local tree SHA.
+
+- [ ] **Step 4: Monitor CI**
+
+Confirm `BuildCoreUT` diff coverage is at least 60%. Once the E2E workflow permits reruns, rerun the failed `input_static_file` job and verify whether the Docker Hub timeout clears.

--- a/docs/superpowers/specs/2026-07-31-agentsight-security-coverage-tests-design.md
+++ b/docs/superpowers/specs/2026-07-31-agentsight-security-coverage-tests-design.md
@@ -1,0 +1,39 @@
+# AgentSight Security Coverage Tests Design
+
+## Context
+
+PR #2670 successfully builds and passes its C++ unit tests, but the CI diff-coverage gate reports 30.9%, below the required 60%. The uncovered additions are concentrated in AgentSight security-event conversion and `SecurityAudit` configuration validation.
+
+## Goal
+
+Raise meaningful diff coverage above the repository threshold by testing externally observable behavior. The tests must validate emitted log contents and configuration outcomes rather than merely execute lines.
+
+## Selected approach
+
+Extend the existing `AgentsightManagerUnittest` and `InputAgentSightUnittest` fixtures.
+
+1. Feed an `AgentsightSecurityRecord` through `AgentsightManager::HandleEvent` after registering a real count-bounded process queue.
+2. Pop the resulting `ProcessQueueItem` and assert the generated `LogEvent` fields, including the event envelope, identity fields, flattened security payload, schema version, original JSON, and timestamps.
+3. Add a malformed-JSON case that verifies the raw event is still emitted with its stable envelope fields.
+4. Add input configuration cases for an invalid `SecurityAudit` value, an empty enforcer socket, and the default socket path.
+
+This keeps production interfaces unchanged and exercises the same queue and event-model path used at runtime.
+
+## Alternatives considered
+
+- Expose JSON conversion helpers directly to tests. This would simplify unit setup but enlarge the production/test API and bypass queue integration.
+- Exclude the new lines from coverage or lower the threshold. This would silence CI without validating behavior and is rejected.
+
+## Test boundaries
+
+- Reuse existing fake AgentSight FFI symbols; no live AgentSight library or enforcer is required.
+- Create and remove queue state within each test so singleton queue state cannot leak between cases.
+- Assert representative scalar types and nested fields without duplicating every JSON key.
+- Do not change production behavior unless a test uncovers an actual defect.
+
+## Success criteria
+
+- New behavior tests pass in the targeted C++ unit-test binaries.
+- Existing AgentSight manager and input tests remain green.
+- CI diff coverage reaches at least 60%.
+- Linux build, compatibility, and static checks remain green.


### PR DESCRIPTION
## Summary

- extend `input_agentsight` with opt-in `SecurityAudit` configuration
- dynamically use AgentSight's unified event API when available while retaining the legacy read path
- convert normalized security events into LoongCollector `LogEvent`s and preserve the original event JSON
- add compatibility coverage for both old and new AgentSight SDK headers

## Why

AgentSight's system-audit events should flow through the existing AgentSight input instead of introducing a second security-only FFI handle and input plugin. This keeps lifecycle, eventfd polling, backpressure, and deployment configuration unified while preserving ABI compatibility.

## Dependency

- AgentSight producer/API: https://github.com/alibaba/anolisa/pull/2051

The feature is disabled by default. With an older AgentSight library, the input falls back to the legacy LLM event API.

## Validation

- `make check-license`
- clang-format dry-run and `git diff --check`
- C/C++ syntax checks against generated old and new AgentSight headers
- AgentSight protocol tests: 15 passed
- `cargo check -p agentsight --lib`
- cbindgen export/header consistency checks

Full Linux-only AgentSight FFI and LoongCollector unit suites are left to CI because the local host is macOS and Docker is unavailable.

