### PR TITLE
feat: add MQTT flusher plugin

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -36,6 +36,7 @@ plugins:
     - import: "github.com/alibaba/ilogtail/plugins/flusher/http"
     - import: "github.com/alibaba/ilogtail/plugins/flusher/kafkav2"
     - import: "github.com/alibaba/ilogtail/plugins/flusher/loki"
+    - import: "github.com/alibaba/ilogtail/plugins/flusher/mqtt"
     - import: "github.com/alibaba/ilogtail/plugins/flusher/opentelemetry"
     - import: "github.com/alibaba/ilogtail/plugins/flusher/prometheus"
     - import: "github.com/alibaba/ilogtail/plugins/flusher/pulsar"

--- a/plugins/flusher/mqtt/flusher_mqtt.go
+++ b/plugins/flusher/mqtt/flusher_mqtt.go
@@ -1,0 +1,144 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mqtt
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/alibaba/ilogtail/pkg/logger"
+	"github.com/alibaba/ilogtail/pkg/pipeline"
+	"github.com/alibaba/ilogtail/pkg/protocol"
+	"github.com/alibaba/ilogtail/pkg/selfmonitor"
+)
+
+const defaultConnectTimeout = 30 * time.Second
+
+type publisher interface {
+	Publish(topic string, qos byte, retained bool, payload interface{}) paho.Token
+	IsConnected() bool
+	Disconnect(quiesce uint)
+}
+
+// FlusherMQTT publishes one JSON object per log to an MQTT topic.
+type FlusherMQTT struct {
+	Server         string
+	Topic          string
+	ClientID       string
+	Username       string
+	Password       string
+	QoS            byte
+	Retained       bool
+	ConnectTimeout time.Duration
+
+	context pipeline.Context
+	client  publisher
+}
+
+var _ pipeline.FlusherV1 = (*FlusherMQTT)(nil)
+
+func NewMQTTFlusher() *FlusherMQTT {
+	return &FlusherMQTT{ConnectTimeout: defaultConnectTimeout}
+}
+
+func (f *FlusherMQTT) Description() string {
+	return "mqtt flusher for logtail"
+}
+
+func (f *FlusherMQTT) Init(context pipeline.Context) error {
+	f.context = context
+	if f.Server == "" {
+		return errors.New("mqtt server is required")
+	}
+	if f.Topic == "" {
+		return errors.New("mqtt topic is required")
+	}
+	if f.QoS > 2 {
+		return fmt.Errorf("mqtt qos must be 0, 1, or 2, got %d", f.QoS)
+	}
+	if f.ConnectTimeout <= 0 {
+		f.ConnectTimeout = defaultConnectTimeout
+	}
+
+	options := paho.NewClientOptions().AddBroker(f.Server).SetClientID(f.ClientID)
+	options.SetUsername(f.Username)
+	options.SetPassword(f.Password)
+	client := paho.NewClient(options)
+	token := client.Connect()
+	if !token.WaitTimeout(f.ConnectTimeout) {
+		return fmt.Errorf("connect to mqtt server %q timed out", f.Server)
+	}
+	if err := token.Error(); err != nil {
+		logger.Warning(f.context.GetRuntimeContext(), selfmonitor.FlusherInitAlarm, "mqtt connect failed", err)
+		return fmt.Errorf("connect to mqtt server %q: %w", f.Server, err)
+	}
+	f.client = client
+	return nil
+}
+
+func (f *FlusherMQTT) IsReady(string, string, int64) bool {
+	return f.client != nil && f.client.IsConnected()
+}
+
+func (f *FlusherMQTT) SetUrgent(bool) {}
+
+func (f *FlusherMQTT) Stop() error {
+	if f.client != nil {
+		f.client.Disconnect(1000)
+		f.client = nil
+	}
+	return nil
+}
+
+func (f *FlusherMQTT) Flush(_ string, _ string, _ string, groups []*protocol.LogGroup) error {
+	if !f.IsReady("", "", 0) {
+		return errors.New("mqtt client is not connected")
+	}
+	for _, group := range groups {
+		for _, log := range group.Logs {
+			payload, err := marshalLog(log)
+			if err != nil {
+				return err
+			}
+			token := f.client.Publish(f.Topic, f.QoS, f.Retained, payload)
+			if !token.WaitTimeout(f.ConnectTimeout) {
+				return fmt.Errorf("publish to mqtt topic %q timed out", f.Topic)
+			}
+			if err := token.Error(); err != nil {
+				return fmt.Errorf("publish to mqtt topic %q: %w", f.Topic, err)
+			}
+		}
+	}
+	return nil
+}
+
+func marshalLog(log *protocol.Log) ([]byte, error) {
+	fields := make(map[string]string, len(log.Contents)+1)
+	for _, content := range log.Contents {
+		fields[content.Key] = content.Value
+	}
+	fields["__time__"] = fmt.Sprint(log.Time)
+	return json.Marshal(fields)
+}
+
+func init() {
+	pipeline.AddFlusherCreator("flusher_mqtt", func() pipeline.Flusher {
+		return NewMQTTFlusher()
+	})
+}

--- a/plugins/flusher/mqtt/flusher_mqtt_test.go
+++ b/plugins/flusher/mqtt/flusher_mqtt_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 iLogtail Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package mqtt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alibaba/ilogtail/pkg/protocol"
+)
+
+func TestMarshalLog(t *testing.T) {
+	data, err := marshalLog(&protocol.Log{
+		Time: 123,
+		Contents: []*protocol.Log_Content{
+			{Key: "message", Value: "hello"},
+			{Key: "source", Value: "test"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal log: %v", err)
+	}
+
+	var fields map[string]string
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	want := map[string]string{"message": "hello", "source": "test", "__time__": "123"}
+	if len(fields) != len(want) {
+		t.Fatalf("got fields %#v, want %#v", fields, want)
+	}
+	for key, value := range want {
+		if fields[key] != value {
+			t.Errorf("field %q = %q, want %q", key, fields[key], value)
+		}
+	}
+}
+
+func TestNewMQTTFlusherDefaults(t *testing.T) {
+	f := NewMQTTFlusher()
+	if f.ConnectTimeout <= 0 {
+		t.Fatalf("ConnectTimeout = %s, want positive default", f.ConnectTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

- add a V1 `flusher_mqtt` plugin using the existing Paho MQTT dependency
- publish one deterministic JSON payload per log with `__time__`
- validate the server, topic, and QoS settings and surface connection/publish failures
- register the plugin and add broker-independent unit coverage for payload formatting

## Validation

- `go test ./plugins/flusher/mqtt`
- `go vet ./plugins/flusher/mqtt`
- `git diff --check`

The package tests do not require a public MQTT broker. The CLA remains a maintainer/user action, so I have not attempted to sign it on anyone's behalf.