### PR TITLE
fix: support otlp_log_v1 protobuf output in kafka flusher

### DIFF
--- a/pkg/protocol/converter/converter.go
+++ b/pkg/protocol/converter/converter.go
@@ -29,6 +29,7 @@ const (
 	ProtocolCustomSingle        = "custom_single"
 	ProtocolCustomSingleFlatten = "custom_single_flatten"
 	ProtocolOtlpV1              = "otlp_v1"
+	ProtocolOtlpLogV1           = "otlp_log_v1"
 	ProtocolInfluxdb            = "influxdb"
 	ProtocolJsonline            = "jsonline"
 	ProtocolRaw                 = "raw"
@@ -107,7 +108,8 @@ var supportedEncodingMap = map[string]map[string]bool{
 		EncodingProtobuf: false,
 	},
 	ProtocolOtlpV1: {
-		EncodingNone: true,
+		EncodingNone:     true,
+		EncodingProtobuf: true,
 	},
 	ProtocolInfluxdb: {
 		EncodingCustom: true,
@@ -142,6 +144,7 @@ func NewConverterWithSep(protocol, encoding, sep string, ignoreUnExpectedData bo
 }
 
 func NewConverter(protocol, encoding string, tagKeyRenameMap, protocolKeyRenameMap map[string]string, globalConfig *config.GlobalConfig) (*Converter, error) {
+	protocol = NormalizeProtocol(protocol)
 	enc, ok := supportedEncodingMap[protocol]
 	if !ok {
 		return nil, fmt.Errorf("unsupported protocol: %s", protocol)
@@ -156,6 +159,17 @@ func NewConverter(protocol, encoding string, tagKeyRenameMap, protocolKeyRenameM
 		ProtocolKeyRenameMap: protocolKeyRenameMap,
 		GlobalConfig:         globalConfig,
 	}, nil
+}
+
+// NormalizeProtocol maps documented protocol aliases to the internal protocol name.
+func NormalizeProtocol(protocol string) string {
+	normalized := strings.TrimSpace(protocol)
+	switch strings.ToLower(normalized) {
+	case ProtocolOtlpLogV1:
+		return ProtocolOtlpV1
+	default:
+		return normalized
+	}
 }
 
 func (c *Converter) Do(logGroup *protocol.LogGroup) (logs interface{}, err error) {
@@ -191,6 +205,8 @@ func (c *Converter) ToByteStreamWithSelectedFields(logGroup *protocol.LogGroup, 
 		return c.ConvertToInfluxdbProtocolStream(logGroup, targetFields)
 	case ProtocolJsonline:
 		return c.ConvertToJsonlineProtocolStreamFlatten(logGroup)
+	case ProtocolOtlpV1:
+		return c.ConvertToOtlpLogStream(logGroup, targetFields)
 	default:
 		return nil, nil, fmt.Errorf("unsupported protocol: %s", c.Protocol)
 	}
@@ -204,6 +220,8 @@ func (c *Converter) ToByteStreamWithSelectedFieldsV2(groupEvents *models.Pipelin
 		return c.ConvertToSingleProtocolStreamFlattenV2(groupEvents, targetFields)
 	case ProtocolJsonline:
 		return c.ConvertToJsonlineProtocolStreamV2(groupEvents)
+	case ProtocolOtlpV1:
+		return c.ConvertToOtlpLogStreamV2(groupEvents, targetFields)
 	case ProtocolRaw:
 		return c.ConvertToRawStream(groupEvents, targetFields)
 	case ProtocolInfluxdb:

--- a/pkg/protocol/converter/otlp.go
+++ b/pkg/protocol/converter/otlp.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
@@ -100,6 +101,66 @@ func (c *Converter) ConvertToOtlpResourseLogs(logGroup *protocol.LogGroup, targe
 	}
 
 	return rsLogs, desiredValues, nil
+}
+
+func (c *Converter) ConvertToOtlpLogStream(logGroup *protocol.LogGroup, targetFields []string) ([][]byte, []map[string]string, error) {
+	if logGroup == nil || len(logGroup.Logs) == 0 {
+		return nil, nil, nil
+	}
+
+	rsLogs, _, err := c.ConvertToOtlpResourseLogs(logGroup, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if rsLogs.ScopeLogs().Len() == 0 {
+		return nil, nil, nil
+	}
+
+	payload, err := marshalOtlpResourceLogs(rsLogs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var desiredValue map[string]string
+	if len(targetFields) > 0 {
+		desiredValue = findTargetValuesInLogTags(targetFields, logGroup.LogTags)
+	}
+	return [][]byte{payload}, []map[string]string{desiredValue}, nil
+}
+
+func (c *Converter) ConvertToOtlpLogStreamV2(groupEvents *models.PipelineGroupEvents, targetFields []string) ([][]byte, []map[string]string, error) {
+	if groupEvents == nil || len(groupEvents.Events) == 0 {
+		return nil, nil, nil
+	}
+
+	rsLogs, _, _, err := ConvertPipelineEventToOtlpEvent[plog.ResourceLogs, pmetric.ResourceMetrics, ptrace.ResourceSpans](c, groupEvents)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	scopeLogs := rsLogs.ScopeLogs()
+	if scopeLogs.Len() == 0 {
+		return nil, nil, nil
+	}
+
+	payload, err := marshalOtlpResourceLogs(rsLogs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var desiredValue map[string]string
+	if len(targetFields) > 0 {
+		desiredValue = findTargetFieldsInGroup(targetFields, groupEvents.Group)
+	}
+
+	return [][]byte{payload}, []map[string]string{desiredValue}, nil
+}
+
+func marshalOtlpResourceLogs(rsLogs plog.ResourceLogs) ([]byte, error) {
+	logs := plog.NewLogs()
+	newResource := logs.ResourceLogs().AppendEmpty()
+	rsLogs.MoveTo(newResource)
+	return plogotlp.NewExportRequestFromLogs(logs).MarshalProto()
 }
 
 func ConvertPipelineEventToOtlpEvent[

--- a/pkg/protocol/converter/otlp_test.go
+++ b/pkg/protocol/converter/otlp_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 
 	"github.com/alibaba/ilogtail/pkg/config"
 	"github.com/alibaba/ilogtail/pkg/models"
@@ -142,6 +143,84 @@ func TestNewConvertToOtlpLogs(t *testing.T) {
 				})
 			})
 		})
+	})
+}
+
+func TestConvertToOtlpLogStreamV2(t *testing.T) {
+	convey.Convey("When converting otlp logs to protobuf bytes", t, func() {
+		c, err := NewConverter(ProtocolOtlpLogV1, EncodingProtobuf, nil, nil, &config.GlobalConfig{})
+		convey.So(err, convey.ShouldBeNil)
+
+		groupEvents := &models.PipelineGroupEvents{
+			Group: &models.GroupInfo{
+				Metadata: models.NewMetadata(),
+				Tags:     models.NewTags(),
+			},
+			Events: []models.PipelineEvent{
+				models.NewLog(
+					"log_name",
+					[]byte("hello world"),
+					"INFO",
+					"",
+					"",
+					models.NewTagsWithMap(map[string]string{
+						"app": "demo",
+					}),
+					1662434209,
+				),
+			},
+		}
+		groupEvents.Group.Tags.Add("app", "demo")
+
+		stream, values, err := c.ToByteStreamWithSelectedFieldsV2(groupEvents, []string{"tag.app"})
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(stream, convey.ShouldHaveLength, 1)
+		convey.So(values, convey.ShouldHaveLength, 1)
+		convey.So(values[0]["tag.app"], convey.ShouldEqual, "demo")
+
+		req := plogotlp.NewExportRequest()
+		err = req.UnmarshalProto(stream.([][]byte)[0])
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(req.Logs().ResourceLogs().Len(), convey.ShouldEqual, 1)
+		convey.So(req.Logs().ResourceLogs().At(0).ScopeLogs().Len(), convey.ShouldEqual, 1)
+		convey.So(req.Logs().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().Len(), convey.ShouldEqual, 1)
+		convey.So(req.Logs().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Bytes().AsRaw(), convey.ShouldResemble, []byte("hello world"))
+		convey.So(req.Logs().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).SeverityText(), convey.ShouldEqual, "INFO")
+	})
+}
+
+func TestConvertToOtlpLogStream(t *testing.T) {
+	convey.Convey("When converting log groups to otlp protobuf bytes", t, func() {
+		c, err := NewConverter(ProtocolOtlpLogV1, EncodingProtobuf, nil, nil, &config.GlobalConfig{})
+		convey.So(err, convey.ShouldBeNil)
+
+		logGroup := &protocol.LogGroup{
+			LogTags: []*protocol.LogTag{
+				{Key: "__hostname__", Value: "node-a"},
+			},
+			Logs: []*protocol.Log{
+				{
+					Time: 1662434209,
+					Contents: []*protocol.Log_Content{
+						{Key: "content", Value: "hello log group"},
+						{Key: "level", Value: "INFO"},
+					},
+				},
+			},
+		}
+
+		stream, values, err := c.ToByteStreamWithSelectedFields(logGroup, []string{"__hostname__"})
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(stream, convey.ShouldHaveLength, 1)
+		convey.So(values, convey.ShouldHaveLength, 1)
+		convey.So(values[0]["__hostname__"], convey.ShouldEqual, "node-a")
+
+		req := plogotlp.NewExportRequest()
+		err = req.UnmarshalProto(stream.([][]byte)[0])
+		convey.So(err, convey.ShouldBeNil)
+		record := req.Logs().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+		convey.So(record.Body().AsString(), convey.ShouldEqual, "hello log group")
+		convey.So(record.SeverityText(), convey.ShouldEqual, "INFO")
 	})
 }
 


### PR DESCRIPTION
## Summary

Fix `flusher_kafka_v2` OTLP log output when configured with `Convert.Protocol: otlp_log_v1` and `Encoding: protobuf`.

The documented `otlp_log_v1` protocol is normalized to the internal `otlp_v1` protocol name, but the Kafka byte-stream conversion path did not handle `ProtocolOtlpV1`. This caused container stdout LogGroup flushing to fail with:

```text
flush kafka convert log fail, error: unsupported protocol: otlp_v1
```

## Changes

- Normalize documented `otlp_log_v1` to the internal `otlp_v1` protocol.
- Allow protobuf encoding for OTLP log conversion.
- Add OTLP protobuf byte-stream conversion for both LogGroup and PipelineGroupEvents paths.
- Add tests covering OTLP protobuf stream round-trip conversion.

## Tests

```text
go test ./protocol/converter -run 'Otlp|OTLP' -count=1
go test ./plugins/flusher/kafkav2 -run TestDoesNotExist -count=1
```

Fixes #2675
