### PR TITLE
test(e2e): add numeric log field assertion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,10 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019:'
+      - linters:
+          - gosec
+        path: pkg/selfmonitor/alarm_type.go
+        text: 'G101:'
     paths:
       - plugins/input/journal/unit.go
       - plugins/input/journal/follow.go

--- a/test/engine/steps.go
+++ b/test/engine/steps.go
@@ -102,6 +102,7 @@ func ScenarioInitializer(ctx *godog.ScenarioContext) {
 	ctx.Then(`^there is at least \{(\d+)\} logs$`, verify.LogCountAtLeast)
 	ctx.Then(`^there is at least \{(\d+)\} logs with filter key \{(.*)\} value \{(.*)\}$`, verify.LogCountAtLeastWithFilter)
 	ctx.Then(`^the log fields match kv`, verify.LogFieldKV)
+	ctx.Then(`^the log field \{(.*)\} greater or equal than \{(-?\d+)\}`, verify.LogFieldGreaterThanEqual)
 	ctx.Then(`^the log fields have exact kv`, verify.LogFieldExactKV)
 	ctx.Then(`^the log tags match kv`, verify.TagKV)
 	ctx.Then(`^the kafka partitions at least \{(\d+)\}$`, verify.KafkaPartitionsAtLeast)

--- a/test/engine/steps.go
+++ b/test/engine/steps.go
@@ -102,7 +102,7 @@ func ScenarioInitializer(ctx *godog.ScenarioContext) {
 	ctx.Then(`^there is at least \{(\d+)\} logs$`, verify.LogCountAtLeast)
 	ctx.Then(`^there is at least \{(\d+)\} logs with filter key \{(.*)\} value \{(.*)\}$`, verify.LogCountAtLeastWithFilter)
 	ctx.Then(`^the log fields match kv`, verify.LogFieldKV)
-	ctx.Then(`^the log field \{(.*)\} greater or equal than \{(-?\d+)\}`, verify.LogFieldGreaterThanEqual)
+	ctx.Then(`^the log field \{(.*)\} greater than or equal to \{(-?\d+)\}`, verify.LogFieldGreaterThanEqual)
 	ctx.Then(`^the log fields have exact kv`, verify.LogFieldExactKV)
 	ctx.Then(`^the log tags match kv`, verify.TagKV)
 	ctx.Then(`^the kafka partitions at least \{(\d+)\}$`, verify.KafkaPartitionsAtLeast)

--- a/test/engine/verify/log_field.go
+++ b/test/engine/verify/log_field.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -75,6 +76,72 @@ func LogField(ctx context.Context, expectFieldStr string) (context.Context, erro
 		}
 	}
 	return ctx, nil
+}
+
+func LogFieldGreaterThanEqual(ctx context.Context, expectFieldStr string, expectValue int64) (context.Context, error) {
+	var from int32
+	value := ctx.Value(config.StartTimeContextKey)
+	if value != nil {
+		from = value.(int32)
+	} else {
+		return ctx, fmt.Errorf("no start time")
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(context.TODO(), config.TestConfig.RetryTimeout)
+	defer cancel()
+	var err error
+	var groups []*protocol.LogGroup
+	err = retry.Do(
+		func() error {
+			groups, err = subscriber.TestSubscriber.GetData(control.GetQuery(ctx), from)
+			return err
+		},
+		retry.Context(timeoutCtx),
+		retry.Delay(5*time.Second),
+		retry.DelayType(retry.FixedDelay),
+	)
+	if err != nil {
+		return ctx, err
+	}
+	return ctx, logFieldGreaterThanEqual(groups, expectFieldStr, expectValue)
+}
+
+func logFieldGreaterThanEqual(groups []*protocol.LogGroup, expectFieldStr string, expectValue int64) error {
+	var (
+		maxValue      int64
+		hasValidValue bool
+		parseErr      error
+	)
+	for _, group := range groups {
+		for _, log := range group.Logs {
+			for _, content := range log.Contents {
+				if content.Key != expectFieldStr {
+					continue
+				}
+				valueInt, err := strconv.ParseInt(content.Value, 10, 64)
+				if err != nil {
+					if parseErr == nil {
+						parseErr = fmt.Errorf("parse field %s value %q: %w", expectFieldStr, content.Value, err)
+					}
+					continue
+				}
+				if valueInt >= expectValue {
+					return nil
+				}
+				if !hasValidValue || valueInt > maxValue {
+					maxValue = valueInt
+					hasValidValue = true
+				}
+			}
+		}
+	}
+	if hasValidValue {
+		return fmt.Errorf("want %s >= %d, but got %d", expectFieldStr, expectValue, maxValue)
+	}
+	if parseErr != nil {
+		return parseErr
+	}
+	return fmt.Errorf("want contains key %s, but not found", expectFieldStr)
 }
 
 func LogFieldKV(ctx context.Context, expectKeyValuesStr string) (context.Context, error) {

--- a/test/engine/verify/log_field_test.go
+++ b/test/engine/verify/log_field_test.go
@@ -32,6 +32,27 @@ func metricLog(kv ...string) *protocol.Log {
 	return log
 }
 
+func TestLogFieldGreaterThanEqual(t *testing.T) {
+	groups := []*protocol.LogGroup{{
+		Logs: []*protocol.Log{
+			metricLog("count", "9"),
+			metricLog("count", "10"),
+		},
+	}}
+
+	require.NoError(t, logFieldGreaterThanEqual(groups, "count", 10))
+	require.EqualError(t, logFieldGreaterThanEqual(groups, "count", 11), "want count >= 11, but got 10")
+	negativeGroups := []*protocol.LogGroup{{Logs: []*protocol.Log{metricLog("count", "-10")}}}
+	require.NoError(t, logFieldGreaterThanEqual(negativeGroups, "count", -10))
+	require.EqualError(t, logFieldGreaterThanEqual(groups, "missing", 1), "want contains key missing, but not found")
+	require.EqualError(t, logFieldGreaterThanEqual(nil, "count", 1), "want contains key count, but not found")
+	require.ErrorContains(
+		t,
+		logFieldGreaterThanEqual([]*protocol.LogGroup{{Logs: []*protocol.Log{metricLog("count", "invalid")}}}, "count", 1),
+		`parse field count value "invalid"`,
+	)
+}
+
 func TestLogContainsExactKV(t *testing.T) {
 	// A canonical multi-value metric-log row produced by metric_mock via the v2
 	// export path: __name__/__value__/__labels__ carry exact values.


### PR DESCRIPTION
## 背景

在 Go 1.25 内部适配中发现，通用 E2E 日志数值断言只存在于内部仓库，且旧实现遇到第一条低于阈值的记录时会提前失败。为保持双仓边界，先将这项通用能力提交到开源仓库，再由内部仓库同步该提交。

同时，`pkg/selfmonitor/alarm_type.go` 只存放告警类型标识，不包含凭据；内部专有告警名会触发 gosec G101 误报，因此在共享 lint 配置中按文件和规则精确排除。

## 主要改动

- 新增日志字段大于等于指定整数的 Godog step，支持负数阈值。
- 遍历所有同名字段；任意值满足阈值即成功，不再被前面的低值误判。
- 分别报告字段缺失、数值解析失败和最大值仍低于阈值。
- 补充多记录、负数、缺失字段、非法值和空输入单测。
- 仅对告警类型目录中的 gosec G101 凭据误报增加精确排除。

## 验证

- `go test ./engine/verify -count=1`
- `go test -run '^$' ./engine`
- `golangci-lint run --timeout 5m ./...`（test 模块，0 issues）
- `golangci-lint config verify -c .golangci.yml`
- `golangci-lint run --timeout 5m ./...`（pkg 模块，0 issues）