### PR TITLE
fix(flusher_sls): skip sending empty package list

### DIFF
--- a/core/collection_pipeline/serializer/SLSSerializer.cpp
+++ b/core/collection_pipeline/serializer/SLSSerializer.cpp
@@ -528,6 +528,10 @@ void SLSEventGroupSerializer::SerializeRawEvent(LogGroupSerializer& serializer,
 }
 
 bool SLSEventGroupListSerializer::Serialize(vector<CompressedLogGroup>&& v, string& res, string& errorMsg) {
+    if (v.empty()) {
+        errorMsg = "empty log package list";
+        return false;
+    }
     sls_logs::SlsLogPackageList logPackageList;
     for (const auto& item : v) {
         auto package = logPackageList.add_packages();

--- a/core/plugin/flusher/sls/FlusherSLS.cpp
+++ b/core/plugin/flusher/sls/FlusherSLS.cpp
@@ -1139,13 +1139,32 @@ bool FlusherSLS::SerializeAndPush(BatchedEventsList&& groupList) {
             }
         }
     }
-    if (enablePackageList) {
+    // all groups in the list may fail to be serialized or compressed, in which case nothing should be sent, otherwise
+    // an empty package list would be sent, which can never succeed and would be retried repeatedly
+    if (enablePackageList && !compressedLogGroups.empty()) {
         string errorMsg;
-        mGroupListSerializer->DoSerialize(std::move(compressedLogGroups), serializedData, errorMsg);
-        allSucceeded
-            = Flusher::PushToQueue(make_unique<SLSSenderQueueItem>(
-                  std::move(serializedData), packageSize, this, mQueueKey, mLogstore, RawDataType::EVENT_GROUP_LIST))
-            && allSucceeded;
+        if (!mGroupListSerializer->DoSerialize(std::move(compressedLogGroups), serializedData, errorMsg)) {
+            LOG_WARNING(mContext->GetLogger(),
+                        ("failed to serialize event group list",
+                         errorMsg)("action", "discard data")("plugin", sName)("config", mContext->GetConfigName()));
+            mContext->GetAlarm().SendAlarmWarning(SERIALIZE_FAIL_ALARM,
+                                                  "failed to serialize event group list: " + errorMsg
+                                                      + "\taction: discard data\tplugin: " + sName
+                                                      + "\tconfig: " + mContext->GetConfigName(),
+                                                  mContext->GetRegion(),
+                                                  mContext->GetProjectName(),
+                                                  mContext->GetConfigName(),
+                                                  mContext->GetLogstoreName());
+            allSucceeded = false;
+        } else {
+            allSucceeded = Flusher::PushToQueue(make_unique<SLSSenderQueueItem>(std::move(serializedData),
+                                                                                packageSize,
+                                                                                this,
+                                                                                mQueueKey,
+                                                                                mLogstore,
+                                                                                RawDataType::EVENT_GROUP_LIST))
+                && allSucceeded;
+        }
     }
     return allSucceeded;
 }

--- a/core/unittest/flusher/FlusherSLSUnittest.cpp
+++ b/core/unittest/flusher/FlusherSLSUnittest.cpp
@@ -65,6 +65,7 @@ public:
     void TestFlush();
     void TestFlushAll();
     void TestAddPackId();
+    void TestSerializeAndPushAllEmptyGroups();
     void OnGoPipelineSend();
 
 protected:
@@ -1955,6 +1956,49 @@ void FlusherSLSUnittest::TestAddPackId() {
     APSARA_TEST_STREQ("34451096883514E2-0", batch.mTags.mInner["__pack_id__"].data());
 }
 
+void FlusherSLSUnittest::TestSerializeAndPushAllEmptyGroups() {
+    // package list is enabled when there are more than 1 group in the batch. if all of them fail to be serialized
+    // (e.g. logs with empty content only), nothing should be pushed to the sender queue, otherwise a request with
+    // an empty package list would be sent, which can never succeed and would be retried repeatedly
+    Json::Value configJson, optionalGoPipeline;
+    string configStr, errorMsg;
+    configStr = R"(
+        {
+            "Type": "flusher_sls",
+            "Project": "test_project",
+            "Logstore": "test_logstore",
+            "Region": "test_region",
+            "Endpoint": "test_region.log.aliyuncs.com",
+            "Aliuid": "123456789"
+        }
+    )";
+    ParseJsonTable(configStr, configJson, errorMsg);
+    FlusherSLS flusher;
+    flusher.SetContext(ctx);
+    flusher.CreateMetricsRecordRef(FlusherSLS::sName, "1");
+    flusher.Init(configJson, optionalGoPipeline);
+    flusher.CommitMetricsRecordRef();
+
+    BatchedEventsList batchedEventsList;
+    for (size_t i = 0; i < 2; ++i) {
+        PipelineEventGroup group(make_shared<SourceBuffer>());
+        group.SetMetadata(EventGroupMetaKey::SOURCE_ID, string("source-id"));
+        auto e = group.AddLogEvent();
+        e->SetTimestamp(1234567890); // no content at all, so the serialized log group is empty
+        batchedEventsList.emplace_back(std::move(group.MutableEvents()),
+                                       std::move(group.GetSizedTags()),
+                                       std::move(group.GetSourceBuffer()),
+                                       group.GetMetadata(EventGroupMetaKey::SOURCE_ID),
+                                       std::move(group.GetExactlyOnceCheckpoint()));
+    }
+
+    APSARA_TEST_FALSE(flusher.SerializeAndPush(std::move(batchedEventsList)));
+
+    vector<SenderQueueItem*> res;
+    SenderQueueManager::GetInstance()->GetAvailableItems(res, 80);
+    APSARA_TEST_TRUE(res.empty());
+}
+
 void FlusherSLSUnittest::OnGoPipelineSend() {
     {
         Json::Value configJson, optionalGoPipeline;
@@ -2051,6 +2095,7 @@ UNIT_TEST_CASE(FlusherSLSUnittest, TestSend)
 UNIT_TEST_CASE(FlusherSLSUnittest, TestFlush)
 UNIT_TEST_CASE(FlusherSLSUnittest, TestFlushAll)
 UNIT_TEST_CASE(FlusherSLSUnittest, TestAddPackId)
+UNIT_TEST_CASE(FlusherSLSUnittest, TestSerializeAndPushAllEmptyGroups)
 UNIT_TEST_CASE(FlusherSLSUnittest, OnGoPipelineSend)
 
 } // namespace logtail

--- a/core/unittest/serializer/SLSSerializerUnittest.cpp
+++ b/core/unittest/serializer/SLSSerializerUnittest.cpp
@@ -757,18 +757,27 @@ void SLSSerializerUnittest::TestSerializeEventGroup() {
 }
 
 void SLSSerializerUnittest::TestSerializeEventGroupList() {
-    vector<CompressedLogGroup> v;
-    v.emplace_back("data1", 10);
-
     SLSEventGroupListSerializer serializer(sFlusher.get());
-    string res, errorMsg;
-    APSARA_TEST_TRUE(serializer.DoSerialize(std::move(v), res, errorMsg));
-    sls_logs::SlsLogPackageList logPackageList;
-    APSARA_TEST_TRUE(logPackageList.ParseFromString(res));
-    APSARA_TEST_EQUAL(1, logPackageList.packages_size());
-    APSARA_TEST_STREQ("data1", logPackageList.packages(0).data().c_str());
-    APSARA_TEST_EQUAL(10, logPackageList.packages(0).uncompress_size());
-    APSARA_TEST_EQUAL(sls_logs::SlsCompressType::SLS_CMP_NONE, logPackageList.packages(0).compress_type());
+    {
+        vector<CompressedLogGroup> v;
+        v.emplace_back("data1", 10);
+
+        string res, errorMsg;
+        APSARA_TEST_TRUE(serializer.DoSerialize(std::move(v), res, errorMsg));
+        sls_logs::SlsLogPackageList logPackageList;
+        APSARA_TEST_TRUE(logPackageList.ParseFromString(res));
+        APSARA_TEST_EQUAL(1, logPackageList.packages_size());
+        APSARA_TEST_STREQ("data1", logPackageList.packages(0).data().c_str());
+        APSARA_TEST_EQUAL(10, logPackageList.packages(0).uncompress_size());
+        APSARA_TEST_EQUAL(sls_logs::SlsCompressType::SLS_CMP_NONE, logPackageList.packages(0).compress_type());
+    }
+    {
+        // empty package list should not be serialized, otherwise an empty request would be sent
+        vector<CompressedLogGroup> v;
+        string res, errorMsg;
+        APSARA_TEST_FALSE(serializer.DoSerialize(std::move(v), res, errorMsg));
+        APSARA_TEST_TRUE(res.empty());
+    }
 }
 
 


### PR DESCRIPTION
Fixes #2683

## 问题

`FlusherSLS::SerializeAndPush(BatchedEventsList&&)` 中 `enablePackageList = groupList.size() > 1`。当一次 flush 的 batch 里 ≥2 个 group 的内容大小全为 0（`SLSEventGroupSerializer::Serialize` 命中 `all empty logs` 分支返回 false）或全部压缩失败时，逐个 `continue` 后 `compressedLogGroups` 为空；但收尾分支 `if (enablePackageList)` 无条件调用 `mGroupListSerializer->DoSerialize` 并忽略返回值，而 `SLSEventGroupListSerializer::Serialize` 对空 vector 会产出 0 个 packages 的 `SlsLogPackageList` 且返回 true，于是一个空 body 的 `BatchPostLogStoreLogs` 被推入发送队列。

空包在服务端必然失败（实测 Status 500 且 InFlow=0），会被反复重试最长 6 小时，并持续调用 `RegionConcurrencyLimiter->OnFail`，拖累同 region 正常数据的发送并发。典型触发场景是周期性写入空行/空 JSON 的统计日志。

引入于 5aa4f2c8（#1523），首现 3.0.0，3.x 至 main 均无保护；2.x 走旧 Sender.cpp 不受影响。

## 修改

- `FlusherSLS::SerializeAndPush`：收尾分支增加 `!compressedLogGroups.empty()` 判断，全部序列化/压缩失败时不再发送任何东西（此时 `allSucceeded` 已为 false）。
- 同时不再忽略 `mGroupListSerializer->DoSerialize` 的返回值，失败时打 warning + `SERIALIZE_FAIL_ALARM`，而不是把 `serializedData` 里的残留内容发出去。
- `SLSEventGroupListSerializer::Serialize`：对空列表返回 false（`empty log package list`），做一层兜底防御。

## 测试

- 新增 `FlusherSLSUnittest.TestSerializeAndPushAllEmptyGroups`：构造 2 个仅含无 content 日志事件的 group，验证 `SerializeAndPush` 返回 false 且发送队列中没有任何 item。已确认该用例在修复前失败、修复后通过。
- 补充 `SLSSerializerUnittest.TestSerializeEventGroupList` 的空列表用例。
- 本地（loongcollector-build-linux:2.1.17 镜像）跑通 `flusher_sls_unittest`（10/10）与 `sls_serializer_unittest`（8/8）。