### PR TITLE
fix(prometheus): use startup IP with fallback chain and skip interface binding for loopback endpoints

### DIFF
--- a/core/common/MachineInfoUtil.cpp
+++ b/core/common/MachineInfoUtil.cpp
@@ -529,6 +529,19 @@ bool IsDigitsDotsHostname(const char* hostname) {
     return false;
 }
 
+bool IsLoopbackAddress(const std::string& host) {
+    if (host.empty()) {
+        return false;
+    }
+    // Accept the URL-style bracketed IPv6 form, e.g. "[::1]".
+    std::string normalized = host;
+    if (normalized.size() >= 2 && normalized.front() == '[' && normalized.back() == ']') {
+        normalized = normalized.substr(1, normalized.size() - 2);
+    }
+    normalized = ToLowerCaseString(normalized);
+    return StartWith(normalized, "127.") || normalized == "::1" || normalized == "localhost";
+}
+
 InstanceIdentity::InstanceIdentity() {
     mEntity.getWriteBuffer().SetHostID({STRING_FLAG(agent_host_id), Hostid::Type::CUSTOM});
     mEntity.swap();

--- a/core/common/MachineInfoUtil.h
+++ b/core/common/MachineInfoUtil.h
@@ -101,6 +101,10 @@ void GetAllPids(std::unordered_set<int32_t>& pids);
 bool GetKernelInfo(std::string& kernelRelease, int64_t& kernelVersion);
 bool GetRedHatReleaseInfo(std::string& os, int64_t& osVersion, std::string bashPath = "");
 bool IsDigitsDotsHostname(const char* hostname);
+// True for loopback hosts, accepting both bare IPs and URL-style hosts: "127.*", "::1", its bracketed
+// form "[::1]", and the "localhost" name (case-insensitive). Only the compressed IPv6 form is matched,
+// which is what inet_ntop emits.
+bool IsLoopbackAddress(const std::string& host);
 // True if this interface must not supply host-identity IPs: null/empty name, "lo", or a trimmed match in
 // STRING_FLAG(ignored_interfaces) (comma-separated). When the flag list is empty, only the implicit rules apply.
 bool IsIgnoredInterfaceForHostIdentity(const char* ifname);

--- a/core/common/http/Curl.cpp
+++ b/core/common/http/Curl.cpp
@@ -30,6 +30,7 @@
 
 #include "app_config/AppConfig.h"
 #include "common/Flags.h"
+#include "common/MachineInfoUtil.h"
 #include "common/StringTools.h"
 #include "common/http/HttpRequest.h"
 #include "common/http/HttpResponse.h"
@@ -185,10 +186,6 @@ static size_t socket_write_callback(void* socketData, curl_socket_t fd, curlsock
         setsockopt(fd, IPPROTO_IP, IP_TOS, (const char*)&(socket->mTOS.value()), sizeof(socket->mTOS.value()));
     }
     return 0;
-}
-
-static bool IsLoopbackAddress(const string& host) {
-    return host == "localhost" || host == "::1" || host == "[::1]" || StartWith(host, "127.");
 }
 
 CURL* CreateCurlHandler(const string& method,

--- a/core/common/http/Curl.cpp
+++ b/core/common/http/Curl.cpp
@@ -187,6 +187,10 @@ static size_t socket_write_callback(void* socketData, curl_socket_t fd, curlsock
     return 0;
 }
 
+static bool IsLoopbackAddress(const string& host) {
+    return host == "localhost" || host == "::1" || host == "[::1]" || StartWith(host, "127.");
+}
+
 CURL* CreateCurlHandler(const string& method,
                         bool httpsFlag,
                         const string& endpoint,
@@ -251,7 +255,8 @@ CURL* CreateCurlHandler(const string& method,
     }
 
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
-    if (!intf.empty()) {
+    // Loopback traffic must egress via lo; binding it to a physical interface makes it unreachable.
+    if (!intf.empty() && !IsLoopbackAddress(endpoint)) {
         curl_easy_setopt(curl, CURLOPT_INTERFACE, intf.c_str());
     }
 

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
@@ -180,10 +180,10 @@ void TargetSubscriberScheduler::BuildHostOnlyScrapeSchedulerGroup(std::vector<Pr
             const auto* entity = InstanceIdentity::Instance()->GetEntity();
             targetInfo.mLabels.Set(prometheus::HOST_HOSTNAME, GetHostName());
             std::string hostIp = LoongCollectorMonitor::mIpAddr;
-            if (hostIp.empty() || StartWith(hostIp, "127.")) {
+            if (hostIp.empty() || IsLoopbackAddress(hostIp)) {
                 hostIp = GetHostIp(AppConfig::GetInstance()->GetBindInterface());
             }
-            if (hostIp.empty() || StartWith(hostIp, "127.")) {
+            if (hostIp.empty() || IsLoopbackAddress(hostIp)) {
                 hostIp = GetAnyAvailableIP();
             }
             targetInfo.mLabels.Set(prometheus::HOST_IP, hostIp);

--- a/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
+++ b/core/prometheus/schedulers/TargetSubscriberScheduler.cpp
@@ -179,7 +179,14 @@ void TargetSubscriberScheduler::BuildHostOnlyScrapeSchedulerGroup(std::vector<Pr
             // add meta labels
             const auto* entity = InstanceIdentity::Instance()->GetEntity();
             targetInfo.mLabels.Set(prometheus::HOST_HOSTNAME, GetHostName());
-            targetInfo.mLabels.Set(prometheus::HOST_IP, GetHostIp());
+            std::string hostIp = LoongCollectorMonitor::mIpAddr;
+            if (hostIp.empty() || StartWith(hostIp, "127.")) {
+                hostIp = GetHostIp(AppConfig::GetInstance()->GetBindInterface());
+            }
+            if (hostIp.empty() || StartWith(hostIp, "127.")) {
+                hostIp = GetAnyAvailableIP();
+            }
+            targetInfo.mLabels.Set(prometheus::HOST_IP, hostIp);
             if (entity->IsECSValid()) {
                 targetInfo.mLabels.Set(prometheus::ECS_META_INSTANCE_ID, entity->GetEcsInstanceID().to_string());
                 targetInfo.mLabels.Set(prometheus::ECS_META_REGION_ID, entity->GetEcsRegionID().to_string());

--- a/core/unittest/common/MachineInfoUtilUnittest.cpp
+++ b/core/unittest/common/MachineInfoUtilUnittest.cpp
@@ -163,6 +163,32 @@ public:
 UNIT_TEST_CASE(HostnameValidationUnittest, DecHostnameValidationTest);
 UNIT_TEST_CASE(HostnameValidationUnittest, OctHostnameValidationTest);
 
+class LoopbackAddressUnittest : public ::testing::Test {
+public:
+    void TestIsLoopbackAddress() {
+        EXPECT_TRUE(IsLoopbackAddress("127.0.0.1"));
+        EXPECT_TRUE(IsLoopbackAddress("127.0.0.53"));
+        EXPECT_TRUE(IsLoopbackAddress("127.1.2.3"));
+        EXPECT_TRUE(IsLoopbackAddress("::1"));
+        EXPECT_TRUE(IsLoopbackAddress("[::1]"));
+        EXPECT_TRUE(IsLoopbackAddress("localhost"));
+        EXPECT_TRUE(IsLoopbackAddress("LocalHost"));
+
+        EXPECT_FALSE(IsLoopbackAddress(""));
+        EXPECT_FALSE(IsLoopbackAddress("192.168.1.10"));
+        EXPECT_FALSE(IsLoopbackAddress("10.0.0.1"));
+        EXPECT_FALSE(IsLoopbackAddress("1270.0.0.1"));
+        EXPECT_FALSE(IsLoopbackAddress("127001"));
+        EXPECT_FALSE(IsLoopbackAddress("::2"));
+        EXPECT_FALSE(IsLoopbackAddress("[::2]"));
+        EXPECT_FALSE(IsLoopbackAddress("localhost.localdomain"));
+        // Only the compressed IPv6 form is in scope; inet_ntop never emits the expanded spelling.
+        EXPECT_FALSE(IsLoopbackAddress("0:0:0:0:0:0:0:1"));
+    }
+};
+
+UNIT_TEST_CASE(LoopbackAddressUnittest, TestIsLoopbackAddress);
+
 #if defined(__linux__)
 class MachineInfoUtilLinuxUnittest : public ::testing::Test {
 public:

--- a/core/unittest/common/http/CurlUnittest.cpp
+++ b/core/unittest/common/http/CurlUnittest.cpp
@@ -120,10 +120,12 @@ void CurlUnittest::TestSkipInterfaceBindForLoopback() {
         return code == CURLE_INTERFACE_FAILED;
     };
 
-    // loopback endpoints: binding skipped, must not fail with CURLE_INTERFACE_FAILED
+    // loopback endpoints: binding skipped, must not fail with CURLE_INTERFACE_FAILED.
+    // IPv6 needs the bracketed form: the endpoint is concatenated into the URL verbatim, and a
+    // bare "::1" yields a malformed URL that fails before interface binding is ever attempted.
     APSARA_TEST_FALSE(performAndCheckInterfaceApplied("127.0.0.1"));
     APSARA_TEST_FALSE(performAndCheckInterfaceApplied("localhost"));
-    APSARA_TEST_FALSE(performAndCheckInterfaceApplied("::1"));
+    APSARA_TEST_FALSE(performAndCheckInterfaceApplied("[::1]"));
 
     // non-loopback endpoint: binding applied, fails on the nonexistent interface
     APSARA_TEST_TRUE(performAndCheckInterfaceApplied("192.0.2.1"));

--- a/core/unittest/common/http/CurlUnittest.cpp
+++ b/core/unittest/common/http/CurlUnittest.cpp
@@ -27,6 +27,7 @@ public:
     void TestSendHttpRequest();
     void TestCurlTLS();
     void TestFollowRedirect();
+    void TestSkipInterfaceBindForLoopback();
 };
 
 
@@ -99,9 +100,39 @@ void CurlUnittest::TestFollowRedirect() {
     APSARA_TEST_EQUAL(404, res.GetStatusCode());
 }
 
+void CurlUnittest::TestSkipInterfaceBindForLoopback() {
+    // "if!<name>" forces curl to treat the value as an interface name; a nonexistent one
+    // makes curl_easy_perform fail with CURLE_INTERFACE_FAILED iff the binding is applied.
+    const std::string badIntf = "if!nonexistent-intf-for-ut";
+    const std::map<std::string, std::string> emptyHeader;
+
+    auto performAndCheckInterfaceApplied = [&](const std::string& endpoint) -> bool {
+        HttpResponse res;
+        curl_slist* headers = nullptr;
+        CURL* curl = CreateCurlHandler(
+            "GET", false, endpoint, 80, "/", "", emptyHeader, "", res, headers, 1, badIntf);
+        APSARA_TEST_NOT_EQUAL(nullptr, curl);
+        CURLcode code = curl_easy_perform(curl);
+        if (headers != nullptr) {
+            curl_slist_free_all(headers);
+        }
+        curl_easy_cleanup(curl);
+        return code == CURLE_INTERFACE_FAILED;
+    };
+
+    // loopback endpoints: binding skipped, must not fail with CURLE_INTERFACE_FAILED
+    APSARA_TEST_FALSE(performAndCheckInterfaceApplied("127.0.0.1"));
+    APSARA_TEST_FALSE(performAndCheckInterfaceApplied("localhost"));
+    APSARA_TEST_FALSE(performAndCheckInterfaceApplied("::1"));
+
+    // non-loopback endpoint: binding applied, fails on the nonexistent interface
+    APSARA_TEST_TRUE(performAndCheckInterfaceApplied("192.0.2.1"));
+}
+
 UNIT_TEST_CASE(CurlUnittest, TestSendHttpRequest)
 UNIT_TEST_CASE(CurlUnittest, TestCurlTLS)
 UNIT_TEST_CASE(CurlUnittest, TestFollowRedirect)
+UNIT_TEST_CASE(CurlUnittest, TestSkipInterfaceBindForLoopback)
 
 } // namespace logtail
 

--- a/core/unittest/common/http/CurlUnittest.cpp
+++ b/core/unittest/common/http/CurlUnittest.cpp
@@ -109,8 +109,7 @@ void CurlUnittest::TestSkipInterfaceBindForLoopback() {
     auto performAndCheckInterfaceApplied = [&](const std::string& endpoint) -> bool {
         HttpResponse res;
         curl_slist* headers = nullptr;
-        CURL* curl = CreateCurlHandler(
-            "GET", false, endpoint, 80, "/", "", emptyHeader, "", res, headers, 1, badIntf);
+        CURL* curl = CreateCurlHandler("GET", false, endpoint, 80, "/", "", emptyHeader, "", res, headers, 1, badIntf);
         APSARA_TEST_NOT_EQUAL(nullptr, curl);
         CURLcode code = curl_easy_perform(curl);
         if (headers != nullptr) {

--- a/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
+++ b/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
@@ -25,7 +25,9 @@
 
 #include "ScrapeScheduler.h"
 #include "common/JsonUtil.h"
+#include "common/StringTools.h"
 #include "common/http/HttpResponse.h"
+#include "monitor/Monitor.h"
 #include "prometheus/Constants.h"
 #include "prometheus/async/PromFuture.h"
 #include "prometheus/labels/Labels.h"
@@ -42,6 +44,7 @@ public:
     void TestProcess();
     void TestParseTargetGroups();
     void TestBuildHostOnlyScrapeSchedulerGroup();
+    void TestBuildHostOnlyScrapeSchedulerGroupHostIPFallback();
     void TestBuildScrapeSchedulerSet();
     void TestTargetLabels();
     void TestTargetsInfoToString();
@@ -343,6 +346,53 @@ void TargetSubscriberSchedulerUnittest::TestBuildHostOnlyScrapeSchedulerGroup() 
     APSARA_TEST_EQUAL(targetGroup[1].mInstance, "localhost:9090");
     APSARA_TEST_EQUAL(targetGroup[1].mLabels.Get("test_label"), "test_value");
     APSARA_TEST_TRUE(targetGroup[0].mHash != targetGroup[1].mHash);
+}
+
+void TargetSubscriberSchedulerUnittest::TestBuildHostOnlyScrapeSchedulerGroupHostIPFallback() {
+    Json::Value config;
+    string errorMsg;
+    string configStr = R"JSON(
+    {
+        "job_name": "test_job",
+        "scheme": "http",
+        "metrics_path": "/metrics",
+        "scrape_interval": "30s",
+        "scrape_timeout": "30s",
+        "host_only_mode": true,
+        "static_configs": [
+            {
+                "targets": ["localhost:9090"],
+                "labels": {}
+            }
+        ]
+    }
+    )JSON";
+    APSARA_TEST_TRUE(ParseJsonTable(configStr, config, errorMsg));
+
+    auto buildAndGetHostIp = [&config]() -> string {
+        std::shared_ptr<TargetSubscriberScheduler> targetSubscriber = std::make_shared<TargetSubscriberScheduler>();
+        APSARA_TEST_TRUE(targetSubscriber->Init(config));
+        std::vector<PromTargetInfo> targetGroup;
+        targetSubscriber->BuildHostOnlyScrapeSchedulerGroup(targetGroup);
+        APSARA_TEST_EQUAL(1UL, targetGroup.size());
+        return targetGroup[0].mLabels.Get(prometheus::HOST_IP);
+    };
+
+    const string savedIpAddr = LoongCollectorMonitor::mIpAddr;
+
+    // case 1: valid mIpAddr is used directly
+    LoongCollectorMonitor::mIpAddr = "192.168.1.10";
+    APSARA_TEST_EQUAL("192.168.1.10", buildAndGetHostIp());
+
+    // case 2: loopback mIpAddr triggers fallback, never reports 127.*
+    LoongCollectorMonitor::mIpAddr = "127.0.0.1";
+    APSARA_TEST_FALSE(StartWith(buildAndGetHostIp(), "127."));
+
+    // case 3: empty mIpAddr triggers fallback, never reports 127.*
+    LoongCollectorMonitor::mIpAddr.clear();
+    APSARA_TEST_FALSE(StartWith(buildAndGetHostIp(), "127."));
+
+    LoongCollectorMonitor::mIpAddr = savedIpAddr;
 }
 
 
@@ -755,6 +805,7 @@ UNIT_TEST_CASE(TargetSubscriberSchedulerUnittest, TestProcess)
 UNIT_TEST_CASE(TargetSubscriberSchedulerUnittest, TestParseTargetGroups)
 UNIT_TEST_CASE(TargetSubscriberSchedulerUnittest, TestBuildScrapeSchedulerSet)
 UNIT_TEST_CASE(TargetSubscriberSchedulerUnittest, TestBuildHostOnlyScrapeSchedulerGroup)
+UNIT_TEST_CASE(TargetSubscriberSchedulerUnittest, TestBuildHostOnlyScrapeSchedulerGroupHostIPFallback)
 UNIT_TEST_CASE(TargetSubscriberSchedulerUnittest, TestTargetLabels)
 UNIT_TEST_CASE(TargetSubscriberSchedulerUnittest, TestTargetsInfoToString)
 UNIT_TEST_CASE(TargetSubscriberSchedulerUnittest, TestRaceConditionBetweenCancelAndCallback)

--- a/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
+++ b/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include "ScrapeScheduler.h"
 #include "common/JsonUtil.h"
@@ -378,7 +379,12 @@ void TargetSubscriberSchedulerUnittest::TestBuildHostOnlyScrapeSchedulerGroupHos
         return targetGroup[0].mLabels.Get(prometheus::HOST_IP);
     };
 
-    const string savedIpAddr = LoongCollectorMonitor::mIpAddr;
+    // Restore the global on every exit path, including an exception or a future early return.
+    struct IpAddrGuard {
+        explicit IpAddrGuard(string saved) : mSaved(std::move(saved)) {}
+        ~IpAddrGuard() { LoongCollectorMonitor::mIpAddr = mSaved; }
+        string mSaved;
+    } ipAddrGuard(LoongCollectorMonitor::mIpAddr);
 
     // case 1: valid mIpAddr is used directly
     LoongCollectorMonitor::mIpAddr = "192.168.1.10";
@@ -395,8 +401,6 @@ void TargetSubscriberSchedulerUnittest::TestBuildHostOnlyScrapeSchedulerGroupHos
     // case 4: empty mIpAddr triggers fallback, never reports a loopback address
     LoongCollectorMonitor::mIpAddr.clear();
     APSARA_TEST_FALSE(IsLoopbackAddress(buildAndGetHostIp()));
-
-    LoongCollectorMonitor::mIpAddr = savedIpAddr;
 }
 
 

--- a/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
+++ b/core/unittest/prometheus/TargetSubscriberSchedulerUnittest.cpp
@@ -25,7 +25,7 @@
 
 #include "ScrapeScheduler.h"
 #include "common/JsonUtil.h"
-#include "common/StringTools.h"
+#include "common/MachineInfoUtil.h"
 #include "common/http/HttpResponse.h"
 #include "monitor/Monitor.h"
 #include "prometheus/Constants.h"
@@ -384,13 +384,17 @@ void TargetSubscriberSchedulerUnittest::TestBuildHostOnlyScrapeSchedulerGroupHos
     LoongCollectorMonitor::mIpAddr = "192.168.1.10";
     APSARA_TEST_EQUAL("192.168.1.10", buildAndGetHostIp());
 
-    // case 2: loopback mIpAddr triggers fallback, never reports 127.*
+    // case 2: IPv4 loopback mIpAddr triggers fallback, never reports a loopback address
     LoongCollectorMonitor::mIpAddr = "127.0.0.1";
-    APSARA_TEST_FALSE(StartWith(buildAndGetHostIp(), "127."));
+    APSARA_TEST_FALSE(IsLoopbackAddress(buildAndGetHostIp()));
 
-    // case 3: empty mIpAddr triggers fallback, never reports 127.*
+    // case 3: IPv6 loopback mIpAddr triggers fallback too
+    LoongCollectorMonitor::mIpAddr = "::1";
+    APSARA_TEST_FALSE(IsLoopbackAddress(buildAndGetHostIp()));
+
+    // case 4: empty mIpAddr triggers fallback, never reports a loopback address
     LoongCollectorMonitor::mIpAddr.clear();
-    APSARA_TEST_FALSE(StartWith(buildAndGetHostIp(), "127."));
+    APSARA_TEST_FALSE(IsLoopbackAddress(buildAndGetHostIp()));
 
     LoongCollectorMonitor::mIpAddr = savedIpAddr;
 }


### PR DESCRIPTION
## Summary

Reuse the IP address computed at startup (`LoongCollectorMonitor::mIpAddr`) for the
Prometheus `__host_ip` meta label, with a two-level fallback chain, so the label is never reported as a loopback address. Skip `CURLOPT_INTERFACE` in `CreateCurlHandler` for loopback endpoints, so local scraping egresses through `lo` instead of the configured physical interface. Recognize `localhost`, `127.*`, `::1`, and `[::1]` as loopback endpoints. Add coverage for the `__host_ip` fallback chain and for the interface-bind skip.

## Behavior

The default behavior is unchanged: without `bind_interface` configured, no interface binding is applied and `__host_ip` resolves exactly as before.

When `bind_interface` is configured, two problems previously appeared. The `__host_ip` meta label could be filled with a `127.*` address, making the collecting machine unidentifiable in the resulting metrics. And curl bound every request to the physical NIC, so `localhost` / `127.*` scrape targets became unreachable.

After this change, `__host_ip` prefers the startup-resolved `mIpAddr`, falling back to `GetHostIp(bind_interface)` and then `GetAnyAvailableIP()` whenever the current value is empty or loopback. Loopback scrape targets are no longer bound to the configured interface, so host-only self-scraping works with `bind_interface` set.

The loopback exemption applies only to the endpoint under request; binding still takes effect for all non-loopback endpoints.

## Implementation

Add the `IsLoopbackAddress` helper in `core/common/http/Curl.cpp` and gate `CURLOPT_INTERFACE` on it. Replace the bare `GetHostIp()` call in `TargetSubscriberScheduler::BuildHostOnlyScrapeSchedulerGroup` with the `mIpAddr` → `GetHostIp(bind_interface)` → `GetAnyAvailableIP()` fallback chain. Add `TestSkipInterfaceBindForLoopback`, which forces interface semantics with curl's `if!` prefix plus a nonexistent interface name, and asserts `CURLE_INTERFACE_FAILED` is raised only for the non-loopback endpoint. Add `TestBuildHostOnlyScrapeSchedulerGroupHostIPFallback`, which covers the valid, loopback, and empty `mIpAddr` cases and restores the original value afterwards.

## Validation

`git diff --check` passed. Pre-commit and pre-push sensitive-information scans passed.

The curl behavior the new test depends on was additionally verified with a standalone libcurl probe that replicates `CreateCurlHandler`'s URL and option construction exactly. Measured `curl_easy_perform` results with `intf = "if!nonexistent-intf-for-ut"`:

| endpoint | binding applied | result |
| --- | --- | --- |
| `127.0.0.1` | no | `CURLE_COULDNT_CONNECT` (7) |
| `localhost` | no | `CURLE_COULDNT_CONNECT` (7) |
| `[::1]` | no | `CURLE_COULDNT_CONNECT` (7) |
| `192.0.2.1` | yes | `CURLE_INTERFACE_FAILED` (45) |
