### PR TITLE
fix(file): accept cached rotated subdirs

### DIFF
--- a/core/collection_pipeline/CollectionPipelineManager.h
+++ b/core/collection_pipeline/CollectionPipelineManager.h
@@ -81,6 +81,7 @@ private:
     friend class BoundedProcessQueueUnittest;
     friend class CircularProcessQueueUnittest;
     friend class CommonConfigProviderUnittest;
+    friend class EventDispatcherDirUnittest;
     friend class FlusherUnittest;
     friend class PipelineUnittest;
     friend class PipelineUpdateUnittest;

--- a/core/file_server/EventDispatcher.cpp
+++ b/core/file_server/EventDispatcher.cpp
@@ -545,10 +545,15 @@ EventDispatcher::ValidateCheckpointResult EventDispatcher::validateCheckpoint(
         return ValidateCheckpointResult::kZeroSigSize;
     }
 
+    uint16_t searchDepth = 0;
+    if (inputFile) {
+        searchDepth = inputFile->mMaxCheckpointDirSearchDepth;
+    }
+
     // Try to find the real file with dev inode, check cache at first.
     map<DevInode, SplitedFilePath>::iterator findIter = cachePathDevInodeMap.find(checkpoint->mDevInode);
     if (findIter != cachePathDevInodeMap.end()) {
-        if (findIter->second.mFileDir != path) {
+        if (!IsDirectoryWithinSearchDepth(path, findIter->second.mFileDir, searchDepth)) {
             LOG_INFO(sLogger,
                      ("delete checkpoint", "file has been moved to other dir")("config", checkpoint->mConfigName)(
                          "log reader queue name", checkpoint->mFileName)("original real file path", realFilePath)(
@@ -557,9 +562,9 @@ EventDispatcher::ValidateCheckpointResult EventDispatcher::validateCheckpoint(
             return ValidateCheckpointResult::kLogDirChanged;
         }
 
-        if (CheckFileSignature(
-                PathJoin(path, findIter->second.mFileName), checkpoint->mSignatureHash, checkpoint->mSignatureSize)) {
-            checkpoint->mRealFileName = PathJoin(findIter->second.mFileDir, findIter->second.mFileName);
+        const string cachedFilePath = PathJoin(findIter->second.mFileDir, findIter->second.mFileName);
+        if (CheckFileSignature(cachedFilePath, checkpoint->mSignatureHash, checkpoint->mSignatureSize)) {
+            checkpoint->mRealFileName = cachedFilePath;
             LOG_INFO(sLogger,
                      ("generate MODIFY event for file with checkpoint",
                       "file has been renamed, but still in the same dir")("config", checkpoint->mConfigName)(
@@ -603,10 +608,6 @@ EventDispatcher::ValidateCheckpointResult EventDispatcher::validateCheckpoint(
             config->GetContext().GetConfigName(),
             config->GetContext().GetLogstoreName());
         return ValidateCheckpointResult::kCacheFull;
-    }
-    uint16_t searchDepth = 0;
-    if (inputFile) {
-        searchDepth = inputFile->mMaxCheckpointDirSearchDepth;
     }
     auto const searchResult
         = SearchFilePathByDevInodeInDirectory(path, searchDepth, checkpoint->mDevInode, &cachePathDevInodeMap);

--- a/core/file_server/checkpoint/CheckPointManager.cpp
+++ b/core/file_server/checkpoint/CheckPointManager.cpp
@@ -721,6 +721,24 @@ boost::optional<std::string> SearchFilePathByDevInodeInDirectory(const std::stri
 #undef METHOD_LOG_PATTERN
 }
 
+bool IsDirectoryWithinSearchDepth(const std::string& baseDir, const std::string& candidateDir, uint16_t searchDepth) {
+    if (candidateDir == baseDir) {
+        return true;
+    }
+    if (candidateDir.size() <= baseDir.size() || candidateDir.compare(0, baseDir.size(), baseDir) != 0
+        || candidateDir[baseDir.size()] != PATH_SEPARATOR[0]) {
+        return false;
+    }
+
+    size_t depth = 0;
+    for (size_t i = baseDir.size(); i < candidateDir.size(); ++i) {
+        if (candidateDir[i] == PATH_SEPARATOR[0] && ++depth > searchDepth) {
+            return false;
+        }
+    }
+    return true;
+}
+
 #ifdef APSARA_UNIT_TEST_MAIN
 void CheckPointManager::RemoveLocalCheckPoint() {
     std::string checkPointFile = AppConfig::GetInstance()->GetCheckPointFilePath();

--- a/core/file_server/checkpoint/CheckPointManager.h
+++ b/core/file_server/checkpoint/CheckPointManager.h
@@ -198,4 +198,7 @@ boost::optional<std::string> SearchFilePathByDevInodeInDirectory(const std::stri
                                                                  std::map<DevInode, SplitedFilePath>* cache,
                                                                  bool* searchTruncated);
 
+// Return whether candidateDir is reachable when searching baseDir with searchDepth.
+bool IsDirectoryWithinSearchDepth(const std::string& baseDir, const std::string& candidateDir, uint16_t searchDepth);
+
 } // namespace logtail

--- a/core/unittest/checkpoint/CheckpointManagerUnittest.cpp
+++ b/core/unittest/checkpoint/CheckpointManagerUnittest.cpp
@@ -73,6 +73,7 @@ public:
     }
 
     void TestSearchFilePathByDevInodeInDirectory();
+    void TestIsDirectoryWithinSearchDepth();
     void TestPendingSurvivesDumpRound();
     void TestPendingSurvivesTwoDumpRounds();
     void TestConsumeDeletesPending();
@@ -124,6 +125,7 @@ FileDiscoveryOptions CheckpointManagerUnittest::sDiscoveryOpts;
 CollectionPipelineContext CheckpointManagerUnittest::sCtx;
 
 UNIT_TEST_CASE(CheckpointManagerUnittest, TestSearchFilePathByDevInodeInDirectory);
+UNIT_TEST_CASE(CheckpointManagerUnittest, TestIsDirectoryWithinSearchDepth);
 UNIT_TEST_CASE(CheckpointManagerUnittest, TestPendingSurvivesDumpRound);
 UNIT_TEST_CASE(CheckpointManagerUnittest, TestPendingSurvivesTwoDumpRounds);
 UNIT_TEST_CASE(CheckpointManagerUnittest, TestConsumeDeletesPending);
@@ -203,6 +205,17 @@ void CheckpointManagerUnittest::TestSearchFilePathByDevInodeInDirectory() {
         EXPECT_EQ(cache.at(devInode).mFileDir, kSubDir.string());
         EXPECT_EQ(cache.at(devInode).mFileName, kRotateFileName);
     }
+}
+
+void CheckpointManagerUnittest::TestIsDirectoryWithinSearchDepth() {
+    const std::string baseDir = PathJoin(kTestRootDir, "logs");
+
+    EXPECT_TRUE(IsDirectoryWithinSearchDepth(baseDir, baseDir, 0));
+    EXPECT_FALSE(IsDirectoryWithinSearchDepth(baseDir, PathJoin(baseDir, "archive"), 0));
+    EXPECT_TRUE(IsDirectoryWithinSearchDepth(baseDir, PathJoin(baseDir, "archive"), 1));
+    EXPECT_TRUE(IsDirectoryWithinSearchDepth(baseDir, PathJoin(PathJoin(baseDir, "2026"), "09"), 2));
+    EXPECT_FALSE(IsDirectoryWithinSearchDepth(baseDir, PathJoin(PathJoin(baseDir, "2026"), "09"), 1));
+    EXPECT_FALSE(IsDirectoryWithinSearchDepth(baseDir, baseDir + "-old", 2));
 }
 
 // A pending handoff entry (written outside any dump round) must survive a periodic

--- a/core/unittest/controller/EventDispatcherDirUnittest.cpp
+++ b/core/unittest/controller/EventDispatcherDirUnittest.cpp
@@ -16,13 +16,22 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <fstream>
 #include <memory>
 #include <string>
 
+#include "collection_pipeline/CollectionPipelineManager.h"
+#include "collection_pipeline/plugin/PluginRegistry.h"
+#include "common/FileSystemUtil.h"
 #include "common/Flags.h"
+#include "common/HashUtil.h"
+#include "config/CollectionConfig.h"
+#include "file_server/ConfigManager.h"
 #include "file_server/EventDispatcher.h"
+#include "file_server/FileServer.h"
 #include "file_server/event/Event.h"
 #include "file_server/event_handler/EventHandler.h"
+#include "plugin/input/InputFile.h"
 #include "unittest/Unittest.h"
 using namespace std;
 
@@ -65,7 +74,13 @@ public:
 
 class EventDispatcherDirUnittest : public ::testing::Test {
 protected:
+    static void SetUpTestCase() { PluginRegistry::GetInstance()->LoadPlugins(); }
+
+    static void TearDownTestCase() { PluginRegistry::GetInstance()->UnloadPlugins(); }
+
     void SetUp() override {
+        mCheckpointTestRoot = (bfs::path(GetProcessExecutionDir()) / "EventDispatcherCheckpointUnittest").string();
+        bfs::remove_all(mCheckpointTestRoot);
         mHandlers.resize(10);
         for (int i = 0; i < 10; ++i) {
             std::string dir;
@@ -84,6 +99,12 @@ protected:
     }
 
     void TearDown() override {
+        const string baseDir = (bfs::path(mCheckpointTestRoot) / "logs").string();
+        EventDispatcher::GetInstance()->mPathWdMap.erase(baseDir);
+        FileServer::GetInstance()->RemoveFileDiscoveryConfig(kCheckpointConfigName);
+        ConfigManager::GetInstance()->ClearFilePipelineMatchCache();
+        CollectionPipelineManager::GetInstance()->ClearAllPipelines();
+        bfs::remove_all(mCheckpointTestRoot);
         mHandlers.clear();
         for (int i = 0; i < 10; ++i) {
             EventDispatcher::GetInstance()->RemoveOneToOneMapEntry(i);
@@ -91,6 +112,9 @@ protected:
     }
     std::vector<MockHandler> mHandlers;
     MockHandler* mTimeOutHandler;
+    std::string mCheckpointTestRoot;
+
+    static const std::string kCheckpointConfigName;
 
 public:
     void TestFindAllSubDirAndHandler() {
@@ -145,11 +169,78 @@ public:
             }
         }
     }
+
+    void TestValidateCheckpointUsesCachedSubdirectory() {
+        const string baseDir = (bfs::path(mCheckpointTestRoot) / "logs").string();
+        const string archiveDir = (bfs::path(baseDir) / "archive").string();
+        const string logicalPath = (bfs::path(baseDir) / "app.log").string();
+        const string rotatedFileName = "app.log.1";
+        const string rotatedPath = (bfs::path(archiveDir) / rotatedFileName).string();
+        const string contents = "rotated log\n";
+        bfs::create_directories(archiveDir);
+        std::ofstream(rotatedPath) << contents;
+
+        Json::Value input(Json::objectValue);
+        input["Type"] = "input_file";
+        input["FilePaths"] = Json::Value(Json::arrayValue);
+        input["FilePaths"].append((bfs::path(baseDir) / "*.log").string());
+        input["MaxCheckpointDirSearchDepth"] = 1;
+        Json::Value flusher(Json::objectValue);
+        flusher["Type"] = "flusher_blackhole";
+        auto configJson = std::make_unique<Json::Value>(Json::objectValue);
+        (*configJson)["inputs"] = Json::Value(Json::arrayValue);
+        (*configJson)["inputs"].append(input);
+        (*configJson)["flushers"] = Json::Value(Json::arrayValue);
+        (*configJson)["flushers"].append(flusher);
+
+        CollectionConfig pipelineConfig(kCheckpointConfigName, std::move(configJson), "/fake/path");
+        ASSERT_TRUE(pipelineConfig.Parse());
+        auto* pipelineManager = CollectionPipelineManager::GetInstance();
+        auto pipeline = pipelineManager->BuildPipeline(std::move(pipelineConfig));
+        ASSERT_NE(nullptr, pipeline);
+        pipelineManager->mPipelineNameEntityMap[kCheckpointConfigName] = pipeline;
+        auto* inputFile = const_cast<InputFile*>(static_cast<const InputFile*>(pipeline->GetInputs()[0]->GetPlugin()));
+        FileServer::GetInstance()->AddFileDiscoveryConfig(
+            kCheckpointConfigName, &inputFile->mFileDiscovery, &pipeline->GetContext());
+        ConfigManager::GetInstance()->ClearFilePipelineMatchCache();
+
+        uint64_t signatureHash = 0;
+        uint32_t signatureSize = 0;
+        SignatureToHash(contents, signatureHash, signatureSize);
+        auto checkpoint = std::make_shared<CheckPoint>(logicalPath,
+                                                       "",
+                                                       0,
+                                                       signatureSize,
+                                                       signatureHash,
+                                                       GetFileDevInode(rotatedPath),
+                                                       kCheckpointConfigName,
+                                                       "",
+                                                       false,
+                                                       false,
+                                                       "",
+                                                       false);
+        map<DevInode, SplitedFilePath> cache{{checkpoint->mDevInode, SplitedFilePath(archiveDir, rotatedFileName)}};
+        vector<Event*> events;
+        EventDispatcher::GetInstance()->mPathWdMap[baseDir] = 100;
+
+        const auto result = EventDispatcher::GetInstance()->validateCheckpoint(checkpoint, cache, events);
+
+        EXPECT_EQ(EventDispatcher::ValidateCheckpointResult::kRotate, result);
+        EXPECT_EQ(rotatedPath, checkpoint->mRealFileName);
+        ASSERT_EQ(1U, events.size());
+        EXPECT_EQ(kCheckpointConfigName, events[0]->GetConfigName());
+        for (auto* event : events) {
+            delete event;
+        }
+    }
 };
+
+const std::string EventDispatcherDirUnittest::kCheckpointConfigName = "checkpoint_cache_subdir";
 
 APSARA_UNIT_TEST_CASE(EventDispatcherDirUnittest, TestFindAllSubDirAndHandler, 0);
 APSARA_UNIT_TEST_CASE(EventDispatcherDirUnittest, TestUnregisterAllDir, 0);
 APSARA_UNIT_TEST_CASE(EventDispatcherDirUnittest, TestStopAllDir, 0);
+APSARA_UNIT_TEST_CASE(EventDispatcherDirUnittest, TestValidateCheckpointUsesCachedSubdirectory, 0);
 } // end of namespace logtail
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## What changed

- apply `MaxCheckpointDirSearchDepth` to inode-cache hits as well as fresh directory scans
- validate the signature against the cached full path, including its subdirectory
- add path-boundary unit coverage and a direct `validateCheckpoint` cache-hit regression test

## Why

`validateCheckpoint` shares an inode-to-path cache across checkpoints. A fresh scan can cache a rotated file in an allowed subdirectory, but a later cache hit previously required the cached directory to equal the base directory. This made two checkpoints for the same file behave differently: the first accepted the rotated file and the second returned `kLogDirChanged`.

The cache-hit path also checked the signature under the base directory instead of the cached directory.

## Validation

- `git diff --check`
- clang-format against all changed lines
- repository sensitive-information checks for commit and push
- focused unit coverage for exact-depth, over-depth, sibling-prefix, and the full cached-subdirectory rotate path
- full cross-platform compilation and test suite running in CI

Fixes #2694