### PR TITLE
优化proc写死问题，并自动透传容器元信息

### DIFF
--- a/changes/v2.0.0.md
+++ b/changes/v2.0.0.md
@@ -22,6 +22,7 @@ All issues and pull requests are [here](https://github.com/alibaba/ilogtail/mile
 - [public] [both] [updated] Fix issue where container IP is occasionally empty for Kubernetes pods in HostNetwork mode #1280
 - [public] [both] [updated] Improve goprofile plugin to support real local IP inclusion #1281
 - [public] [both] [updated] Added a switch to control the loading of the processor_spl, which by default remains unloaded #1312
+- [public] [linux] [added] input_agentsight: auto-attach container metadata tags (_container_name_, _image_name_, _container_ip_, _pod_name_, _namespace_, _pod_uid_) to event groups in containerized deployments
 
 ### Fixed
 

--- a/core/container_manager/ContainerManager.cpp
+++ b/core/container_manager/ContainerManager.cpp
@@ -66,6 +66,12 @@ void ContainerManager::Stop() {
     }
 }
 
+std::shared_ptr<RawContainerInfo> ContainerManager::GetContainerInfoById(const std::string& containerID) const {
+    ReadLock lock(mContainerMapRWLock);
+    auto it = mContainerMap.find(containerID);
+    return it == mContainerMap.end() ? nullptr : it->second;
+}
+
 void ContainerManager::pollingLoop() {
     time_t lastUpdateAllTime = 0;
     time_t lastUpdateDiffTime = 0;

--- a/core/container_manager/ContainerManager.h
+++ b/core/container_manager/ContainerManager.h
@@ -47,6 +47,12 @@ public:
     void Init();
     void Stop();
 
+    // Look up cached container info by full container ID. Returns nullptr when the ID is unknown
+    // (e.g. host process, container removed from the snapshot, or the polling loop has not been
+    // started via Init()). The returned info is immutable after publication, so reading it outside
+    // the lock is safe.
+    std::shared_ptr<RawContainerInfo> GetContainerInfoById(const std::string& containerID) const;
+
     void ApplyContainerDiffs();
     bool CheckContainerDiffForAllConfig();
 

--- a/core/ebpf/EBPFAdapter.cpp
+++ b/core/ebpf/EBPFAdapter.cpp
@@ -263,6 +263,8 @@ bool EBPFAdapter::tryLoadAgentSightDylib() {
     std::string optSymErr;
     sym.config_set_enable_raw_https = reinterpret_cast<decltype(sym.config_set_enable_raw_https)>(
         tmpLib->LoadMethod("agentsight_config_set_enable_raw_https", optSymErr));
+    sym.config_set_procfs_root = reinterpret_cast<decltype(sym.config_set_procfs_root)>(
+        tmpLib->LoadMethod("agentsight_config_set_procfs_root", optSymErr));
     sym.config_add_cmdline_rule = reinterpret_cast<decltype(sym.config_add_cmdline_rule)>(
         tmpLib->LoadMethod("agentsight_config_add_cmdline_rule", symErr));
     sym.config_add_https
@@ -291,7 +293,8 @@ bool EBPFAdapter::tryLoadAgentSightDylib() {
     mAgentSightSymbols = std::make_unique<AgentSightSymbolTable>(sym);
     LOG_INFO(sLogger,
              ("[EBPFAdapter] AgentSight symbols loaded", STRING_FLAG(ebpf_agentsight_dylib_base_name))(
-                 "raw_https_api", sym.config_set_enable_raw_https != nullptr));
+                 "raw_https_api", sym.config_set_enable_raw_https != nullptr)(
+                 "procfs_root_api", sym.config_set_procfs_root != nullptr));
     return true;
 }
 

--- a/core/ebpf/EBPFAdapter.h
+++ b/core/ebpf/EBPFAdapter.h
@@ -39,6 +39,10 @@ struct AgentSightSymbolTable {
     /// Optional (libagentsight >= 0.9.0): opt into raw HTTPS fallback events (AgentsightHttpsData).
     /// Left null by older libraries; callers must null-check before use.
     void (*config_set_enable_raw_https)(AgentsightConfigHandle*, int) = nullptr;
+    /// Optional (libagentsight >= 0.11.0): procfs mount point pid lookups resolve through, so a
+    /// container can read a bind-mounted host procfs instead of its own /proc.
+    /// Left null by older libraries; callers must null-check before use.
+    void (*config_set_procfs_root)(AgentsightConfigHandle*, const char*) = nullptr;
     void (*config_add_cmdline_rule)(AgentsightConfigHandle*, const char* const*, const char*, int) = nullptr;
     void (*config_add_https)(AgentsightConfigHandle*, const char*) = nullptr;
     int (*config_add_http)(AgentsightConfigHandle*, const char*) = nullptr;

--- a/core/ebpf/EBPFServer.cpp
+++ b/core/ebpf/EBPFServer.cpp
@@ -402,8 +402,8 @@ bool EBPFServer::startPluginInternal(const std::string& pipelineName,
             }
             case PluginType::AGENTSIGHT_OBSERVE: {
                 if (!pluginMgr) {
-                    auto mgr
-                        = AgentsightManager::Create(mProcessCacheManager, mEBPFAdapter, mCommonEventQueue, &mEventPool);
+                    auto mgr = AgentsightManager::Create(
+                        mProcessCacheManager, mEBPFAdapter, mCommonEventQueue, &mEventPool, mHostPathPrefix.string());
                     mgr->SetMetrics(mLossKernelEventsTotal, mPushLogFailedTotal);
                     pluginMgr = mgr;
                 }

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -29,11 +29,14 @@
 #include "common/StringView.h"
 #include "common/UUIDUtil.h"
 #include "common/magic_enum.hpp"
+#include "constants/TagConstants.h"
+#include "container_manager/ContainerManager.h"
 #include "ebpf/Config.h"
 #include "ebpf/EBPFServer.h"
 #include "ebpf/plugin/agentsight/AgentsightEvents.h"
 #include "ebpf/plugin/agentsight/AgentsightMessageUtil.h"
 #include "ebpf/type/table/BaseElements.h"
+#include "file_server/ContainerInfo.h"
 #include "logger/Logger.h"
 #include "models/LogEvent.h"
 #include "models/PipelineEventGroup.h"
@@ -814,7 +817,39 @@ void FillAgentsightHttpResponseLog(const AgentsightHttpsRecord& rec,
     EmitHttpBody(log, "http.response.body", rec.mResponseBody);
 }
 
+/// Resolves @containerId against the process-wide container inventory maintained by
+/// ContainerManager (its polling loop is started by InputAgentSight in containerized deployments)
+/// and attaches the standard container metadata tags to @group — the same channel and keys
+/// input_file / input_container_stdio use, so downstream can join agentsight data with
+/// file/stdio data on identical tag names.
+///
+/// Silently no-ops when the id is empty (host process) or unknown (container already removed from
+/// the snapshot, or the event raced the first snapshot after startup): the record keeps its
+/// `container.id` content field and nothing else changes. Deliberately no IsPurageContainerMode
+/// gate here — the inventory is simply empty when the manager was never started, and the mode flag
+/// is fixed at AppConfig construction, which would keep this path out of unit tests.
+void AttachAgentsightContainerTags(PipelineEventGroup& group, const std::string& containerId) {
+    if (containerId.empty()) {
+        return;
+    }
+    const auto info = ContainerManager::GetInstance()->GetContainerInfoById(containerId);
+    if (!info) {
+        LOG_DEBUG(sLogger, ("Agentsight container meta not found", "")("containerId", containerId));
+        return;
+    }
+    AttachAgentsightContainerTagsFromInfo(group, *info);
+}
+
 } // namespace
+
+void AttachAgentsightContainerTagsFromInfo(PipelineEventGroup& group, const RawContainerInfo& info) {
+    for (const auto& md : info.mMetadatas) {
+        group.SetTag(GetDefaultTagKeyString(md.first), md.second);
+    }
+    for (const auto& md : info.mCustomMetadatas) {
+        group.SetTag(md.first, md.second);
+    }
+}
 
 AgentsightManager::AgentsightManager(const std::shared_ptr<ProcessCacheManager>& processCacheManager,
                                      const std::shared_ptr<EBPFAdapter>& eBPFAdapter,
@@ -1242,6 +1277,8 @@ int AgentsightManager::HandleHttpsEvent(const AgentsightHttpsRecord* rec) {
             *rec, eventGroup.AddLogEvent(true, mEventPool), CalculateRandomUUID(), exchangeId);
     }
 
+    AttachAgentsightContainerTags(eventGroup, rec->mContainerId);
+
     std::unique_ptr<ProcessQueueItem> item = std::make_unique<ProcessQueueItem>(std::move(eventGroup), pluginIndex);
     if (QueueStatus::OK == ProcessQueueManager::GetInstance()->PushQueue(queueKey, std::move(item))) {
         ADD_COUNTER(mRawHttpMetrics.pushLogsTotal, logCount);
@@ -1340,6 +1377,8 @@ int AgentsightManager::HandleLlmEvent(AgentsightLlmRecord* rec) {
             FillAgentsightCombinedLlmLog(*rec, log, messageDeltaOnly, emitPayload);
         }
     }
+
+    AttachAgentsightContainerTags(eventGroup, rec->mContainerId);
 
     std::unique_ptr<ProcessQueueItem> item = std::make_unique<ProcessQueueItem>(std::move(eventGroup), pluginIndex);
     if (QueueStatus::OK == ProcessQueueManager::GetInstance()->PushQueue(queueKey, std::move(item))) {

--- a/core/ebpf/plugin/agentsight/AgentsightManager.cpp
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.cpp
@@ -26,6 +26,7 @@
 
 #include "collection_pipeline/queue/ProcessQueueItem.h"
 #include "collection_pipeline/queue/ProcessQueueManager.h"
+#include "common/FileSystemUtil.h"
 #include "common/StringView.h"
 #include "common/UUIDUtil.h"
 #include "common/magic_enum.hpp"
@@ -820,8 +821,11 @@ AgentsightManager::AgentsightManager(const std::shared_ptr<ProcessCacheManager>&
                                      const std::shared_ptr<EBPFAdapter>& eBPFAdapter,
                                      moodycamel::BlockingConcurrentQueue<std::shared_ptr<CommonEvent>>& queue,
                                      EventPool* pool,
+                                     std::string hostRootPath,
                                      const size_t sessionInputCacheMaxSize)
-    : AbstractManager(processCacheManager, eBPFAdapter, queue, pool), mSessionInputCache(sessionInputCacheMaxSize, 0) {
+    : AbstractManager(processCacheManager, eBPFAdapter, queue, pool),
+      mHostRootPath(std::move(hostRootPath)),
+      mSessionInputCache(sessionInputCacheMaxSize, 0) {
 }
 
 int AgentsightManager::Init() {
@@ -889,6 +893,25 @@ bool AgentsightManager::RestartAgentSightLocked(const SecurityOptions& opts) {
     sym->config_set_verbose(cfg, static_cast<int>(opts.mVerbose));
     if (!opts.mLogPath.empty()) {
         sym->config_set_log_path(cfg, opts.mLogPath.c_str());
+    }
+
+    // In container mode, point the library's pid lookups at the host procfs. Left alone it reads its
+    // own /proc, which lists only processes sharing our pid namespace — agents in other pods stay
+    // invisible unless the pod runs with hostPID. This mirrors what ProcessCacheManager already does
+    // for the driver-based plugins (mHostPathPrefix / "proc"); no user configuration is involved.
+    // Skipped on a host install, where mHostRootPath is "/" and the library's own default is /proc.
+    if (!mHostRootPath.empty() && mHostRootPath != "/") {
+        const std::string procfsRoot = PathJoin(mHostRootPath, "proc");
+        if (sym->config_set_procfs_root) {
+            sym->config_set_procfs_root(cfg, procfsRoot.c_str());
+            LOG_INFO(sLogger, ("AgentSight", "pid lookups resolve through")("procfs_root", procfsRoot));
+        } else {
+            LOG_WARNING(sLogger,
+                        ("AgentSight",
+                         "running in container mode but agentsight_config_set_procfs_root symbol not found; pid "
+                         "lookups keep using our own /proc and require hostPID to discover processes in other pid "
+                         "namespaces (requires libagentsight >= 0.11.0)")("procfs_root", procfsRoot));
+        }
     }
 
     // Raw HTTPS fallback is opt-in on both sides: the Rust FfiEventSender drops these events unless

--- a/core/ebpf/plugin/agentsight/AgentsightManager.h
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.h
@@ -28,11 +28,23 @@
 #include "ebpf/plugin/agentsight/AgentsightMessageUtil.h"
 #include "monitor/metric_models/ReentrantMetricsRecord.h"
 
+namespace logtail {
+class PipelineEventGroup;
+struct RawContainerInfo;
+} // namespace logtail
+
 namespace logtail::ebpf {
 
 // Defined in AgentsightEvents.h; only used through pointers here.
 class AgentsightLlmRecord;
 class AgentsightHttpsRecord;
+
+/// Sets the standard container metadata tags on @group from @info — the same keys
+/// input_file / input_container_stdio emit (`_container_name_`, `_image_name_`, `_container_ip_`,
+/// `_pod_name_`, `_namespace_`, `_pod_uid_` via GetDefaultTagKeyString, plus custom metadatas
+/// verbatim). Pure function with no singleton access, so it is unit-testable on its own; the
+/// ContainerManager lookup wrapper lives in AgentsightManager.cpp.
+void AttachAgentsightContainerTagsFromInfo(PipelineEventGroup& group, const RawContainerInfo& info);
 
 class AgentsightManager : public AbstractManager {
 public:

--- a/core/ebpf/plugin/agentsight/AgentsightManager.h
+++ b/core/ebpf/plugin/agentsight/AgentsightManager.h
@@ -41,14 +41,17 @@ public:
                       const std::shared_ptr<EBPFAdapter>& eBPFAdapter,
                       moodycamel::BlockingConcurrentQueue<std::shared_ptr<CommonEvent>>& queue,
                       EventPool* pool,
+                      std::string hostRootPath,
                       size_t sessionInputCacheMaxSize = kMaxSessionInputStates);
 
     static std::shared_ptr<AgentsightManager>
     Create(const std::shared_ptr<ProcessCacheManager>& processCacheManager,
            const std::shared_ptr<EBPFAdapter>& eBPFAdapter,
            moodycamel::BlockingConcurrentQueue<std::shared_ptr<CommonEvent>>& queue,
-           EventPool* pool) {
-        return std::make_shared<AgentsightManager>(processCacheManager, eBPFAdapter, queue, pool);
+           EventPool* pool,
+           std::string hostRootPath) {
+        return std::make_shared<AgentsightManager>(
+            processCacheManager, eBPFAdapter, queue, pool, std::move(hostRootPath));
     }
 
     ~AgentsightManager() override = default;
@@ -113,6 +116,12 @@ private:
     void clearSessionInputState();
 
     static constexpr size_t kMaxSessionInputStates = 4096;
+
+    // Host root as seen from inside the container ("/logtail_host", or "/" on a host install).
+    // Passed to libagentsight so its pid lookups read <root>/proc instead of our own /proc, which
+    // only lists processes sharing our pid namespace. Declared before mSessionInputCache to match
+    // the constructor's initialisation order.
+    std::string mHostRootPath;
 
     std::string mConfigName;
     const CollectionPipelineContext* mPipelineCtx{nullptr};

--- a/core/plugin/input/InputAgentSight.cpp
+++ b/core/plugin/input/InputAgentSight.cpp
@@ -16,6 +16,8 @@
 
 #include <unordered_map>
 
+#include "app_config/AppConfig.h"
+#include "container_manager/ContainerManager.h"
 #include "ebpf/EBPFServer.h"
 #include "ebpf/include/export.h"
 #include "logger/Logger.h"
@@ -46,6 +48,13 @@ bool InputAgentSight::Start() {
     ebpf::EBPFServer::GetInstance()->Init();
     if (!ebpf::EBPFServer::GetInstance()->IsSupportedEnv(logtail::ebpf::PluginType::AGENTSIGHT_OBSERVE)) {
         return false;
+    }
+    // Containerized deployment (k8s DaemonSet / docker): keep the process-wide container inventory
+    // running so HandleLlmEvent / HandleHttpsEvent can enrich event groups with container metadata
+    // tags by container ID, the same source input_file / input_container_stdio use. Init is
+    // idempotent; host-mode deployments skip it and enrichment silently degrades to container.id only.
+    if (AppConfig::GetInstance()->IsPurageContainerMode()) {
+        ContainerManager::GetInstance()->Init();
     }
     return ebpf::EBPFServer::GetInstance()->EnablePlugin(mContext->GetConfigName(),
                                                          mIndex,

--- a/core/unittest/container_manager/ContainerManagerUnittest.cpp
+++ b/core/unittest/container_manager/ContainerManagerUnittest.cpp
@@ -71,6 +71,7 @@ public:
     void TestClearContainerInfo() const;
     void TestApplyContainerDiffsRefreshAllClearsStaleContainers();
     void TestLoadContainerInfoAfterConfigInit();
+    void TestGetContainerInfoById() const;
     void runTestFile(const std::string& testFilePath) const;
 
 private:
@@ -2792,6 +2793,38 @@ void ContainerManagerUnittest::parseLabelFilters(const Json::Value& filtersJson,
     }
 }
 
+void ContainerManagerUnittest::TestGetContainerInfoById() const {
+    ContainerManager containerManager;
+
+    auto info = std::make_shared<RawContainerInfo>();
+    info->mID = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    info->mName = "test-container";
+    info->AddMetadata("_container_name_", "test-container");
+    containerManager.mContainerMap[info->mID] = info;
+
+    {
+        // Known full container ID resolves to the cached info.
+        auto found = containerManager.GetContainerInfoById(info->mID);
+        EXPECT_TRUE(found != nullptr);
+        if (found) {
+            EXPECT_EQ(found->mID, info->mID);
+            EXPECT_EQ(found->mName, "test-container");
+            EXPECT_EQ(found->mMetadatas.size(), 1U);
+        }
+    }
+    {
+        // Unknown ID (e.g. short/variant form, host process id, removed container) resolves to null.
+        EXPECT_TRUE(containerManager.GetContainerInfoById("a1b2c3d4e5f6") == nullptr);
+        EXPECT_TRUE(
+            containerManager.GetContainerInfoById("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+            == nullptr);
+    }
+    {
+        // Empty ID resolves to null without touching the map.
+        EXPECT_TRUE(containerManager.GetContainerInfoById("") == nullptr);
+    }
+}
+
 UNIT_TEST_CASE(ContainerManagerUnittest, TestcomputeMatchedContainersDiff)
 UNIT_TEST_CASE(ContainerManagerUnittest, TestrefreshAllContainersSnapshot)
 UNIT_TEST_CASE(ContainerManagerUnittest, TestincrementallyUpdateContainersSnapshot)
@@ -2816,6 +2849,7 @@ UNIT_TEST_CASE(ContainerManagerUnittest, TestRefreshAllContainersFlag)
 UNIT_TEST_CASE(ContainerManagerUnittest, TestClearContainerInfo)
 UNIT_TEST_CASE(ContainerManagerUnittest, TestApplyContainerDiffsRefreshAllClearsStaleContainers)
 UNIT_TEST_CASE(ContainerManagerUnittest, TestLoadContainerInfoAfterConfigInit)
+UNIT_TEST_CASE(ContainerManagerUnittest, TestGetContainerInfoById)
 
 } // namespace logtail
 

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -21,17 +21,24 @@
 #include <variant>
 #include <vector>
 
+#include "json/json.h"
+
+#include "app_config/AppConfig.h"
 #include "collection_pipeline/CollectionPipelineContext.h"
 #include "collection_pipeline/queue/ProcessQueueItem.h"
 #include "collection_pipeline/queue/ProcessQueueManager.h"
 #include "collection_pipeline/queue/QueueKeyManager.h"
+#include "common/FileSystemUtil.h"
 #include "common/StringView.h"
+#include "constants/TagConstants.h"
+#include "container_manager/ContainerManager.h"
 #include "ebpf/Config.h"
 #include "ebpf/EBPFAdapter.h"
 #include "ebpf/plugin/agentsight/AgentsightEvents.h"
 #include "ebpf/plugin/agentsight/AgentsightManager.h"
 #include "ebpf/type/FileEvent.h"
 #include "models/LogEvent.h"
+#include "models/PipelineEventGroup.h"
 #include "unittest/Unittest.h"
 #include "unittest/ebpf/ManagerUnittestBase.h"
 
@@ -289,6 +296,63 @@ std::string contentOf(const LogEvent& log, const char* key) {
     return std::string(v.data(), v.size());
 }
 
+std::string tagOf(const PipelineEventGroup& group, const char* key) {
+    const StringView v = group.GetTag(StringView(key));
+    return v.empty() ? std::string() : std::string(v.data(), v.size());
+}
+
+/// Fixture container for the metadata-enrichment tests. The ContainerManager singleton is
+/// process-global and never torn down in this binary, so the seeded entry stays visible to later
+/// tests; the ID is distinct enough that no other test fabricates it by accident.
+const char* kUtContainerId = "c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00";
+
+/// Seeds the process-wide ContainerManager singleton through the public persistence path (the same
+/// one ContainerManagerUnittest::TestSaveLoadContainerInfo exercises): write a v1.0.0
+/// docker_path_config.json and reload it, which swaps the whole container map. MetaDatas carries
+/// the six standard keys (routed to RawContainerInfo::mMetadatas by AddMetadata) plus one custom
+/// key (routed to mCustomMetadatas), covering both tag sources the enricher reads.
+void seedContainerInventory() {
+    Json::Value meta(Json::objectValue);
+    meta["_container_name_"] = "ut-agent-container";
+    meta["_image_name_"] = "registry.example.com/agent:ut";
+    meta["_container_ip_"] = "172.17.0.7";
+    meta["_pod_name_"] = "agent-pod-ut";
+    meta["_namespace_"] = "ut-ns";
+    meta["_pod_uid_"] = "ut-pod-uid";
+    meta["app"] = "ut-custom-tag";
+    Json::Value container(Json::objectValue);
+    container["ID"] = kUtContainerId;
+    container["Name"] = "ut-agent-container";
+    container["MetaDatas"] = meta;
+    Json::Value arr(Json::arrayValue);
+    arr.append(container);
+    Json::Value root(Json::objectValue);
+    root["version"] = "1.0.0";
+    root["Containers"] = arr;
+    OverwriteFile(PathJoin(GetAgentDataDir(), "docker_path_config.json"), root.toStyledString());
+    ContainerManager::GetInstance()->LoadContainerInfo();
+}
+
+/// The six standard container metadata tag keys, in default-key-name form.
+const char* kUtContainerTagKeys[] = {
+    "_container_name_",
+    "_image_name_",
+    "_container_ip_",
+    "_pod_name_",
+    "_namespace_",
+    "_pod_uid_",
+};
+
+void expectUtContainerTags(const PipelineEventGroup& group) {
+    APSARA_TEST_EQUAL("ut-agent-container", tagOf(group, "_container_name_"));
+    APSARA_TEST_EQUAL("registry.example.com/agent:ut", tagOf(group, "_image_name_"));
+    APSARA_TEST_EQUAL("172.17.0.7", tagOf(group, "_container_ip_"));
+    APSARA_TEST_EQUAL("agent-pod-ut", tagOf(group, "_pod_name_"));
+    APSARA_TEST_EQUAL("ut-ns", tagOf(group, "_namespace_"));
+    APSARA_TEST_EQUAL("ut-pod-uid", tagOf(group, "_pod_uid_"));
+    APSARA_TEST_EQUAL("ut-custom-tag", tagOf(group, "app"));
+}
+
 class AgentSightTestEBPFAdapter : public EBPFAdapter {
 public:
     void setAgentSightSymbols(std::unique_ptr<AgentSightSymbolTable> sym) { mTestSyms = std::move(sym); }
@@ -486,6 +550,10 @@ public:
     void TestHttpsHostExtractionVariants();
     void TestHttpsEventOmitsEmptyOptionalFields();
     void TestLlmServerAddressFromRequestUrl();
+    void TestAttachAgentsightContainerTagsFromInfo();
+    void TestContainerTagsAttachedForLlmEvent();
+    void TestContainerTagsAttachedForHttpsEvent();
+    void TestContainerTagsMissDegradesSilently();
 
 protected:
     std::shared_ptr<AgentSightTestEBPFAdapter> mAgentSightAdapter;
@@ -1444,6 +1512,99 @@ void AgentsightManagerUnittest::TestLlmServerAddressFromRequestUrl() {
     mgr->Destroy();
 }
 
+void AgentsightManagerUnittest::TestAttachAgentsightContainerTagsFromInfo() {
+    // Pure function: no singleton involved, tags come straight from the info's metadata vectors.
+    RawContainerInfo info;
+    info.AddMetadata("_container_name_", "pure-container"); // known key -> mMetadatas
+    info.AddMetadata("_image_name_", "registry.example.com/pure:1");
+    info.AddMetadata("app", "pure-custom"); // unknown key -> mCustomMetadatas
+
+    auto sourceBuffer = std::make_shared<SourceBuffer>();
+    PipelineEventGroup group(sourceBuffer);
+    AttachAgentsightContainerTagsFromInfo(group, info);
+
+    APSARA_TEST_EQUAL("pure-container", tagOf(group, "_container_name_"));
+    APSARA_TEST_EQUAL("registry.example.com/pure:1", tagOf(group, "_image_name_"));
+    APSARA_TEST_EQUAL("pure-custom", tagOf(group, "app"));
+    APSARA_TEST_FALSE(group.HasTag(StringView("_pod_name_")));
+
+    // Empty info attaches nothing.
+    RawContainerInfo empty;
+    PipelineEventGroup bareGroup(std::make_shared<SourceBuffer>());
+    AttachAgentsightContainerTagsFromInfo(bareGroup, empty);
+    APSARA_TEST_EQUAL(0UL, bareGroup.GetTags().size());
+}
+
+void AgentsightManagerUnittest::TestContainerTagsAttachedForLlmEvent() {
+    seedContainerInventory();
+    const char* kConfig = "p_container_tags_llm";
+    auto mgr = makeManager();
+    registerConfigWithPoppableQueue(*mgr, kConfig);
+    // EventStreamFormat is static state shared across tests; pin the split shape explicitly.
+    agentsightOptions().mAgentsightEventStreamFormat = true;
+
+    auto rec = makeMinimalLlmRecord(kConfig, "sess-container");
+    rec->mContainerId = kUtContainerId;
+    APSARA_TEST_EQUAL(0, mgr->HandleEvent(rec));
+
+    std::unique_ptr<ProcessQueueItem> item;
+    const auto logs = popLogEvents(item);
+    APSARA_TEST_EQUAL(2UL, logs.size());
+    expectUtContainerTags(item->mEventGroup);
+    mgr->Destroy();
+}
+
+void AgentsightManagerUnittest::TestContainerTagsAttachedForHttpsEvent() {
+    seedContainerInventory();
+    const char* kConfig = "p_container_tags_https";
+    auto mgr = makeManager();
+    registerConfigWithPoppableQueue(*mgr, kConfig);
+
+    HttpsSpec spec;
+    spec.containerId = kUtContainerId;
+    spec.statusCode = 200;
+    spec.responseBody = "ok";
+
+    std::unique_ptr<ProcessQueueItem> item;
+    const auto logs = emitHttps(*mgr, kConfig, spec, item);
+    APSARA_TEST_EQUAL(2UL, logs.size());
+    expectUtContainerTags(item->mEventGroup);
+    mgr->Destroy();
+}
+
+void AgentsightManagerUnittest::TestContainerTagsMissDegradesSilently() {
+    seedContainerInventory();
+    const char* kConfig = "p_container_tags_miss";
+    auto mgr = makeManager();
+    registerConfigWithPoppableQueue(*mgr, kConfig);
+
+    // Unknown container ID (container gone from the snapshot, or a short/variant form): the event
+    // is still pushed and simply carries no container tags.
+    {
+        auto rec = makeMinimalLlmRecord(kConfig, "sess-unknown-container");
+        rec->mContainerId = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        APSARA_TEST_EQUAL(0, mgr->HandleEvent(rec));
+        std::unique_ptr<ProcessQueueItem> item;
+        const auto logs = popLogEvents(item);
+        APSARA_TEST_TRUE(!logs.empty());
+        for (const char* key : kUtContainerTagKeys) {
+            APSARA_TEST_FALSE(item->mEventGroup.HasTag(StringView(key)));
+        }
+    }
+    // Empty container ID (host process): same degradation, exercised through the raw HTTP path.
+    {
+        HttpsSpec spec;
+        spec.containerId = nullptr;
+        std::unique_ptr<ProcessQueueItem> item;
+        const auto logs = emitHttps(*mgr, kConfig, spec, item);
+        APSARA_TEST_TRUE(!logs.empty());
+        for (const char* key : kUtContainerTagKeys) {
+            APSARA_TEST_FALSE(item->mEventGroup.HasTag(StringView(key)));
+        }
+    }
+    mgr->Destroy();
+}
+
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestGetPluginType);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateValidation);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestAddOrUpdateNoSymbols);
@@ -1480,5 +1641,9 @@ UNIT_TEST_CASE(AgentsightManagerUnittest, TestStaleConfigRecordDroppedNotReroute
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestHttpsHostExtractionVariants);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestHttpsEventOmitsEmptyOptionalFields);
 UNIT_TEST_CASE(AgentsightManagerUnittest, TestLlmServerAddressFromRequestUrl);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestAttachAgentsightContainerTagsFromInfo);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestContainerTagsAttachedForLlmEvent);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestContainerTagsAttachedForHttpsEvent);
+UNIT_TEST_CASE(AgentsightManagerUnittest, TestContainerTagsMissDegradesSilently);
 
 UNIT_TEST_MAIN

--- a/core/unittest/ebpf/AgentsightManagerUnittest.cpp
+++ b/core/unittest/ebpf/AgentsightManagerUnittest.cpp
@@ -369,10 +369,12 @@ public:
     PluginOptions asVariant() { return &agentsightOptions(); }
 
     std::shared_ptr<AgentsightManager> makeManager(const size_t sessionInputCacheMaxSize = 4096) {
+        // "/" is the host-mode root: the procfs-root setter path is skipped for it.
         auto m = std::make_shared<AgentsightManager>(mProcessCacheManager,
                                                      std::static_pointer_cast<EBPFAdapter>(mAgentSightAdapter),
                                                      *mEventQueue,
                                                      mEventPool.get(),
+                                                     "/",
                                                      sessionInputCacheMaxSize);
         APSARA_TEST_EQUAL(0, m->Init());
         return m;
@@ -649,7 +651,8 @@ void AgentsightManagerUnittest::TestResumeInvalidOptions() {
     auto p = new TestableAgentsightManager(mProcessCacheManager,
                                            std::static_pointer_cast<EBPFAdapter>(mAgentSightAdapter),
                                            *mEventQueue,
-                                           mEventPool.get());
+                                           mEventPool.get(),
+                                           "/");
     std::shared_ptr<TestableAgentsightManager> mgr(p);
     APSARA_TEST_EQUAL(0, mgr->Init());
     PluginOptions nullSec{static_cast<SecurityOptions*>(nullptr)};
@@ -661,7 +664,8 @@ void AgentsightManagerUnittest::TestResumeWithNoRegistration() {
     auto p = new TestableAgentsightManager(mProcessCacheManager,
                                            std::static_pointer_cast<EBPFAdapter>(mAgentSightAdapter),
                                            *mEventQueue,
-                                           mEventPool.get());
+                                           mEventPool.get(),
+                                           "/");
     std::shared_ptr<TestableAgentsightManager> mgr(p);
     APSARA_TEST_EQUAL(0, mgr->Init());
     APSARA_TEST_EQUAL(0, mgr->resume(asVariant()));

--- a/docs/cn/plugins/input/native/input_agentsight.md
+++ b/docs/cn/plugins/input/native/input_agentsight.md
@@ -36,6 +36,28 @@ dev
 |  ProbeConfig.MessageDeltaOnly  |  bool  |  否  |  `true`  |  为 `true` 时**不**输出全量 `gen_ai.input.messages`；仍输出 `gen_ai.input.messages_delta`、`gen_ai.system_instructions_hash` / `gen_ai.tool.definitions_hash`（非空时），以及 hash 相对上一轮变化时的 `gen_ai.system_instructions` / `gen_ai.tool.definitions`。为 `false` 时**每次**输出非空的全量 `gen_ai.input.messages`。**不影响** `gen_ai.output.messages`；`messages_delta` 及 session 状态维护**不受**本开关影响。  |
 |  ProbeConfig.RawHttpsFallback  |  bool  |  否  |  `false`  |  为 `true` 时，**无法解析为 LLM 语义**的流量（未知 API path、非标准 body）不再被丢弃，而是以原始 HTTP 形式上报（`event.name=http.request` / `http.response`，见下文）。需要 `libagentsight >= 0.9.0`；旧版动态库上该开关无效（日志告警后自动降级为关闭）。**默认关闭**：原始 body 未做任何脱敏。  |
 
+### 容器元信息标签（自动附加）
+
+当采集器运行在**容器化部署**（K8s DaemonSet、或挂载了 `/:/logtail_host` 的 docker 容器；判定依据为 `/logtail_host` 路径存在）时，本插件会自动把事件所属容器的元信息以**组级 Tag** 形式附加到每条事件组上——与 `input_file` / `input_container_stdio` 的容器元信息透传**同一渠道、同一套键名**，下游可用相同的键跨插件聚合。无需任何配置开关。
+
+| Tag 键 | 说明 |
+| --- | --- |
+| `_container_name_` | 容器名 |
+| `_image_name_` | 镜像名 |
+| `_container_ip_` | 容器 IP |
+| `_pod_name_` | Pod 名（K8s 场景） |
+| `_namespace_` | 命名空间（K8s 场景） |
+| `_pod_uid_` | Pod UID（K8s 场景） |
+
+容器自定义元信息（如环境配置产生的附加标签）按原键名透传。在 SLS 中这些键呈现为 `__tag__:` 前缀；日志内容里的 `container.id` 字段（见字段表）保持不变。
+
+**自动降级**（事件照常输出，仅缺少容器 Tag）：
+
+- 采集器为宿主机直装等非容器化部署；
+- 进程不在容器内（`container.id` 为空）；
+- 容器刚退出、已移出容器快照，或事件早于启动后首轮容器快照完成（秒级窗口）；
+- `container.id` 非完整 64 位容器 ID 的变体形态。
+
 ### `RawHttpsFallback: true` 输出的原始 HTTP 日志
 
 仅在 AgentSight 无法把流量解析成 GenAI 语义时产生，与 `gen_ai.*` 日志**互斥**（一次流量最多产生一种）。
@@ -57,7 +79,7 @@ dev
 | `pid` / `comm` | 进程 ID 与进程名 |
 | `cmdline` | 进程完整命令行（argv 以空格连接，截断到 127 字节）。进程已退出时为空，此时该字段不输出 |
 | `agent.type` | 命中 `CmdlineWhitelist` 的 agent 类型（小写）。未命中任何规则时回退为进程名 —— 与 `gen_ai.*` 日志同一套解析口径，**但键名不带 `gen_ai.` 前缀**，见下方说明 |
-| `container.id` | 从 `/proc/<pid>/cgroup` 解析的容器 ID；非容器进程为空，此时该字段不输出 |
+| `container.id` | 从 `/proc/<pid>/cgroup` 解析的容器 ID；非容器进程为空，此时该字段不输出。容器化部署下容器元信息另以组级 Tag 附加，见上文「容器元信息标签（自动附加）」 |
 | `url.scheme` | 固定 `https` |
 | `time_unix_nano` / `observed_time_unix_nano` | 同 `gen_ai.*` 日志 |
 
@@ -385,7 +407,7 @@ Http:
 | `pid` | string | 进程号（十进制字符串） |
 | `comm` | string | 进程名称 |
 | `cmdline` | string | 进程完整命令行（`argv` 空格拼接，截断到 127 字节），来自 `/proc/<PID>/cmdline`；进程已退出时为空则不输出 |
-| `container.id` | string | 进程所属容器 id，由 agentsight 侧按 pid 解析；非容器进程或解析失败时为空则不输出 |
+| `container.id` | string | 进程所属容器 id，由 agentsight 侧按 pid 解析；非容器进程或解析失败时为空则不输出。容器化部署下容器元信息另以组级 Tag 附加，见「容器元信息标签（自动附加）」 |
 | `gen_ai.agent.type` | string | Agent **类型**（如 `openclaw`、`claude-code`），来自 cmdline 白名单 |
 | `time_unix_nano` | string | 本条日志事件时刻，Unix 纪元纳秒（十进制字符串）；与 `SetLogTimestampFromNs` 所用时间戳一致 |
 | `observed_time_unix_nano` | string | 观测时刻，与 `time_unix_nano` **相同**（十进制字符串） |


### PR DESCRIPTION
## 背景

DaemonSet 形态启用 `input_agentsight` 时，agentsight 只能发现自己所在 pid
namespace 里的进程：它所有按 pid 索引的 procfs 读取（cmdline / exe / maps /
cgroup / `<pid>/root`）都硬编码 `/proc`，而容器的 `/proc` 只列出同 namespace
的进程。要采集其他业务 pod 里的 Agent，此前只能给 DaemonSet 加
`hostPID: true`。

其实 uprobe 挂载本身不需要 hostPID（全部 `pid=-1` 全局挂载、按 inode 注册，
天然跨 pidns），阻塞点只在用户态解析路径。anolisa 侧已支持可配置的 procfs
根（[alibaba/anolisa#2804](https://github.com/alibaba/anolisa/pull/2804)，
已合入并批量同步进 coolbpf），本 PR 是 loongcollector 侧的对接。

同时采集链路上还有两处容器信息缺口，本 PR 一并补齐：

1. **容器元信息不透传**：`input_file` / `input_container_stdio` 采集时会自动
   带上 `_container_name_` / `_image_name_` / `_pod_name_` 等容器元信息，而
   `input_agentsight` 只有 `container.id` 一个内容字段，下游无法用同一套键
   跨插件聚合；
2. **k8s systemd cgroup 驱动集群采不到 `container.id`**：
   `cri-containerd-<64hex>.scope`（containerd/CRI-O + systemd cgroup 驱动，
   多数托管 K8s 集群的默认形态）不匹配 agentsight 原有四种 cgroup 布局，
   `container_id` 恒为空。已由
   [alibaba/anolisa#2997](https://github.com/alibaba/anolisa/pull/2997)
   修复，本 PR 通过 coolbpf bump 带上。

## 改动

四个功能提交（+1 合并提交）：

1. **`feat(ebpf): pass host path prefix to AgentSight for pid lookups`**
   - `EBPFServer.cpp`：`AgentsightManager::Create` 传入 `mHostPathPrefix`，
     与 `CpuProfilingManager` 既有做法一致
   - `AgentsightManager`：新增 `mHostRootPath`；启动时在容器模式下（前缀非
     `/`）调用 `agentsight_config_set_procfs_root(cfg, "<root>/proc")`
   - `EBPFAdapter`：按现有**可选符号模式** dlsym 新符号，签名内联声明于
     `AgentSightSymbolTable`，加载日志增加 `procfs_root_api` 可用性字段
   - 单测 3 处构造补参
2. **`feat(ebpf): auto-attach container metadata tags in agentsight`**
   - `ContainerManager`：新增公开的 `GetContainerInfoById`（按完整容器 ID
     查询，ReadLock + `mContainerMap`；发布后数据不可变，锁外读安全）
   - `InputAgentSight::Start`：纯容器模式（`/logtail_host` 存在）时调用
     `ContainerManager::Init()`（幂等；与 `InputCpuProfiling` 同一先例）
   - `AgentsightManager`：`HandleLlmEvent` / `HandleHttpsEvent` 入队前按记录
     自带的 `container.id` 查询容器信息，附加**组级 Tag**——与 file/stdio
     采集同一渠道同一套键名：`_container_name_`、`_image_name_`、
     `_container_ip_`、`_pod_name_`、`_namespace_`、`_pod_uid_`，自定义元信息
     按原键名透传（SLS 中呈现为 `__tag__:` 前缀）；查询未命中静默降级
   - 新增 5 个单测；`input_agentsight.md` 增加「容器元信息标签（自动附加）」
     小节；`changes/v2.0.0.md` 增加条目
3. **`fix(ebpf): bump coolbpf to pick up agentsight procfs root support`**
   - submodule `5c8d281 → 88bca2c`（该版本已包含完整同步：`utils/procfs`、
     基于 procfs 根的 pidns 判定、新 FFI 符号）
4. **`fix(ebpf): bump coolbpf to pick up agentsight systemd cgroup container id fix`**
   - `88bca2c → fb3880f`：手工同步 alibaba/anolisa#2997——新增第 5 种 cgroup
     布局（路径含容器运行时标记时，末段去 `.scope` 后缀、去最后一个 `-` 前缀，
     接受 64 位 hex），覆盖 `cri-containerd-` / `crio-` / `libpod-`；标记门禁
     保证宿主机 systemd 单元不会误匹配

## 行为说明

- **零用户配置**：两项能力都复用现有容器模式自动检测
  （`AppConfig::IsPurageContainerMode`），无任何新增配置项
- 容器模式：pid 查询走 `<root>/proc`（即 `/logtail_host/proc`），可发现其他
  pod 的进程，**不再依赖 `hostPID`**；事件组自动携带容器元信息 Tag
- 宿主安装（前缀 `/`）：行为不变，容器 Tag 静默缺省
- 老版本 `libagentsight.so`：procfs_root 符号缺失时优雅降级——打 warn 并继续
  使用自身 `/proc`（此时需要 hostPID），不影响启动
- 元信息查询未命中（非容器进程、容器已退出/移出快照、事件早于首轮容器快照
  的秒级窗口）：仅缺 Tag，事件照常输出；`container.id` 内容字段保持不变

## 依赖与合入顺序

- 上游依赖均已就绪：anolisa #2804（procfs 根）、#2997（systemd cgroup 容器
  ID 解析）均已合入（#2997 已过完整门槛：27/27 container 单测 + 宿主机单元
  负例）
- coolbpf 指针 `fb3880f` = 批量同步基线 `88bca2c` + #2997 的手工同步提交。
  **该 tip 目前只存在于本地 clone**：等批量同步把 #2997 落到 gitee coolbpf
  后，会把此 bump 换指向同步产生的真实 hash（在此之前 CI 拉取该子模块提交会
  失败）
- `include/agentsight.h` 为构建时 cbindgen 生成，无需提交

## 验证

- C++ 侧单测全绿：`agentsight_manager_unittest` 40/40（含 5 个容器 Tag 新
  用例）、`container_manager_unittest` 25/25（含 `GetContainerInfoById` 新
  用例）、`input_ebpf_agentsight_unittest` 通过；`libagentsight` 重建成功
- agentsight 侧（anolisa #2804）已过完整门槛：1600+ 单测 + 3 个针对该功能的
  集成测试，并在真实内核上验证过四种部署形态的 pidns 判定取值
- 集群端到端验证建议：容器模式（无 `hostPID`）部署后——
  1. 日志出现 `AgentSight pid lookups resolve through /logtail_host/proc`，
     能采集到其他 pod 内 Agent 的事件；
  2. k8s systemd cgroup 驱动集群上 `container.id` 非空；
  3. SLS 日志带 `__tag__:_container_name_` 等容器元信息标签
