### PR TITLE
fix(config): use increment(ec) in config dir scan

### DIFF
--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -356,7 +356,7 @@ void Application::Start() { // GCOVR_EXCL_START
             } catch (const filesystem::filesystem_error& e) {
                 LOG_ERROR(sLogger,
                           ("config dir scan threw", e.what())("error code", e.code().value())("error msg",
-                                                                                             e.code().message()));
+                                                                                              e.code().message()));
             } catch (const exception& e) {
                 LOG_ERROR(sLogger, ("config dir scan threw", e.what()));
             }

--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -18,6 +18,8 @@
 #include "gperftools/malloc_extension.h"
 #endif
 
+#include <exception>
+#include <filesystem>
 #include <thread>
 
 #include "app_config/AppConfig.h"
@@ -321,35 +323,44 @@ void Application::Start() { // GCOVR_EXCL_START
             lastOnetimeConfigTimeoutCheckTime = curTime;
         }
         if (curTime - lastConfigCheckTime >= INT32_FLAG(config_scan_interval)) {
-            auto configDiff = PipelineConfigWatcher::GetInstance()->CheckConfigDiff();
-            if (configDiff.first.HasDiff()) {
-                CollectionPipelineManager::GetInstance()->UpdatePipelines(configDiff.first);
-            }
-            // feedback ignored configs after config update ensures ignored configs are set to FAILED status
-            if (configDiff.first.HasIgnored()) {
-                PipelineConfigWatcher::GetInstance()->FeedbackIgnoredConfigs(configDiff.first);
-            }
-            if (configDiff.second.HasDiff()) {
-                TaskPipelineManager::GetInstance()->UpdatePipelines(configDiff.second);
-            }
-            if (configDiff.first.HasDiff() || configDiff.second.HasDiff()) {
-                OnetimeConfigInfoManager::GetInstance()->DumpCheckpointFile();
-            }
-            LoongCollectorMonitor::GetInstance()->SetAgentConfigTotal(
-                CollectionPipelineManager::GetInstance()->GetPipelineCount()
-                + TaskPipelineManager::GetInstance()->GetPipelineCount()
-                + OnetimeConfigInfoManager::GetInstance()->GetConfigCount()
-                - PipelineConfigWatcher::GetInstance()->GetBuiltInPipelineCount());
-
-            // after every config loaded, set the flag to true
-            if (lastConfigCheckTime == 0) {
-                TaskPipelineManager::GetInstance()->SetFirstCheckConfigExecuted(true);
-            }
-            InstanceConfigDiff instanceConfigDiff = InstanceConfigWatcher::GetInstance()->CheckConfigDiff();
-            if (instanceConfigDiff.HasDiff()) {
-                InstanceConfigManager::GetInstance()->UpdateInstanceConfigs(instanceConfigDiff);
-            }
+            const bool firstConfigCheck = (lastConfigCheckTime == 0);
             lastConfigCheckTime = curTime;
+            try {
+                auto configDiff = PipelineConfigWatcher::GetInstance()->CheckConfigDiff();
+                if (configDiff.first.HasDiff()) {
+                    CollectionPipelineManager::GetInstance()->UpdatePipelines(configDiff.first);
+                }
+                // feedback ignored configs after config update ensures ignored configs are set to FAILED status
+                if (configDiff.first.HasIgnored()) {
+                    PipelineConfigWatcher::GetInstance()->FeedbackIgnoredConfigs(configDiff.first);
+                }
+                if (configDiff.second.HasDiff()) {
+                    TaskPipelineManager::GetInstance()->UpdatePipelines(configDiff.second);
+                }
+                if (configDiff.first.HasDiff() || configDiff.second.HasDiff()) {
+                    OnetimeConfigInfoManager::GetInstance()->DumpCheckpointFile();
+                }
+                LoongCollectorMonitor::GetInstance()->SetAgentConfigTotal(
+                    CollectionPipelineManager::GetInstance()->GetPipelineCount()
+                    + TaskPipelineManager::GetInstance()->GetPipelineCount()
+                    + OnetimeConfigInfoManager::GetInstance()->GetConfigCount()
+                    - PipelineConfigWatcher::GetInstance()->GetBuiltInPipelineCount());
+
+                // after every config loaded, set the flag to true
+                if (firstConfigCheck) {
+                    TaskPipelineManager::GetInstance()->SetFirstCheckConfigExecuted(true);
+                }
+                InstanceConfigDiff instanceConfigDiff = InstanceConfigWatcher::GetInstance()->CheckConfigDiff();
+                if (instanceConfigDiff.HasDiff()) {
+                    InstanceConfigManager::GetInstance()->UpdateInstanceConfigs(instanceConfigDiff);
+                }
+            } catch (const filesystem::filesystem_error& e) {
+                LOG_ERROR(sLogger,
+                          ("config dir scan threw", e.what())("error code", e.code().value())("error msg",
+                                                                                             e.code().message()));
+            } catch (const exception& e) {
+                LOG_ERROR(sLogger, ("config dir scan threw", e.what()));
+            }
         }
 #ifndef LOGTAIL_NO_TC_MALLOC
         if (curTime - gLastTcmallocReleaseMemTime >= INT32_FLAG(tcmalloc_release_memory_interval)) {

--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -323,8 +323,6 @@ void Application::Start() { // GCOVR_EXCL_START
             lastOnetimeConfigTimeoutCheckTime = curTime;
         }
         if (curTime - lastConfigCheckTime >= INT32_FLAG(config_scan_interval)) {
-            const bool firstConfigCheck = (lastConfigCheckTime == 0);
-            lastConfigCheckTime = curTime;
             try {
                 auto configDiff = PipelineConfigWatcher::GetInstance()->CheckConfigDiff();
                 if (configDiff.first.HasDiff()) {
@@ -347,13 +345,14 @@ void Application::Start() { // GCOVR_EXCL_START
                     - PipelineConfigWatcher::GetInstance()->GetBuiltInPipelineCount());
 
                 // after every config loaded, set the flag to true
-                if (firstConfigCheck) {
+                if (lastConfigCheckTime == 0) {
                     TaskPipelineManager::GetInstance()->SetFirstCheckConfigExecuted(true);
                 }
                 InstanceConfigDiff instanceConfigDiff = InstanceConfigWatcher::GetInstance()->CheckConfigDiff();
                 if (instanceConfigDiff.HasDiff()) {
                     InstanceConfigManager::GetInstance()->UpdateInstanceConfigs(instanceConfigDiff);
                 }
+                lastConfigCheckTime = curTime;
             } catch (const filesystem::filesystem_error& e) {
                 LOG_ERROR(sLogger,
                           ("config dir scan threw", e.what())("error code", e.code().value())("error msg",

--- a/core/application/Application.cpp
+++ b/core/application/Application.cpp
@@ -355,10 +355,10 @@ void Application::Start() { // GCOVR_EXCL_START
                 lastConfigCheckTime = curTime;
             } catch (const filesystem::filesystem_error& e) {
                 LOG_ERROR(sLogger,
-                          ("config dir scan threw", e.what())("error code", e.code().value())("error msg",
-                                                                                              e.code().message()));
+                          ("action", "scan config dir")("status", "failed")("error", e.what())(
+                              "error code", e.code().value())("error msg", e.code().message()));
             } catch (const exception& e) {
-                LOG_ERROR(sLogger, ("config dir scan threw", e.what()));
+                LOG_ERROR(sLogger, ("action", "scan config dir")("status", "failed")("error", e.what()));
             }
         }
 #ifndef LOGTAIL_NO_TC_MALLOC

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -156,9 +156,10 @@ void CommonConfigProvider::LoadConfigFile() {
         }
     }
     if (itEc) {
-        LOG_WARNING(sLogger,
-                    ("failed to iterate config dir",
-                     mContinuousPipelineConfigDir.string())("error code", itEc.value())("error msg", itEc.message()));
+        LOG_WARNING(
+            sLogger,
+            ("action", "iterate config dir")("status", "failed")("dir path", mContinuousPipelineConfigDir.string())(
+                "error code", itEc.value())("error msg", itEc.message()));
     }
     itEc.clear();
     for (auto it = filesystem::directory_iterator(mInstanceSourceDir, itEc);
@@ -183,8 +184,8 @@ void CommonConfigProvider::LoadConfigFile() {
     }
     if (itEc) {
         LOG_WARNING(sLogger,
-                    ("failed to iterate config dir",
-                     mInstanceSourceDir.string())("error code", itEc.value())("error msg", itEc.message()));
+                    ("action", "iterate config dir")("status", "failed")("dir path", mInstanceSourceDir.string())(
+                        "error code", itEc.value())("error msg", itEc.message()));
     }
 }
 

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -134,8 +134,11 @@ void CommonConfigProvider::Stop() {
 }
 
 void CommonConfigProvider::LoadConfigFile() {
-    error_code ec;
-    for (auto const& entry : filesystem::directory_iterator(mContinuousPipelineConfigDir, ec)) {
+    error_code itEc;
+    for (auto it = filesystem::directory_iterator(mContinuousPipelineConfigDir, itEc);
+         !itEc && it != filesystem::directory_iterator();
+         it.increment(itEc)) {
+        const auto& entry = *it;
         Json::Value detail;
         if (LoadConfigDetailFromFile(entry, detail)) {
             ConfigInfo info;
@@ -152,7 +155,16 @@ void CommonConfigProvider::LoadConfigFile() {
             ConfigFeedbackReceiver::GetInstance().RegisterContinuousPipelineConfig(info.name, this);
         }
     }
-    for (auto const& entry : filesystem::directory_iterator(mInstanceSourceDir, ec)) {
+    if (itEc) {
+        LOG_WARNING(sLogger,
+                    ("failed to iterate config dir", mContinuousPipelineConfigDir.string())("error code", itEc.value())(
+                        "error msg", itEc.message()));
+    }
+    itEc.clear();
+    for (auto it = filesystem::directory_iterator(mInstanceSourceDir, itEc);
+         !itEc && it != filesystem::directory_iterator();
+         it.increment(itEc)) {
+        const auto& entry = *it;
         Json::Value detail;
         if (LoadConfigDetailFromFile(entry, detail)) {
             ConfigInfo info;
@@ -168,6 +180,11 @@ void CommonConfigProvider::LoadConfigFile() {
             }
             ConfigFeedbackReceiver::GetInstance().RegisterInstanceConfig(info.name, this);
         }
+    }
+    if (itEc) {
+        LOG_WARNING(sLogger,
+                    ("failed to iterate config dir", mInstanceSourceDir.string())("error code", itEc.value())(
+                        "error msg", itEc.message()));
     }
 }
 

--- a/core/config/common_provider/CommonConfigProvider.cpp
+++ b/core/config/common_provider/CommonConfigProvider.cpp
@@ -157,8 +157,8 @@ void CommonConfigProvider::LoadConfigFile() {
     }
     if (itEc) {
         LOG_WARNING(sLogger,
-                    ("failed to iterate config dir", mContinuousPipelineConfigDir.string())("error code", itEc.value())(
-                        "error msg", itEc.message()));
+                    ("failed to iterate config dir",
+                     mContinuousPipelineConfigDir.string())("error code", itEc.value())("error msg", itEc.message()));
     }
     itEc.clear();
     for (auto it = filesystem::directory_iterator(mInstanceSourceDir, itEc);
@@ -183,8 +183,8 @@ void CommonConfigProvider::LoadConfigFile() {
     }
     if (itEc) {
         LOG_WARNING(sLogger,
-                    ("failed to iterate config dir", mInstanceSourceDir.string())("error code", itEc.value())(
-                        "error msg", itEc.message()));
+                    ("failed to iterate config dir",
+                     mInstanceSourceDir.string())("error code", itEc.value())("error msg", itEc.message()));
     }
 }
 

--- a/core/config/watcher/InstanceConfigWatcher.cpp
+++ b/core/config/watcher/InstanceConfigWatcher.cpp
@@ -15,6 +15,7 @@
 #include "config/watcher/InstanceConfigWatcher.h"
 
 #include <memory>
+#include <mutex>
 #include <unordered_set>
 
 #include "common/FileSystemUtil.h"
@@ -52,15 +53,17 @@ InstanceConfigDiff InstanceConfigWatcher::CheckConfigDiff() {
                         ("config dir path is not a directory", "skip current object")("dir path", dir.string()));
             continue;
         }
-        for (auto const& entry : filesystem::directory_iterator(dir, ec)) {
-            // lock the dir if it is provided by config provider
-            unique_lock<mutex> lock;
-            auto itr = mDirMutexMap.find(dir.string());
-            if (itr != mDirMutexMap.end()) {
-                lock = unique_lock<mutex>(*itr->second, defer_lock);
-                lock.lock();
-            }
+        unique_lock<mutex> lock;
+        auto muxItr = mDirMutexMap.find(dir.string());
+        if (muxItr != mDirMutexMap.end()) {
+            lock = unique_lock<mutex>(*muxItr->second);
+        }
 
+        error_code itEc;
+        for (auto it = filesystem::directory_iterator(dir, itEc);
+             !itEc && it != filesystem::directory_iterator();
+             it.increment(itEc)) {
+            const auto& entry = *it;
             const filesystem::path& path = entry.path();
             const string& configName = path.stem().string();
             if (configName == REGION_CONFIG || configName == READABLE_REGION_CONFIG) {
@@ -137,6 +140,11 @@ InstanceConfigDiff InstanceConfigWatcher::CheckConfigDiff() {
             } else {
                 LOG_DEBUG(sLogger, ("existing config file unchanged", "skip current object"));
             }
+        }
+        if (itEc) {
+            LOG_WARNING(sLogger,
+                        ("failed to iterate config dir", "skip remaining objects")("dir path", dir.string())(
+                            "error code", itEc.value())("error msg", itEc.message()));
         }
     }
     for (const auto& name : mInstanceConfigManager->GetAllConfigNames()) {

--- a/core/config/watcher/InstanceConfigWatcher.cpp
+++ b/core/config/watcher/InstanceConfigWatcher.cpp
@@ -142,7 +142,7 @@ InstanceConfigDiff InstanceConfigWatcher::CheckConfigDiff() {
         }
         if (itEc) {
             LOG_WARNING(sLogger,
-                        ("failed to iterate config dir", "skip remaining objects")("dir path", dir.string())(
+                        ("action", "iterate config dir")("status", "failed")("dir path", dir.string())(
                             "error code", itEc.value())("error msg", itEc.message()));
         }
     }

--- a/core/config/watcher/InstanceConfigWatcher.cpp
+++ b/core/config/watcher/InstanceConfigWatcher.cpp
@@ -60,8 +60,7 @@ InstanceConfigDiff InstanceConfigWatcher::CheckConfigDiff() {
         }
 
         error_code itEc;
-        for (auto it = filesystem::directory_iterator(dir, itEc);
-             !itEc && it != filesystem::directory_iterator();
+        for (auto it = filesystem::directory_iterator(dir, itEc); !itEc && it != filesystem::directory_iterator();
              it.increment(itEc)) {
             const auto& entry = *it;
             const filesystem::path& path = entry.path();

--- a/core/config/watcher/PipelineConfigWatcher.cpp
+++ b/core/config/watcher/PipelineConfigWatcher.cpp
@@ -217,8 +217,7 @@ void PipelineConfigWatcher::InsertPipelines(CollectionConfigDiff& pDiff,
         }
 
         error_code itEc;
-        for (auto it = filesystem::directory_iterator(dir, itEc);
-             !itEc && it != filesystem::directory_iterator();
+        for (auto it = filesystem::directory_iterator(dir, itEc); !itEc && it != filesystem::directory_iterator();
              it.increment(itEc)) {
             const auto& entry = *it;
             const filesystem::path& path = entry.path();

--- a/core/config/watcher/PipelineConfigWatcher.cpp
+++ b/core/config/watcher/PipelineConfigWatcher.cpp
@@ -297,7 +297,7 @@ void PipelineConfigWatcher::InsertPipelines(CollectionConfigDiff& pDiff,
         }
         if (itEc) {
             LOG_WARNING(sLogger,
-                        ("failed to iterate config dir", "skip remaining objects")("dir path", dir.string())(
+                        ("action", "iterate config dir")("status", "failed")("dir path", dir.string())(
                             "error code", itEc.value())("error msg", itEc.message()));
         }
     }

--- a/core/config/watcher/PipelineConfigWatcher.cpp
+++ b/core/config/watcher/PipelineConfigWatcher.cpp
@@ -210,15 +210,17 @@ void PipelineConfigWatcher::InsertPipelines(CollectionConfigDiff& pDiff,
                         ("config dir path is not a directory", "skip current object")("dir path", dir.string()));
             continue;
         }
-        for (auto const& entry : filesystem::directory_iterator(dir, ec)) {
-            // lock the dir if it is provided by config provider
-            unique_lock<mutex> lock;
-            auto itr = mDirMutexMap.find(dir.string());
-            if (itr != mDirMutexMap.end()) {
-                lock = unique_lock<mutex>(*itr->second, defer_lock);
-                lock.lock();
-            }
+        unique_lock<mutex> lock;
+        auto muxItr = mDirMutexMap.find(dir.string());
+        if (muxItr != mDirMutexMap.end()) {
+            lock = unique_lock<mutex>(*muxItr->second);
+        }
 
+        error_code itEc;
+        for (auto it = filesystem::directory_iterator(dir, itEc);
+             !itEc && it != filesystem::directory_iterator();
+             it.increment(itEc)) {
+            const auto& entry = *it;
             const filesystem::path& path = entry.path();
             const string& configName = path.stem().string();
             const string& filepath = path.string();
@@ -293,6 +295,11 @@ void PipelineConfigWatcher::InsertPipelines(CollectionConfigDiff& pDiff,
                 // check unchanged config just for singleton input
                 CheckUnchangedConfig(configName, path, pDiff, singletonCache);
             }
+        }
+        if (itEc) {
+            LOG_WARNING(sLogger,
+                        ("failed to iterate config dir", "skip remaining objects")("dir path", dir.string())(
+                            "error code", itEc.value())("error msg", itEc.message()));
         }
     }
 }

--- a/core/unittest/config/ConfigWatcherUnittest.cpp
+++ b/core/unittest/config/ConfigWatcherUnittest.cpp
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <exception>
 #include <filesystem>
 #include <fstream>
+#include <thread>
 
 #include "collection_pipeline/CollectionPipelineManager.h"
 #include "config/ConfigDiff.h"
@@ -38,6 +40,7 @@ public:
     void IgnoreNewLowerPrioritySingletonConfig() const;
     void IgnoreModifiedLowerPrioritySingletonConfig() const;
     void HigherPriorityOverrideLowerPrioritySingletonConfig() const;
+    void ConfigDirMutatedDuringScanDoesNotThrow() const;
 
 protected:
     static void SetUpTestCase() {
@@ -428,12 +431,73 @@ void ConfigWatcherUnittest::HigherPriorityOverrideLowerPrioritySingletonConfig()
     filesystem::remove_all("continuous_pipeline_config");
 }
 
+void ConfigWatcherUnittest::ConfigDirMutatedDuringScanDoesNotThrow() const {
+    filesystem::create_directories(configDir);
+    filesystem::create_directories(instanceConfigDir);
+
+    const string validPipeline = R"(
+        {
+            "inputs": [{"Type": "input_file"}],
+            "flushers": [{"Type": "flusher_sls"}]
+        }
+    )";
+    const string validInstance = R"(
+        {
+            "enable": true,
+            "max_bytes_per_sec": 1234
+        }
+    )";
+    for (int i = 0; i < 16; ++i) {
+        ofstream fout(configDir / ("p" + to_string(i) + ".json"));
+        fout << validPipeline;
+        ofstream fout2(instanceConfigDir / ("i" + to_string(i) + ".json"));
+        fout2 << validInstance;
+    }
+
+    auto mutate = [](const filesystem::path& dir, const string& prefix) {
+        for (int i = 0; i < 80; ++i) {
+            error_code ec;
+            auto path = dir / (prefix + "0.json");
+            auto tmp = dir / (prefix + "0.json.new");
+            filesystem::remove(path, ec);
+            {
+                ofstream fout(tmp);
+                fout << "{}";
+            }
+            filesystem::rename(tmp, path, ec);
+            filesystem::remove(dir / (prefix + "1.json"), ec);
+        }
+    };
+
+    bool threw = false;
+    try {
+        thread pipelineMutator(mutate, configDir, string("p"));
+        thread instanceMutator(mutate, instanceConfigDir, string("i"));
+        for (int i = 0; i < 30; ++i) {
+            (void)PipelineConfigWatcher::GetInstance()->CheckConfigDiff();
+            (void)InstanceConfigWatcher::GetInstance()->CheckConfigDiff();
+        }
+        pipelineMutator.join();
+        instanceMutator.join();
+    } catch (const exception&) {
+        threw = true;
+    } catch (...) {
+        threw = true;
+    }
+    APSARA_TEST_FALSE(threw);
+
+    filesystem::remove_all(configDir);
+    filesystem::remove_all(instanceConfigDir);
+    InstanceConfigWatcher::GetInstance()->ClearEnvironment();
+}
+
 UNIT_TEST_CASE(ConfigWatcherUnittest, InvalidConfigDirFound)
 UNIT_TEST_CASE(ConfigWatcherUnittest, InvalidConfigFileFound)
 UNIT_TEST_CASE(ConfigWatcherUnittest, DuplicateConfigs)
 UNIT_TEST_CASE(ConfigWatcherUnittest, IgnoreNewLowerPrioritySingletonConfig)
 UNIT_TEST_CASE(ConfigWatcherUnittest, IgnoreModifiedLowerPrioritySingletonConfig)
 UNIT_TEST_CASE(ConfigWatcherUnittest, HigherPriorityOverrideLowerPrioritySingletonConfig)
+UNIT_TEST_CASE(ConfigWatcherUnittest, ConfigDirMutatedDuringScanDoesNotThrow)
 
 } // namespace logtail
 

--- a/core/unittest/config/ConfigWatcherUnittest.cpp
+++ b/core/unittest/config/ConfigWatcherUnittest.cpp
@@ -469,20 +469,24 @@ void ConfigWatcherUnittest::ConfigDirMutatedDuringScanDoesNotThrow() const {
         }
     };
 
+    thread pipelineMutator(mutate, configDir, string("p"));
+    thread instanceMutator(mutate, instanceConfigDir, string("i"));
     bool threw = false;
     try {
-        thread pipelineMutator(mutate, configDir, string("p"));
-        thread instanceMutator(mutate, instanceConfigDir, string("i"));
         for (int i = 0; i < 30; ++i) {
             (void)PipelineConfigWatcher::GetInstance()->CheckConfigDiff();
             (void)InstanceConfigWatcher::GetInstance()->CheckConfigDiff();
         }
-        pipelineMutator.join();
-        instanceMutator.join();
     } catch (const exception&) {
         threw = true;
     } catch (...) {
         threw = true;
+    }
+    if (pipelineMutator.joinable()) {
+        pipelineMutator.join();
+    }
+    if (instanceMutator.joinable()) {
+        instanceMutator.join();
     }
     APSARA_TEST_FALSE(threw);
 


### PR DESCRIPTION
operator++() throws on EBADF and the main loop has no catch, so high-throughput hosts abort with signal 6 during the 10s config walk. Drive iterators with increment(ec) and catch leftover filesystem_error so the process stays up.