### PR TITLE
fix: use /proc/stat btime for Linux system boot time

### DIFF
--- a/core/common/TimeUtil.cpp
+++ b/core/common/TimeUtil.cpp
@@ -19,6 +19,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <fstream>
+#include <sstream>
 #ifdef APSARA_UNIT_TEST_MAIN
 #include <functional>
 #endif
@@ -227,6 +229,32 @@ int ReadUtmp(const char* filename, int* n_entries, utmp** utmp_buf) {
     return 0;
 }
 
+int32_t GetBootTimeFromProcStat(const std::string& procStatPath) {
+    std::ifstream fin(procStatPath);
+    if (!fin) {
+        APSARA_LOG_WARNING(sLogger, ("failed to open proc stat file", procStatPath));
+        return 0;
+    }
+
+    std::string line;
+    while (std::getline(fin, line)) {
+        std::istringstream iss(line);
+        std::string key;
+        iss >> key;
+        if (key == "btime") {
+            std::string value;
+            iss >> value;
+            int32_t bootTime = 0;
+            if (!StringTo(value, bootTime) || bootTime <= 0) {
+                APSARA_LOG_WARNING(sLogger, ("failed to parse btime from proc stat", line));
+                return 0;
+            }
+            return bootTime;
+        }
+    }
+    return 0;
+}
+
 int32_t GetBootTimeFromUtmp() {
     int32_t bootTime = -1;
     int n_users = 0;
@@ -283,7 +311,12 @@ int32_t GetUpTime() {
 
 int32_t GetSystemBootTime() {
 #if defined(__linux__)
-    int32_t bootTime = 0;
+    int32_t bootTime = GetBootTimeFromProcStat();
+    if (bootTime > 0) {
+        APSARA_LOG_INFO(sLogger, ("get system boot time from /proc/stat", bootTime));
+        return bootTime;
+    }
+
     int32_t upTime = GetUpTime();
     if (upTime > 0) {
         time_t currentTime = time(NULL);

--- a/core/common/TimeUtil.h
+++ b/core/common/TimeUtil.h
@@ -109,6 +109,10 @@ Strptime(const char* buf, const char* fmt, LogtailTime* ts, int& nanosecondLengt
 
 int32_t GetSystemBootTime();
 
+#if defined(__linux__)
+int32_t GetBootTimeFromProcStat(const std::string& procStatPath = "/proc/stat");
+#endif
+
 // For feature enable_log_time_auto_adjust.
 time_t GetTimeDelta();
 void UpdateTimeDelta(time_t serverTime);

--- a/core/unittest/common/TimeUtilUnittest.h
+++ b/core/unittest/common/TimeUtilUnittest.h
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+#if defined(__linux__)
+#include <cstdio>
+#include <unistd.h>
+
+#include <fstream>
+#endif
 #include <string>
 #include <vector>
 
@@ -34,6 +40,9 @@ public:
     void TestStrptimeNanosecond();
     void TestGetPreciseTimestampFromLogtailTime();
     void TestBootTimeDiff();
+#if defined(__linux__)
+    void TestGetBootTimeFromProcStat();
+#endif
     void TestKernelTimeToUTC();
     void TestGetTimeStamp();
 };
@@ -44,8 +53,38 @@ APSARA_UNIT_TEST_CASE(TimeUtilUnittest, TestNativeStrptimeFormat, 0);
 APSARA_UNIT_TEST_CASE(TimeUtilUnittest, TestStrptimeNanosecond, 0);
 APSARA_UNIT_TEST_CASE(TimeUtilUnittest, TestGetPreciseTimestampFromLogtailTime, 0);
 APSARA_UNIT_TEST_CASE(TimeUtilUnittest, TestBootTimeDiff, 0);
+#if defined(__linux__)
+APSARA_UNIT_TEST_CASE(TimeUtilUnittest, TestGetBootTimeFromProcStat, 0);
+#endif
 APSARA_UNIT_TEST_CASE(TimeUtilUnittest, TestKernelTimeToUTC, 0);
 APSARA_UNIT_TEST_CASE(TimeUtilUnittest, TestGetTimeStamp, 0);
+
+#if defined(__linux__)
+static void WriteProcStatFile(const std::string& path, const std::string& content) {
+    std::ofstream ofs(path);
+    ofs << content;
+}
+
+void TimeUtilUnittest::TestGetBootTimeFromProcStat() {
+    const std::string pathPrefix = "/tmp/loongcollector_proc_stat_" + std::to_string(getpid());
+    const std::string validPath = pathPrefix + "_valid";
+    const std::string missingBtimePath = pathPrefix + "_missing_btime";
+    const std::string invalidBtimePath = pathPrefix + "_invalid_btime";
+
+    WriteProcStatFile(validPath, "cpu  1 2 3 4 5 6 7 8 9 10\nbtime    \t1719922762\nintr 1\n");
+    APSARA_TEST_EQUAL(1719922762, GetBootTimeFromProcStat(validPath));
+
+    WriteProcStatFile(missingBtimePath, "cpu  1 2 3 4 5 6 7 8 9 10\nintr 1\n");
+    APSARA_TEST_EQUAL(0, GetBootTimeFromProcStat(missingBtimePath));
+
+    WriteProcStatFile(invalidBtimePath, "cpu  1 2 3 4 5 6 7 8 9 10\nbtime invalid\n");
+    APSARA_TEST_EQUAL(0, GetBootTimeFromProcStat(invalidBtimePath));
+
+    remove(validPath.c_str());
+    remove(missingBtimePath.c_str());
+    remove(invalidBtimePath.c_str());
+}
+#endif
 
 void TimeUtilUnittest::TestBootTimeDiff() {
     auto diff = GetTimeDiffFromMonotonic();


### PR DESCRIPTION
## 背景

该 PR 修复 Linux 下系统启动时间计算可能出现轻微漂移的问题。

原实现中，`GetSystemBootTime()` 会通过 `/proc/uptime` 计算系统启动时间：

```cpp
time(NULL) - uptime
```

但 `/proc/uptime` 包含小数秒，而当前实现会将其截断为整数秒，因此 LoongCollector 重启后计算得到的 boot time 可能相比 `/proc/stat` 中的 `btime` 出现 0~1 秒的轻微漂移。

## 修改内容

- 新增 `GetBootTimeFromProcStat()`，用于从 `/proc/stat` 中读取并解析 `btime`。
- Linux 下 `GetSystemBootTime()` 优先使用 `/proc/stat` 中的 `btime`。
- 当 `/proc/stat` 读取失败、缺失 `btime` 或解析失败时，保留原有 `/proc/uptime` 和 `utmp` fallback 逻辑。
- 补充单元测试，覆盖 `btime` 正常、缺失和非法三种情况。

## 测试

已在本地通过以下检查：

```text
git diff --check
ASAN_OPTIONS=detect_leaks=0 ./unittest/common/common_simple_utils_unittest --gtest_filter=TimeUtilUnittest.TestGetBootTimeFromProcStat
ASAN_OPTIONS=detect_leaks=0 ./unittest/common/common_simple_utils_unittest --gtest_filter=TimeUtilUnittest.*
```

测试结果：

```text
TimeUtilUnittest.TestGetBootTimeFromProcStat: PASSED
TimeUtilUnittest.*: 9 tests PASSED
```

Fixes #557.